### PR TITLE
Cache Miss in AddPair()

### DIFF
--- a/Box2D/Box2D/Dynamics/b2ContactManager.cpp
+++ b/Box2D/Box2D/Dynamics/b2ContactManager.cpp
@@ -197,10 +197,10 @@ void b2ContactManager::AddPair(void* proxyUserDataA, void* proxyUserDataB)
 	// TODO_ERIN use a hash table to remove a potential bottleneck when both
 	// bodies have a lot of contacts.
 	// Does a contact already exist?
-	b2ContactEdge* edge = bodyB->GetContactList();
+	b2ContactEdge* edge = bodyA->GetContactList();
 	while (edge)
 	{
-		if (edge->other == bodyA)
+		if (edge->other == bodyB)
 		{
 			b2Fixture* fA = edge->contact->GetFixtureA();
 			b2Fixture* fB = edge->contact->GetFixtureB();


### PR DESCRIPTION
The edges of BodyA are more probable to be in the cache, since pairs are ordered first by proxyIdA and then by proxyIdB.

*AddPair stress test* max step
Before: (268)
This PR: (193)
+38.86%

Related to https://github.com/tainicom/Aether.Physics2D/pull/53

