### PR TITLE
Fix memory leak in b2Polygon

### DIFF
--- a/Contributions/Utilities/ConvexDecomposition/b2Polygon.cpp
+++ b/Contributions/Utilities/ConvexDecomposition/b2Polygon.cpp
@@ -1337,7 +1337,10 @@ b2Polygon TraceEdge(b2Polygon* p){
 				if (nodes[j].nConnected == 0) continue;
 				b2Vec2 diff = nodes[i].position - nodes[j].position;
 				if (diff.LengthSquared() <= COLLAPSE_DIST_SQR){
-					if (nActive <= 3) return b2Polygon();
+					if (nActive <= 3) {
+						delete[] nodes;
+						return b2Polygon();
+					}
 					//printf("Found dupe, %d left\n",nActive);
 					--nActive;
 					foundDupe = true;


### PR DESCRIPTION
Im one of the contributors to Godot engine and we use this utility submodule. It would be nice if this will be fixed here