### PR TITLE
How to run executables on mac

### DIFF
--- a/Building.md
+++ b/Building.md
@@ -16,7 +16,7 @@ Here are the steps for Visual Studio 2017:
 
 ### Xcode
 Here are the steps for Xcode:
-- Command line: `premake5 xcode4`
+- Command line: `./premake5 xcode4`
 - Open the resulting project file (should be `Build/xcode4`)
 - Set the Testbed as the current Scheme
 - Edit the Testbed Scheme, in the Run Options, use a custom working directory

--- a/Testbed/glfw/cocoa_window.m
+++ b/Testbed/glfw/cocoa_window.m
@@ -1420,7 +1420,7 @@ void _glfwPlatformSetWindowFloating(_GLFWwindow* window, GLFWbool enabled)
 
 void _glfwPlatformPollEvents(void)
 {
-    for (;;)
+    while (true)
     {
         NSEvent* event = [NSApp nextEventMatchingMask:NSEventMaskAny
                                             untilDate:[NSDate distantPast]


### PR DESCRIPTION
Executables need ./ before their name in order to be executed