### PR TITLE
Fix a data race in b2BlockAllocator::b2BlockAllocator()

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,10 @@
-BasedOnStyle: Microsoft
-Cpp11BracedListStyle: 'false'
+BasedOnStyle: Chromium
+BreakBeforeBraces: Allman
 ColumnLimit: '90'
-PointerAlignment: Left
+IndentWidth: '4'
 TabWidth: '4'
-UseTab: Never
 AccessModifierOffset: '-4'
+UseTab: Never
+Cpp11BracedListStyle: 'false'
 AllowShortFunctionsOnASingleLine: InlineOnly
+KeepEmptyLinesAtTheStartOfBlocks: 'true'

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+BasedOnStyle: Microsoft
+Cpp11BracedListStyle: 'false'
+ColumnLimit: '90'
+PointerAlignment: Left
+TabWidth: '4'
+UseTab: Never
+AccessModifierOffset: '-4'
+AllowShortFunctionsOnASingleLine: InlineOnly

--- a/Box2D/Box2D.h
+++ b/Box2D/Box2D.h
@@ -34,6 +34,7 @@ For discussion please visit http://box2d.org/forum
 #include "Box2D/Common/b2Settings.h"
 #include "Box2D/Common/b2Draw.h"
 #include "Box2D/Common/b2Timer.h"
+#include "Box2D/Common/b2Rendering.h"
 
 #include "Box2D/Collision/Shapes/b2CircleShape.h"
 #include "Box2D/Collision/Shapes/b2EdgeShape.h"

--- a/Box2D/Collision/Shapes/b2CircleShape.cpp
+++ b/Box2D/Collision/Shapes/b2CircleShape.cpp
@@ -21,10 +21,8 @@
 
 b2Shape* b2CircleShape::Clone(b2BlockAllocator* allocator) const
 {
-	void* mem = allocator->Allocate(sizeof(b2CircleShape));
-	b2CircleShape* clone = new (mem) b2CircleShape;
-	*clone = *this;
-	return clone;
+    void* mem = allocator->Allocate(sizeof(b2CircleShape));
+    return new (mem) b2CircleShape(*this);
 }
 
 int32 b2CircleShape::GetChildCount() const

--- a/Box2D/Common/b2BlockAllocator.cpp
+++ b/Box2D/Common/b2BlockAllocator.cpp
@@ -39,7 +39,6 @@ int32 b2BlockAllocator::s_blockSizes[b2_blockSizes] =
 	640,	// 13
 };
 uint8 b2BlockAllocator::s_blockSizeLookup[b2_maxBlockSize + 1];
-bool b2BlockAllocator::s_blockSizeLookupInitialized;
 
 struct b2Chunk
 {
@@ -63,25 +62,7 @@ b2BlockAllocator::b2BlockAllocator()
 	memset(m_chunks, 0, m_chunkSpace * sizeof(b2Chunk));
 	memset(m_freeLists, 0, sizeof(m_freeLists));
 
-	if (s_blockSizeLookupInitialized == false)
-	{
-		int32 j = 0;
-		for (int32 i = 1; i <= b2_maxBlockSize; ++i)
-		{
-			b2Assert(j < b2_blockSizes);
-			if (i <= s_blockSizes[j])
-			{
-				s_blockSizeLookup[i] = (uint8)j;
-			}
-			else
-			{
-				++j;
-				s_blockSizeLookup[i] = (uint8)j;
-			}
-		}
-
-		s_blockSizeLookupInitialized = true;
-	}
+	static bool blockSizeLookupInitialized = InitializeBlockSizeLookup();
 }
 
 b2BlockAllocator::~b2BlockAllocator()
@@ -212,4 +193,24 @@ void b2BlockAllocator::Clear()
 	memset(m_chunks, 0, m_chunkSpace * sizeof(b2Chunk));
 
 	memset(m_freeLists, 0, sizeof(m_freeLists));
+}
+
+bool b2BlockAllocator::InitializeBlockSizeLookup()
+{
+	int32 j = 0;
+	for (int32 i = 1; i <= b2_maxBlockSize; ++i)
+	{
+		b2Assert(j < b2_blockSizes);
+		if (i <= s_blockSizes[j])
+		{
+			s_blockSizeLookup[i] = (uint8)j;
+		}
+		else
+		{
+			++j;
+			s_blockSizeLookup[i] = (uint8)j;
+		}
+	}
+
+	return true;
 }

--- a/Box2D/Common/b2BlockAllocator.h
+++ b/Box2D/Common/b2BlockAllocator.h
@@ -47,6 +47,9 @@ public:
 	void Clear();
 
 private:
+	bool InitializeBlockSizeLookup();
+
+private:
 
 	b2Chunk* m_chunks;
 	int32 m_chunkCount;
