### PR TITLE
Fixed Warnings and Undefined Behaviour in b2Math.h

### DIFF
--- a/Box2D/Box2D/Common/b2Math.h
+++ b/Box2D/Box2D/Common/b2Math.h
@@ -34,18 +34,13 @@ inline bool b2IsValid(float32 x)
 /// This is a approximate yet fast inverse square-root.
 inline float32 b2InvSqrt(float32 x)
 {
-	union
-	{
-		float32 x;
-		int32 i;
-	} convert;
+	int32 i;
+	memcpy(&i, &x, sizeof(x));
+	i = 0x5f3759df - (i >> 1);
+	memcpy(&x, &i, sizeof(x));
 
-	convert.x = x;
 	float32 xhalf = 0.5f * x;
-	convert.i = 0x5f3759df - (convert.i >> 1);
-	x = convert.x;
-	x = x * (1.5f - xhalf * x * x);
-	return x;
+	return x * (1.5f - xhalf * x * x);
 }
 
 #define	b2Sqrt(x)	sqrtf(x)

--- a/Box2D/Box2D/Common/b2Math.h
+++ b/Box2D/Box2D/Common/b2Math.h
@@ -21,11 +21,13 @@
 
 #include "Box2D/Common/b2Settings.h"
 #include <math.h>
+#include <string.h>
 
 /// This function is used to ensure that a floating point number is not a NaN or infinity.
 inline bool b2IsValid(float32 x)
 {
-	int32 ix = *reinterpret_cast<int32*>(&x);
+	int32 ix;
+	memcpy(&ix, &x, sizeof(x));
 	return (ix & 0x7f800000) != 0x7f800000;
 }
 


### PR DESCRIPTION
I came across a bunch of strict aliasing rule violations when compiling on GCC with -O3 -pedantic -Wall. 

They could all be traced back to b2IsValid, where a float is converted  to an integer using a reinterpret_cast of its memory. Accessing the same  memory through pointers of different type may break on some compilers. I  replaced it with a memcpy and on GCC 7.3 x86-64 with -O3 it generates  the exact same code, just minus the warnings.

Similarly, in b2InvSqrt, type punning was done using a union. That is  legal in C, but not in C++. Most compilers will not have a problem with  that, but it IS undefined behaviour. I replaced that with two memcpy's  as well, and again, GCC creates the exact same assembly code, but it  might prevent some Heisenbugs on other architectures or compilers.