### PR TITLE
Remove unnecessary assignment

### DIFF
--- a/Box2D/Common/b2StackAllocator.cpp
+++ b/Box2D/Common/b2StackAllocator.cpp
@@ -73,8 +73,6 @@ void b2StackAllocator::Free(void* p)
 	}
 	m_allocation -= entry->size;
 	--m_entryCount;
-
-	p = nullptr;
 }
 
 int32 b2StackAllocator::GetMaxAllocation() const


### PR DESCRIPTION
This assignment achieves nothing because `p` is copied by value.
The compiler will always eliminate this line through reaching definition analysis.