### PR TITLE
Premake: replaced buildoptions -std=c++11 with flags C++11

### DIFF
--- a/Box2D/premake5.lua
+++ b/Box2D/premake5.lua
@@ -7,7 +7,7 @@ workspace "Box2D"
 	configurations { "Debug", "Release" }
 
 	configuration "vs*"
-		defines { "_CRT_SECURE_NO_WARNINGS" }	
+		defines { "_CRT_SECURE_NO_WARNINGS" }
 
 	filter "configurations:Debug"
 		targetdir ( "Build/%{_ACTION}/bin/Debug" )
@@ -19,12 +19,10 @@ workspace "Box2D"
 		defines { "NDEBUG" }
 		optimize "On"
 
-	filter { "language:C++", "toolset:gcc" }
-		buildoptions { "-std=c++11" }
-
 project "Box2D"
 	kind "StaticLib"
 	language "C++"
+	flags { "C++11" }
 	files { "Box2D/**.h", "Box2D/**.cpp" }
 	includedirs { "." }
 
@@ -118,6 +116,7 @@ project "IMGUI"
 project "HelloWorld"
 	kind "ConsoleApp"
 	language "C++"
+	flags { "C++11" }
 	files { "HelloWorld/HelloWorld.cpp" }
 	includedirs { "." }
 	links { "Box2D" }
@@ -125,6 +124,7 @@ project "HelloWorld"
 project "Testbed"
 	kind "ConsoleApp"
 	language "C++"
+	flags { "C++11" }
 	defines { "GLEW_STATIC" }
 	files { "Testbed/**.h", "Testbed/**.cpp" }
 	includedirs { "." }


### PR DESCRIPTION
On Linux at least, usage of C++11 is not recognized when premake just uses buildoptions "", causing errors during make such as:

```
../../Box2D/Collision/Shapes/b2ChainShape.h:99:15: error: ‘nullptr’ was not declared in this scope
  m_vertices = nullptr;
```

The issue may be related to https://github.com/premake/premake-core/issues/770 for which the solution is to use `cppdialect`, only available starting premake 5 alpha 12 (currently WIP). For now, I suggest this fix, although redundant and not as elegant as filters.

I also mention the fix on [Stack Overflow](https://stackoverflow.com/questions/38082167/box2d-compiling-trouble-nullptr/45786925#45786925).