### PR TITLE
Use cppdialect "C++11" instead of buildoptions { "-std=c++11" }

### DIFF
--- a/Box2D/premake5.lua
+++ b/Box2D/premake5.lua
@@ -7,7 +7,7 @@ workspace "Box2D"
 	configurations { "Debug", "Release" }
 
 	configuration "vs*"
-		defines { "_CRT_SECURE_NO_WARNINGS" }	
+		defines { "_CRT_SECURE_NO_WARNINGS" }
 
 	filter "configurations:Debug"
 		targetdir ( "Build/%{_ACTION}/bin/Debug" )
@@ -19,12 +19,10 @@ workspace "Box2D"
 		defines { "NDEBUG" }
 		optimize "On"
 
-	filter { "language:C++", "toolset:gcc" }
-		buildoptions { "-std=c++11" }
-
 project "Box2D"
 	kind "StaticLib"
 	language "C++"
+	flags { "C++11" }
 	files { "Box2D/**.h", "Box2D/**.cpp" }
 	includedirs { "." }
 
@@ -118,6 +116,7 @@ project "IMGUI"
 project "HelloWorld"
 	kind "ConsoleApp"
 	language "C++"
+	flags { "C++11" }
 	files { "HelloWorld/HelloWorld.cpp" }
 	includedirs { "." }
 	links { "Box2D" }
@@ -125,6 +124,7 @@ project "HelloWorld"
 project "Testbed"
 	kind "ConsoleApp"
 	language "C++"
+	flags { "C++11" }
 	defines { "GLEW_STATIC" }
 	files { "Testbed/**.h", "Testbed/**.cpp" }
 	includedirs { "." }

--- a/Box2D/premake5.lua
+++ b/Box2D/premake5.lua
@@ -11,7 +11,7 @@ workspace "Box2D"
 
 	filter "configurations:Debug"
 		targetdir ( "Build/%{_ACTION}/bin/Debug" )
-	 	defines { "DEBUG" }
+		defines { "DEBUG" }
 		symbols "On"
 
 	filter "configurations:Release"
@@ -22,7 +22,7 @@ workspace "Box2D"
 project "Box2D"
 	kind "StaticLib"
 	language "C++"
-	flags { "C++11" }
+	cppdialect "C++11"
 	files { "Box2D/**.h", "Box2D/**.cpp" }
 	includedirs { "." }
 
@@ -116,7 +116,7 @@ project "IMGUI"
 project "HelloWorld"
 	kind "ConsoleApp"
 	language "C++"
-	flags { "C++11" }
+	cppdialect "C++11"
 	files { "HelloWorld/HelloWorld.cpp" }
 	includedirs { "." }
 	links { "Box2D" }
@@ -124,7 +124,7 @@ project "HelloWorld"
 project "Testbed"
 	kind "ConsoleApp"
 	language "C++"
-	flags { "C++11" }
+	cppdialect "C++11"
 	defines { "GLEW_STATIC" }
 	files { "Testbed/**.h", "Testbed/**.cpp" }
 	includedirs { "." }


### PR DESCRIPTION
**REQUIREMENT: premake 5 alpha 12**

As mentioned in premake/premake-core#770, buildoptions and flags may not work to set the C++ dialect. From premake 5 alpha 12, we should use `cppdialect`. Otherwise, usage of C++11 is not recognized, causing errors during `make` such as:

> ../../Box2D/Collision/Shapes/b2ChainShape.h:99:15: error: ‘nullptr’ was not declared in this scope
>   m_vertices = nullptr;

My fix replace `buildoptions` with `cppdialect`. Note that I use it only for the 3 projects that really need C++11 features.

_This PR is a reboot from https://github.com/erincatto/Box2D/pull/469 leveraging premake 5 alpha 12._