### PR TITLE
Fixes for Samples for macOS

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -70,7 +70,11 @@ set (SAMPLE_SOURCE_FILES
 	tests/tumbler.cpp
 )
 
-add_executable(samples ${SAMPLE_SOURCE_FILES})
+set (SAMPLE_RESOURCE_FILES
+    data/DroidSans.ttf
+)
+
+add_executable(samples ${SAMPLE_SOURCE_FILES} ${SAMPLE_RESOURCE_FILES})
 target_include_directories(samples PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(samples PUBLIC box2d glfw imgui sajson glad)
 set_target_properties(samples PROPERTIES
@@ -78,4 +82,20 @@ set_target_properties(samples PROPERTIES
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO
 )
-source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${SAMPLE_SOURCE_FILES})
+if(APPLE)
+	set_target_properties(samples PROPERTIES
+        MACOSX_BUNDLE_INFO_PLIST            "${CMAKE_CURRENT_SOURCE_DIR}/MacOSXBundleInfo.plist.in"
+		MACOSX_BUNDLE						TRUE
+        MACOSX_BUNDLE_BUNDLE_NAME           "Samples"
+        MACOSX_BUNDLE_GUI_IDENTIFIER        "org.box2d.samples"
+    )
+
+	# Reflect resources directory tree inside bundle
+	foreach (SAMPLE_RESOURCE_FILE ${SAMPLE_RESOURCE_FILES})
+		get_filename_component(SAMPLE_RESOURCE_DIR ${SAMPLE_RESOURCE_FILE} DIRECTORY)
+		set_source_files_properties(${SAMPLE_RESOURCE_FILE} PROPERTIES
+			MACOSX_PACKAGE_LOCATION Resources/${SAMPLE_RESOURCE_DIR}
+		)
+	endforeach()
+endif()
+source_group(TREE "${CMAKE_CURRENT_SOURCE_DIR}" FILES ${SAMPLE_SOURCE_FILES} ${SAMPLE_RESOURCE_FILES})

--- a/samples/MacOSXBundleInfo.plist.in
+++ b/samples/MacOSXBundleInfo.plist.in
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<key>CFBundleGetInfoString</key>
+	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
+	<key>CFBundleIconFile</key>
+	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
+	<key>CFBundleName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>LSRequiresCarbon</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+    <key>NSSupportsAutomaticGraphicsSwitching</key>
+    <true/>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+</dict>
+</plist>
+

--- a/samples/main.cpp
+++ b/samples/main.cpp
@@ -61,7 +61,7 @@ static void SortTests()
 	std::sort(g_testEntries, g_testEntries + g_testCount, CompareTests);
 }
 
-static void CreateUI(GLFWwindow* window)
+static void CreateUI(GLFWwindow* window, const char* glslVersion = NULL)
 {
 	float xscale, yscale;
 	glfwGetWindowContentScale(window, &xscale, &yscale);
@@ -78,7 +78,7 @@ static void CreateUI(GLFWwindow* window)
 		assert(false);
 	}
 
-	success = ImGui_ImplOpenGL3_Init();
+	success = ImGui_ImplOpenGL3_Init(glslVersion);
 	if (success == false)
 	{
 		printf("ImGui_ImplOpenGL3_Init failed\n");
@@ -479,6 +479,11 @@ int main(int, char**)
 		return -1;
 	}
 
+#if __APPLE__
+    const char* glslVersion = "#version 150";
+#else
+    const char* glslVersion = NULL;
+#endif
 
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
@@ -511,7 +516,7 @@ int main(int, char**)
 
 	g_debugDraw.Create();
 
-	CreateUI(g_mainWindow);
+	CreateUI(g_mainWindow, glslVersion);
 
 	s_settings.m_testIndex = b2Clamp(s_settings.m_testIndex, 0, g_testCount - 1);
 	s_testSelection = s_settings.m_testIndex;


### PR DESCRIPTION
PR solve two problems with samples:
* GLSL 1.3 is not available on macOS, bumped to 1.5 (Apple platforms only)
* To avoid problems with locating data files for Samples were build as a bundle where resource files are copied into it