### PR TITLE
Fix macOS build

### DIFF
--- a/Box2D/Testbed/Framework/DebugDraw.cpp
+++ b/Box2D/Testbed/Framework/DebugDraw.cpp
@@ -197,7 +197,7 @@ struct GLRenderPoints
 	void Create()
 	{
 		const char* vs = \
-        "#version 400\n"
+        "#version 330\n"
         "uniform mat4 projectionMatrix;\n"
         "layout(location = 0) in vec2 v_position;\n"
         "layout(location = 1) in vec4 v_color;\n"
@@ -211,7 +211,7 @@ struct GLRenderPoints
         "}\n";
         
 		const char* fs = \
-        "#version 400\n"
+        "#version 330\n"
         "in vec4 f_color;\n"
         "out vec4 color;\n"
         "void main(void)\n"
@@ -341,7 +341,7 @@ struct GLRenderLines
 	void Create()
 	{
 		const char* vs = \
-        "#version 400\n"
+        "#version 330\n"
         "uniform mat4 projectionMatrix;\n"
         "layout(location = 0) in vec2 v_position;\n"
         "layout(location = 1) in vec4 v_color;\n"
@@ -353,7 +353,7 @@ struct GLRenderLines
         "}\n";
         
 		const char* fs = \
-        "#version 400\n"
+        "#version 330\n"
         "in vec4 f_color;\n"
         "out vec4 color;\n"
         "void main(void)\n"
@@ -469,7 +469,7 @@ struct GLRenderTriangles
 	void Create()
 	{
 		const char* vs = \
-			"#version 400\n"
+			"#version 330\n"
 			"uniform mat4 projectionMatrix;\n"
 			"layout(location = 0) in vec2 v_position;\n"
 			"layout(location = 1) in vec4 v_color;\n"
@@ -481,7 +481,7 @@ struct GLRenderTriangles
 			"}\n";
 
 		const char* fs = \
-			"#version 400\n"
+			"#version 330\n"
 			"in vec4 f_color;\n"
             "out vec4 color;\n"
 			"void main(void)\n"

--- a/Box2D/Testbed/Framework/Main.cpp
+++ b/Box2D/Testbed/Framework/Main.cpp
@@ -427,12 +427,20 @@ static void sInterface()
 }
 
 //
+void glfwErrorCallback(int error, const char *description)
+{
+	fprintf(stderr, "GLFW error occured. Code: %d. Description: %s\n", error, description);
+}
+
+//
 int main(int, char**)
 {
 #if defined(_WIN32)
 	// Enable memory-leak reports
 	_CrtSetDbgFlag(_CRTDBG_LEAK_CHECK_DF | _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG));
 #endif
+
+	glfwSetErrorCallback(glfwErrorCallback);
 
 	g_camera.m_width = 1024;
 	g_camera.m_height = 640;
@@ -447,9 +455,10 @@ int main(int, char**)
 	sprintf(title, "Box2D Testbed Version %d.%d.%d", b2_version.major, b2_version.minor, b2_version.revision);
 
 #if defined(__APPLE__)
-	// Not sure why, but these settings cause glewInit below to crash.
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
+	// Without these settings on macOS, OpenGL 2.1 will be used by default which will cause crashes at boot.
+	// This code is a slightly modified version of the code found here: http://www.glfw.org/faq.html#how-do-i-create-an-opengl-30-context
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 #endif

--- a/Box2D/premake5.lua
+++ b/Box2D/premake5.lua
@@ -19,8 +19,8 @@ workspace "Box2D"
 		defines { "NDEBUG" }
 		optimize "On"
 
-	filter "system:linux"
-		buildoptions {"-std=c++11"}
+	filter "language:C++"
+		buildoptions { "-std=c++11" }
 
 
 project "Box2D"

--- a/Box2D/premake5.lua
+++ b/Box2D/premake5.lua
@@ -5,10 +5,10 @@ workspace "Box2D"
 	location ( "Build/%{_ACTION}" )
 	architecture "x86_64"
 	configurations { "Debug", "Release" }
-	
+
 	configuration "vs*"
 		defines { "_CRT_SECURE_NO_WARNINGS" }	
-	
+
 	filter "configurations:Debug"
 		targetdir ( "Build/%{_ACTION}/bin/Debug" )
 	 	defines { "DEBUG" }
@@ -28,12 +28,11 @@ project "Box2D"
 	language "C++"
 	files { "Box2D/**.h", "Box2D/**.cpp" }
 	includedirs { "." }
-		
-	
+
 project "GLEW"
 	kind "StaticLib"
 	language "C++"
-	defines {"GLEW_STATIC"}
+	defines { "GLEW_STATIC" }
 	files { "glew/*.h", "glew/*.c" }
 	includedirs { "." }
 
@@ -59,19 +58,19 @@ project "GLFW"
 			"glfw/wgl_context.h",
 			"glfw/egl_context.h",
 			"glfw/win32_init.c",
-            "glfw/win32_joystick.c",
+			"glfw/win32_joystick.c",
 			"glfw/win32_monitor.c",
 			"glfw/win32_time.c",
-            "glfw/win32_tls.c",
-            "glfw/win32_window.c",
-        	"glfw/wgl_context.c",
-        	"glfw/egl_context.c"
-        }
-   
-        for i, v in ipairs(glfw_common) do
-        	f[#f + 1] = glfw_common[i]
-        end
-    	files(f)
+			"glfw/win32_tls.c",
+			"glfw/win32_window.c",
+			"glfw/wgl_context.c",
+			"glfw/egl_context.c"
+		}
+
+		for i, v in ipairs(glfw_common) do
+			f[#f + 1] = glfw_common[i]
+		end
+		files(f)
 
 	configuration { "macosx" }
 		local f = {
@@ -84,16 +83,16 @@ project "GLFW"
 			"glfw/cocoa_joystick.m",
 			"glfw/cocoa_monitor.m",
 			"glfw/cocoa_window.m",
-            "glfw/cocoa_time.c",
-            "glfw/posix_tls.c",
-            "glfw/nsgl_context.m",
-            "glfw/egl_context.c"
-        }
+			"glfw/cocoa_time.c",
+			"glfw/posix_tls.c",
+			"glfw/nsgl_context.m",
+			"glfw/egl_context.c"
+		}
 
-        for i, v in ipairs(glfw_common) do
-        	f[#f + 1] = glfw_common[i]
-        end
-    	files(f)
+		for i, v in ipairs(glfw_common) do
+			f[#f + 1] = glfw_common[i]
+		end
+		files(f)
 	configuration { "not windows", "not macosx" }
 		local f = {
 			"glfw/x11_platform.h",
@@ -109,27 +108,27 @@ project "GLFW"
 			"glfw/glx_context.h",
 			"glfw/glx_context.c",
 			"glfw/glext.h",
-            "glfw/xkb_unicode.c",
-            "glfw/linux_joystick.c",
-            "glfw/posix_time.c",
-        	"glfw/posix_tls.c",
-        	"glfw/glx_context.c",
-        	"glfw/egl_context.c"
-        }
+			"glfw/xkb_unicode.c",
+			"glfw/linux_joystick.c",
+			"glfw/posix_time.c",
+			"glfw/posix_tls.c",
+			"glfw/glx_context.c",
+			"glfw/egl_context.c"
+		}
 
-        for i, v in ipairs(glfw_common) do
-        	f[#f + 1] = glfw_common[i]
-        end
-    	files(f)
+		for i, v in ipairs(glfw_common) do
+			f[#f + 1] = glfw_common[i]
+		end
+		files(f)
 
 project "IMGUI"
 	kind "StaticLib"
 	language "C++"
-	defines {"GLEW_STATIC"}
+	defines { "GLEW_STATIC" }
 	files { "imgui/*.h", "imgui/*.cpp" }
 	includedirs { "." }
 	configuration { "macosx" }
-    	defines{ "GLFW_INCLUDE_GLCOREARB" }
+		defines { "GLFW_INCLUDE_GLCOREARB" }
 
 project "HelloWorld"
 	kind "ConsoleApp"
@@ -165,19 +164,18 @@ project "HelloWorld"
 	files { "HelloWorld/HelloWorld.cpp" }
 	includedirs { "." }
 	links { "Box2D" }
-
 
 project "Testbed"
 	kind "ConsoleApp"
 	language "C++"
-	defines {"GLEW_STATIC"}
+	defines { "GLEW_STATIC" }
 	files { "Testbed/**.h", "Testbed/**.cpp" }
 	includedirs { "." }
 	links { "Box2D", "GLFW", "IMGUI"}
 	configuration { "windows" }
 		links { "GLEW", "glu32", "opengl32", "winmm" }
 	configuration { "macosx" }
-    	defines{ "GLFW_INCLUDE_GLCOREARB" }
+		defines { "GLFW_INCLUDE_GLCOREARB" }
 		links { "OpenGL.framework", "Cocoa.framework", "IOKit.framework", "CoreFoundation.framework", "CoreVideo.framework"}
 	configuration { "gmake" }
 		links { "GL", "GLU", "GLEW", "X11", "Xrandr", "Xinerama", "Xcursor", "pthread", "dl" }


### PR DESCRIPTION
Attempting to build the current revision of Box2D on macOS in Xcode currently gives this build error: `Use of undeclared identifier 'nullptr'`

This PR fixes that build error and also standardises some indentation/spacing.