@@ -56,7 +59,6 @@ private:
 
 	static int32 s_blockSizes[b2_blockSizes];
 	static uint8 s_blockSizeLookup[b2_maxBlockSize + 1];
-	static bool s_blockSizeLookupInitialized;
 };
 
 #endif

--- a/Box2D/Common/b2Draw.h
+++ b/Box2D/Common/b2Draw.h
@@ -20,23 +20,7 @@
 #define B2_DRAW_H
 
 #include "Box2D/Common/b2Math.h"
-
-/// Color for debug drawing. Each value has the range [0,1].
-struct b2Color
-{
-	b2Color() {}
-	b2Color(float32 rIn, float32 gIn, float32 bIn, float32 aIn = 1.0f)
-	{
-		r = rIn; g = gIn; b = bIn; a = aIn;
-	}
-
-	void Set(float32 rIn, float32 gIn, float32 bIn, float32 aIn = 1.0f)
-	{
-		r = rIn; g = gIn; b = bIn; a = aIn;
-	}
-
-	float32 r, g, b, a;
-};
+#include "Box2D/Common/b2Rendering.h"
 
 /// Implement and register this class with a b2World to provide debug drawing of physics
 /// entities in your game.

--- a/Box2D/Common/b2Math.h
+++ b/Box2D/Common/b2Math.h
@@ -34,10 +34,10 @@ inline bool b2IsValid(float32 x)
 /// A 2D column vector.
 struct b2Vec2
 {
-	/// Default constructor does nothing (for performance).
-	b2Vec2() {}
+    /// Default constructor does nothing (for performance).
+    b2Vec2() = default;
 
-	/// Construct using coordinates.
+    /// Construct using coordinates.
 	b2Vec2(float32 xIn, float32 yIn) : x(xIn), y(yIn) {}
 
 	/// Set this vector to all zeros.
@@ -106,6 +106,14 @@ struct b2Vec2
 
 		return length;
 	}
+
+    /// Returns the normalized vector
+    b2Vec2 Normalized() const
+    {
+        b2Vec2 tmp(*this);
+        tmp.Normalize();
+        return tmp;
+    }
 
 	/// Does this vector contain finite coordinates?
 	bool IsValid() const

--- a/Box2D/Common/b2Rendering.h
+++ b/Box2D/Common/b2Rendering.h
@@ -72,4 +72,4 @@ private:
     b2Light* m_next = nullptr;
 };
 
-#endif // B2_RENDERING_H
+#endif  // B2_RENDERING_H

--- a/Box2D/Common/b2Rendering.h
+++ b/Box2D/Common/b2Rendering.h
@@ -10,6 +10,8 @@
 class b2Body;
 class b2World;
 
+/// RGB color representation
+/// (component values are expected in the [0, 1] range)
 struct b2Color
 {
     float32 r = 0;
@@ -35,21 +37,37 @@ struct b2Color
     b2Color operator*(float32 s) const { return b2Color(r * s, g * s, b * s); }
 };
 
+/// A basic fixture material
 struct b2Material
 {
     b2Color color;
+    
+    /// Controls specular lighting (>= 0)
+    /// (0 = flat color, ie. no specular lighting)
     float32 shininess = 0;
+    
+    /// Emissive lighting intensity [0, 1]
     float32 emit_intensity = 0;
-    float32 reflect = 0;
 };
 
+/// Light definition
 struct b2LightDef
 {
     b2Color color{ 1, 1, 1 };
+    
+    /// Light intensity (>= 0)
     float32 intensity = 1.0f;
+
+    /// The illumination "range": the light intensity decreases linearly from full
+    /// intensity down to zero at `attenuation_distance`. While not physically accurate,
+    /// it's an easy way to control the lighting results and define area lights.
     float32 attenuation_distance = std::numeric_limits<float>::infinity();
-    b2Vec2 position{ 0, 0 };
+
+    /// Parent body
     b2Body* body = nullptr;
+
+    /// Position relative to the parent body
+    b2Vec2 position{ 0, 0 };
 };
 
 class b2Light

--- a/Box2D/Common/b2Rendering.h
+++ b/Box2D/Common/b2Rendering.h
@@ -5,6 +5,8 @@
 #include "Box2D/Common/b2Math.h"
 #include "Box2D/Common/b2Settings.h"
 
+#include <limits>
+
 class b2Body;
 class b2World;
 
@@ -43,8 +45,9 @@ struct b2Material
 
 struct b2LightDef
 {
-    b2Color color;
-    float32 intensity = 0;
+    b2Color color{ 1, 1, 1 };
+    float32 intensity = 1.0f;
+    float32 attenuation_distance = std::numeric_limits<float>::infinity();
     b2Vec2 position{ 0, 0 };
     b2Body* body = nullptr;
 };

