### PR TITLE
add override to fix compiling error

### DIFF
--- a/Box2D/Box2D/Dynamics/Joints/b2DistanceJoint.h
+++ b/Box2D/Box2D/Dynamics/Joints/b2DistanceJoint.h
@@ -99,7 +99,7 @@ public:
 	float32 GetDampingRatio() const;
 
 	/// Dump joint to dmLog
-	void Dump();
+	void Dump() override;
 
 protected:
 


### PR DESCRIPTION
I am integrating latest version of Box2D to cocos2d-x, and find the compiling error. My environment are:

* Xcode 9.1
* macOS 10.13