### PR TITLE
Bugfix b2Body::SetActive(true)

### DIFF
--- a/Box2D/Dynamics/b2Body.cpp
+++ b/Box2D/Dynamics/b2Body.cpp
@@ -477,6 +477,7 @@ void b2Body::SetActive(bool flag)
 		}
 
 		// Contacts are created the next time step.
+		m_world->m_flags |= b2World::e_newFixture;
 	}
 	else
 	{


### PR DESCRIPTION
When you call `b2Body::SetActive(true)` and no new fixture has been added that frame then `b2World::Step(...)` doesn't call `FindNewContacts()` and so that body has no collision detection on the first step.

The fix is to add the following line of code under the comment below in `SetActive()` which is already there.

```
		// Contacts are created the next time step.
		m_world->m_flags |= b2World::e_newFixture; // ** add this **
```