--- a/Box2D/Common/b2Rendering.h
+++ b/Box2D/Common/b2Rendering.h
@@ -1,0 +1,75 @@
+
+#ifndef B2_RENDERING_H
+#define B2_RENDERING_H
+
+#include "Box2D/Common/b2Math.h"
+#include "Box2D/Common/b2Settings.h"
+
+class b2Body;
+class b2World;
+
+struct b2Color
+{
+    float32 r = 0;
+    float32 g = 0;
+    float32 b = 0;
+
+    b2Color() = default;
+
+    b2Color(float32 r, float32 g, float32 b) : r(r), g(g), b(b) {}
+
+    b2Color operator+(const b2Color& c) const
+    {
+        return b2Color(r + c.r, g + c.g, b + c.b);
+    }
+
+    b2Color operator*(const b2Color& c) const
+    {
+        return b2Color(r * c.r, g * c.g, b * c.b);
+    }
+
+    b2Color operator+(float32 s) const { return b2Color(r + s, g + s, b + s); }
+
+    b2Color operator*(float32 s) const { return b2Color(r * s, g * s, b * s); }
+};
+
+struct b2Material
+{
+    b2Color color;
+    float32 shininess = 0;
+    float32 emit_intensity = 0;
+    float32 reflect = 0;
+};
+
+struct b2LightDef
+{
+    b2Color color;
+    float32 intensity = 0;
+    b2Vec2 position{ 0, 0 };
+    b2Body* body = nullptr;
+};
+
+class b2Light
+{
+    friend class b2World;
+
+public:
+    const b2LightDef& GetDef() const { return m_def; }
+
+    b2World* GetWorld() { return m_world; }
+    const b2World* GetWorld() const { return m_world; }
+
+    b2Light* GetNext() { return m_next; }
+    const b2Light* GetNext() const { return m_next; }
+
+private:
+    b2Light(const b2LightDef* def, b2World* world) : m_def(*def), m_world(world) {}
+
+private:
+    b2LightDef m_def;
+    b2World* m_world = nullptr;
+    b2Light* m_prev = nullptr;
+    b2Light* m_next = nullptr;
+};
+
+#endif // B2_RENDERING_H

--- a/Box2D/Dynamics/b2Body.cpp
+++ b/Box2D/Dynamics/b2Body.cpp
@@ -52,7 +52,11 @@ b2Body::b2Body(const b2BodyDef* bd, b2World* world)
 	if (bd->active)
 	{
 		m_flags |= e_activeFlag;
-	}
+    }
+    if (bd->useDefaultRendering)
+    {
+        m_flags |= e_renderFlag;
+    }
 
 	m_world = world;
 
@@ -103,11 +107,6 @@ b2Body::b2Body(const b2BodyDef* bd, b2World* world)
 
 	m_fixtureList = nullptr;
 	m_fixtureCount = 0;
-}
-
-b2Body::~b2Body()
-{
-	// shapes and joints are destroyed in b2World::Destroy
 }
 
 void b2Body::SetType(b2BodyType type)

--- a/Box2D/Dynamics/b2Body.h
+++ b/Box2D/Dynamics/b2Body.h
@@ -67,6 +67,7 @@ struct b2BodyDef
 		type = b2_staticBody;
 		active = true;
 		gravityScale = 1.0f;
+        useDefaultRendering = true;
 	}
 
 	/// The body type: static, kinematic, or dynamic.
@@ -98,7 +99,10 @@ struct b2BodyDef
 	/// Units are 1/time
 	float32 angularDamping;
 
-	/// Set this flag to false if this body should never fall asleep. Note that
+    /// Scale the gravity applied to this body.
+    float32 gravityScale;
+
+    /// Set this flag to false if this body should never fall asleep. Note that
 	/// this increases CPU usage.
 	bool allowSleep;
 
@@ -117,11 +121,11 @@ struct b2BodyDef
 	/// Does this body start out active?
 	bool active;
 
-	/// Use this to store application specific body data.
-	void* userData;
+    /// Should we use the default
+    bool useDefaultRendering;
 
-	/// Scale the gravity applied to this body.
-	float32 gravityScale;
+    /// Use this to store application specific body data.
+	void* userData;
 };
 
 /// A rigid body. These are created via b2World::CreateBody.
@@ -349,7 +353,10 @@ public:
 	void SetActive(bool flag);
 
 	/// Get the active state of the body.
-	bool IsActive() const;
+    bool IsActive() const;
+
+    /// Use the default rendering for this body?
+    bool UseDefaultRendering() const { return (m_flags & e_renderFlag) != 0; }
 
 	/// Set this body to have fixed rotation. This causes the mass
 	/// to be reset.
@@ -418,11 +425,14 @@ private:
 		e_bulletFlag		= 0x0008,
 		e_fixedRotationFlag	= 0x0010,
 		e_activeFlag		= 0x0020,
-		e_toiFlag			= 0x0040
+        e_toiFlag			= 0x0040,
+        e_renderFlag        = 0x1000,
 	};
 
-	b2Body(const b2BodyDef* bd, b2World* world);
-	~b2Body();
+    b2Body(const b2BodyDef* bd, b2World* world);
+
+    // shapes and joints are destroyed in b2World::Destroy
+    ~b2Body() = default;
 
 	void SynchronizeFixtures();
 	void SynchronizeTransform();

--- a/Box2D/Dynamics/b2Fixture.cpp
+++ b/Box2D/Dynamics/b2Fixture.cpp
@@ -43,6 +43,7 @@ void b2Fixture::Create(b2BlockAllocator* allocator, b2Body* body, const b2Fixtur
 	m_userData = def->userData;
 	m_friction = def->friction;
 	m_restitution = def->restitution;
+    m_material = def->material;
 
 	m_body = body;
 	m_next = nullptr;

--- a/Box2D/Dynamics/b2Fixture.h
+++ b/Box2D/Dynamics/b2Fixture.h
@@ -22,6 +22,7 @@
 #include "Box2D/Dynamics/b2Body.h"
 #include "Box2D/Collision/b2Collision.h"
 #include "Box2D/Collision/Shapes/b2Shape.h"
+#include "Box2D/Common/b2Rendering.h"
 
 class b2BlockAllocator;
 class b2Body;
@@ -88,6 +89,9 @@ struct b2FixtureDef
 
 	/// Contact filtering data.
 	b2Filter filter;
+
+    /// Material, used for rendering.
+    b2Material material;
 };
 
 /// This proxy is used internally to connect fixtures to the broad-phase.
@@ -195,6 +199,9 @@ public:
 	/// Dump this fixture to the log file.
 	void Dump(int32 bodyIndex);
 
+    /// Fixture's material
+    const b2Material& GetMaterial() const { return m_material; }
+
 protected:
 
 	friend class b2Body;
@@ -231,6 +238,8 @@ protected:
 	b2Filter m_filter;
 
 	bool m_isSensor;
+
+    b2Material m_material;
 
 	void* m_userData;
 };

--- a/Box2D/Dynamics/b2World.h
+++ b/Box2D/Dynamics/b2World.h
@@ -30,10 +30,12 @@ struct b2AABB;
 struct b2BodyDef;
 struct b2Color;
 struct b2JointDef;
+struct b2LightDef;
 class b2Body;
 class b2Draw;
 class b2Fixture;
 class b2Joint;
+class b2Light;
 
 /// The world class manages all physics entities, dynamic simulation,
 /// and asynchronous queries. The world also contains efficient memory
@@ -86,7 +88,13 @@ public:
 	/// @warning This function is locked during callbacks.
 	void DestroyJoint(b2Joint* joint);
 
-	/// Take a time step. This performs collision detection, integration,
+    /// Create a light
+    b2Light* CreateLight(const b2LightDef* def);
+
+    /// Destroy a light
+    void DestroyLight(b2Light* light);
+
+    /// Take a time step. This performs collision detection, integration,
 	/// and constraint solution.
 	/// @param timeStep the amount of time to simulate, this should not vary.
 	/// @param velocityIterations for the velocity constraint solver.
@@ -133,7 +141,11 @@ public:
 	b2Joint* GetJointList();
 	const b2Joint* GetJointList() const;
 
-	/// Get the world contact list. With the returned contact, use b2Contact::GetNext to get
+    /// Get the world light list
+    b2Light* GetLightList() { return m_lightList; }
+    const b2Light* GetLightList() const { return m_lightList; }
+
+    /// Get the world contact list. With the returned contact, use b2Contact::GetNext to get
 	/// the next contact in the world list. A nullptr contact indicates the end of the list.
 	/// @return the head of the world contact list.
 	/// @warning contacts are created and destroyed in the middle of a time step.
@@ -165,6 +177,9 @@ public:
 
 	/// Get the number of joints.
 	int32 GetJointCount() const;
+
+    /// Get the number of lights.
+    int32 GetLightCount() const { return m_lightCount; }
 
 	/// Get the number of contacts (each may have 0 or more contact points).
 	int32 GetContactCount() const;
@@ -239,9 +254,11 @@ private:
 
 	b2Body* m_bodyList;
 	b2Joint* m_jointList;
+    b2Light* m_lightList;
 
 	int32 m_bodyCount;
 	int32 m_jointCount;
+    int32 m_lightCount;
 
 	b2Vec2 m_gravity;
 	bool m_allowSleep;


### PR DESCRIPTION
Fix for #527 

This allows multiple threads to safely use their own (not shared)
b2World instances.

The data race is avoided by taking advantage of the thread-safety
guarantees provided by static local variable initialization in C++11:
https://en.cppreference.com/w/cpp/language/storage_duration#Static_local_variables