### PR TITLE
Optimize broadphase AABB and pair management

### DIFF
--- a/include/box2d/b2_broad_phase.h
+++ b/include/box2d/b2_broad_phase.h
@@ -26,7 +26,6 @@
 #include "b2_settings.h"
 #include "b2_collision.h"
 #include "b2_dynamic_tree.h"
-#include <algorithm>
 
 struct b2Pair
 {
@@ -208,37 +207,30 @@ void b2BroadPhase::UpdatePairs(T* callback)
 		m_tree.Query(this, fatAABB);
 	}
 
-	// Reset move buffer
-	m_moveCount = 0;
-
-	// Sort the pair buffer to expose duplicates.
-	std::sort(m_pairBuffer, m_pairBuffer + m_pairCount, b2PairLessThan);
-
-	// Send the pairs back to the client.
-	int32 i = 0;
-	while (i < m_pairCount)
+	// Send pairs to caller
+	for (int32 i = 0; i < m_pairCount; ++i)
 	{
 		b2Pair* primaryPair = m_pairBuffer + i;
 		void* userDataA = m_tree.GetUserData(primaryPair->proxyIdA);
 		void* userDataB = m_tree.GetUserData(primaryPair->proxyIdB);
 
 		callback->AddPair(userDataA, userDataB);
-		++i;
-
-		// Skip any duplicate pairs.
-		while (i < m_pairCount)
-		{
-			b2Pair* pair = m_pairBuffer + i;
-			if (pair->proxyIdA != primaryPair->proxyIdA || pair->proxyIdB != primaryPair->proxyIdB)
-			{
-				break;
-			}
-			++i;
-		}
 	}
 
-	// Try to keep the tree balanced.
-	//m_tree.Rebalance(4);
+	// Clear move flags
+	for (int32 i = 0; i < m_moveCount; ++i)
+	{
+		int32 proxyId = m_moveBuffer[i];
+		if (proxyId == e_nullProxy)
+		{
+			continue;
+		}
+
+		m_tree.ClearMoved(proxyId);
+	}
+
+	// Reset move buffer
+	m_moveCount = 0;
 }
 
 template <typename T>

--- a/include/box2d/b2_broad_phase.h
+++ b/include/box2d/b2_broad_phase.h
@@ -131,22 +131,6 @@ private:
 	int32 m_queryProxyId;
 };
 
-/// This is used to sort pairs.
-inline bool b2PairLessThan(const b2Pair& pair1, const b2Pair& pair2)
-{
-	if (pair1.proxyIdA < pair2.proxyIdA)
-	{
-		return true;
-	}
-
-	if (pair1.proxyIdA == pair2.proxyIdA)
-	{
-		return pair1.proxyIdB < pair2.proxyIdB;
-	}
-
-	return false;
-}
-
 inline void* b2BroadPhase::GetUserData(int32 proxyId) const
 {
 	return m_tree.GetUserData(proxyId);

--- a/include/box2d/b2_dynamic_tree.h
+++ b/include/box2d/b2_dynamic_tree.h
@@ -52,6 +52,8 @@ struct b2TreeNode
 
 	// leaf = 0, free node = -1
 	int32 height;
+
+	bool moved;
 };
 
 /// A dynamic AABB tree broad-phase, inspired by Nathanael Presson's btDbvt.
@@ -86,6 +88,9 @@ public:
 	/// Get proxy user data.
 	/// @return the proxy user data or 0 if the id is invalid.
 	void* GetUserData(int32 proxyId) const;
+
+	bool WasMoved(int32 proxyId) const;
+	void ClearMoved(int32 proxyId);
 
 	/// Get the fat AABB for a proxy.
 	const b2AABB& GetFatAABB(int32 proxyId) const;
@@ -161,6 +166,18 @@ inline void* b2DynamicTree::GetUserData(int32 proxyId) const
 {
 	b2Assert(0 <= proxyId && proxyId < m_nodeCapacity);
 	return m_nodes[proxyId].userData;
+}
+
+inline bool b2DynamicTree::WasMoved(int32 proxyId) const
+{
+	b2Assert(0 <= proxyId && proxyId < m_nodeCapacity);
+	return m_nodes[proxyId].moved;
+}
+
+inline void b2DynamicTree::ClearMoved(int32 proxyId)
+{
+	b2Assert(0 <= proxyId && proxyId < m_nodeCapacity);
+	m_nodes[proxyId].moved = false;
 }
 
 inline const b2AABB& b2DynamicTree::GetFatAABB(int32 proxyId) const

--- a/include/box2d/b2_settings.h
+++ b/include/box2d/b2_settings.h
@@ -67,7 +67,7 @@ typedef unsigned int uint32;
 /// This is used to fatten AABBs in the dynamic tree. This is used to predict
 /// the future position based on the current displacement.
 /// This is a dimensionless multiplier.
-#define b2_aabbMultiplier		2.0f
+#define b2_aabbMultiplier		4.0f
 
 /// A small length used as a collision and constraint tolerance. Usually it is
 /// chosen to be numerically significant, but visually insignificant.

--- a/include/box2d/b2_world.h
+++ b/include/box2d/b2_world.h
@@ -66,7 +66,7 @@ public:
 	void SetContactListener(b2ContactListener* listener);
 
 	/// Register a routine for debug drawing. The debug draw functions are called
-	/// inside with b2World::DrawDebugData method. The debug draw object is owned
+	/// inside with b2World::DebugDraw method. The debug draw object is owned
 	/// by you and must remain in scope.
 	void SetDebugDraw(b2Draw* debugDraw);
 
@@ -109,7 +109,7 @@ public:
 	void ClearForces();
 
 	/// Call this to draw shapes and other debug draw data. This is intentionally non-const.
-	void DrawDebugData();
+	void DebugDraw();
 
 	/// Query the world for all fixtures that potentially overlap the
 	/// provided AABB.

--- a/src/collision/b2_broad_phase.cpp
+++ b/src/collision/b2_broad_phase.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "box2d/b2_broad_phase.h"
+#include <string.h>
 
 b2BroadPhase::b2BroadPhase()
 {
@@ -105,11 +106,18 @@ bool b2BroadPhase::QueryCallback(int32 proxyId)
 		return true;
 	}
 
+	const bool moved = m_tree.WasMoved(proxyId);
+	if (moved && proxyId > m_queryProxyId)
+	{
+		// Both proxies are moving. Avoid duplicate pairs.
+		return true;
+	}
+
 	// Grow the pair buffer as needed.
 	if (m_pairCount == m_pairCapacity)
 	{
 		b2Pair* oldBuffer = m_pairBuffer;
-		m_pairCapacity *= 2;
+		m_pairCapacity = m_pairCapacity + (m_pairCapacity >> 1);
 		m_pairBuffer = (b2Pair*)b2Alloc(m_pairCapacity * sizeof(b2Pair));
 		memcpy(m_pairBuffer, oldBuffer, m_pairCount * sizeof(b2Pair));
 		b2Free(oldBuffer);

--- a/src/dynamics/b2_fixture.cpp
+++ b/src/dynamics/b2_fixture.cpp
@@ -171,7 +171,7 @@ void b2Fixture::Synchronize(b2BroadPhase* broadPhase, const b2Transform& transfo
 	
 		proxy->aabb.Combine(aabb1, aabb2);
 
-		b2Vec2 displacement = transform2.p - transform1.p;
+		b2Vec2 displacement = aabb2.GetCenter() - aabb1.GetCenter();
 
 		broadPhase->MoveProxy(proxy->proxyId, proxy->aabb, displacement);
 	}

--- a/src/dynamics/b2_world.cpp
+++ b/src/dynamics/b2_world.cpp
@@ -1167,7 +1167,7 @@ void b2World::DrawJoint(b2Joint* joint)
 	}
 }
 
-void b2World::DrawDebugData()
+void b2World::DebugDraw()
 {
 	if (m_debugDraw == nullptr)
 	{
@@ -1220,13 +1220,14 @@ void b2World::DrawDebugData()
 		b2Color color(0.3f, 0.9f, 0.9f);
 		for (b2Contact* c = m_contactManager.m_contactList; c; c = c->GetNext())
 		{
-			//b2Fixture* fixtureA = c->GetFixtureA();
-			//b2Fixture* fixtureB = c->GetFixtureB();
+			b2Fixture* fixtureA = c->GetFixtureA();
+			b2Fixture* fixtureB = c->GetFixtureB();
+			int32 indexA = c->GetChildIndexA();
+			int32 indexB = c->GetChildIndexB();
+			b2Vec2 cA = fixtureA->GetAABB(indexA).GetCenter();
+			b2Vec2 cB = fixtureB->GetAABB(indexB).GetCenter();
 
-			//b2Vec2 cA = fixtureA->GetAABB().GetCenter();
-			//b2Vec2 cB = fixtureB->GetAABB().GetCenter();
-
-			//g_debugDraw->DrawSegment(cA, cB, color);
+			m_debugDraw->DrawSegment(cA, cB, color);
 		}
 	}
 

--- a/testbed/CMakeLists.txt
+++ b/testbed/CMakeLists.txt
@@ -11,7 +11,7 @@ set (TESTBED_SOURCE_FILES
 	test.cpp
 	test.h
 	tests/add_pair.cpp
-	tests/apply_forces.cpp
+	tests/apply_force.cpp
 	tests/body_types.cpp
 	tests/box_stack.cpp
 	tests/breakable.cpp

--- a/testbed/draw.cpp
+++ b/testbed/draw.cpp
@@ -23,6 +23,7 @@
 #include "draw.h"
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdlib.h>
 
 #include "imgui/imgui.h"
 

--- a/testbed/main.cpp
+++ b/testbed/main.cpp
@@ -30,7 +30,10 @@
 #include "settings.h"
 #include "test.h"
 
+#include <algorithm>
 #include <stdio.h>
+#include <thread>
+#include <chrono> 
 
 GLFWwindow* g_mainWindow = nullptr;
 static int32 s_testSelection = 0;
@@ -537,15 +540,17 @@ int main(int, char**)
 	s_test = g_testEntries[s_settings.m_testIndex].createFcn();
 
 	// Control the frame rate. One draw per monitor refresh.
-	glfwSwapInterval(1);
+	//glfwSwapInterval(1);
 
-	double time1 = glfwGetTime();
-	double frameTime = 0.0;
-   
 	glClearColor(0.3f, 0.3f, 0.3f, 1.f);
-	
+
+	std::chrono::duration<double> frameTime(0.0);
+	std::chrono::duration<double> sleepAdjust(0.0);
+
 	while (!glfwWindowShouldClose(g_mainWindow))
 	{
+		std::chrono::steady_clock::time_point t1 = std::chrono::steady_clock::now();
+
 		glfwGetWindowSize(g_mainWindow, &g_camera.m_width, &g_camera.m_height);
         
         int bufferWidth, bufferHeight;
@@ -574,6 +579,21 @@ int main(int, char**)
 
 		s_test->Step(s_settings);
 
+		UpdateUI();
+
+		// ImGui::ShowDemoWindow();
+			
+		if (g_debugDraw.m_showUI)
+		{
+			sprintf(buffer, "%.1f ms, %.3f", 1000.0 * frameTime.count(), 1000.0 * sleepAdjust.count());
+			g_debugDraw.DrawString(5, g_camera.m_height - 20, buffer);
+		}
+
+		ImGui::Render();
+		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+
+		glfwSwapBuffers(g_mainWindow);
+
 		if (s_testSelection != s_settings.m_testIndex)
 		{
 			s_settings.m_testIndex = s_testSelection;
@@ -583,28 +603,24 @@ int main(int, char**)
 			g_camera.m_center.Set(0.0f, 20.0f);
 		}
 
-		UpdateUI();
+		glfwPollEvents();
 
-		// ImGui::ShowDemoWindow();
-
-		// Measure speed
-		double time2 = glfwGetTime();
-		double alpha = 0.9;
-		frameTime = alpha * frameTime + (1.0 - alpha) * (time2 - time1);
-		time1 = time2;
-
-		if (g_debugDraw.m_showUI)
+		// Throttle to cap at 60Hz. This adaptive using a sleep adjustment. This could be improved by
+		// using mm_pause or equivalent for the last millisecond.
+		std::chrono::steady_clock::time_point t2 = std::chrono::steady_clock::now();
+		std::chrono::duration<double> target(1.0 / 60.0);
+		std::chrono::duration<double> timeUsed = t2 - t1;
+		std::chrono::duration<double> sleepTime = target - timeUsed + sleepAdjust;
+		if (sleepTime > std::chrono::duration<double>(0))
 		{
-			sprintf(buffer, "%.1f ms", 1000.0 * frameTime);
-			g_debugDraw.DrawString(5, g_camera.m_height - 20, buffer);
+			std::this_thread::sleep_for(sleepTime);
 		}
 
-		ImGui::Render();
-		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+		std::chrono::steady_clock::time_point t3 = std::chrono::steady_clock::now();
+		frameTime = t3 - t1;
 
-		glfwSwapBuffers(g_mainWindow);
-
-		glfwPollEvents();
+		// Compute the sleep adjustment using a low pass filter
+		sleepAdjust = 0.9 * sleepAdjust + 0.1 * (target - frameTime);
 	}
 
 	delete s_test;

--- a/testbed/main.cpp
+++ b/testbed/main.cpp
@@ -585,7 +585,7 @@ int main(int, char**)
 			
 		if (g_debugDraw.m_showUI)
 		{
-			sprintf(buffer, "%.1f ms, %.3f", 1000.0 * frameTime.count(), 1000.0 * sleepAdjust.count());
+			sprintf(buffer, "%.1f ms", 1000.0 * frameTime.count());
 			g_debugDraw.DrawString(5, g_camera.m_height - 20, buffer);
 		}
 

--- a/testbed/test.cpp
+++ b/testbed/test.cpp
@@ -305,7 +305,7 @@ void Test::Step(Settings& settings)
 
 	m_world->Step(timeStep, settings.m_velocityIterations, settings.m_positionIterations);
 
-	m_world->DrawDebugData();
+	m_world->DebugDraw();
     g_debugDraw.Flush();
 
 	if (timeStep > 0.0f)

--- a/testbed/tests/platformer.cpp
+++ b/testbed/tests/platformer.cpp
@@ -113,10 +113,8 @@ public:
 	void Step(Settings& settings) override
 	{
 		Test::Step(settings);
-		g_debugDraw.DrawString(5, m_textLine, "Press: (c) create a shape, (d) destroy a shape.");
-		m_textLine += m_textIncrement;
 
-        b2Vec2 v = m_character->GetBody()->GetLinearVelocity();
+		b2Vec2 v = m_character->GetBody()->GetLinearVelocity();
         g_debugDraw.DrawString(5, m_textLine, "Character Linear Velocity: %f", v.y);
 		m_textLine += m_textIncrement;
 	}

--- a/testbed/tests/polygon_shapes.cpp
+++ b/testbed/tests/polygon_shapes.cpp
@@ -42,45 +42,6 @@ public:
 		m_count = 0;
 	}
 
-	void DrawFixture(b2Fixture* fixture)
-	{
-		b2Color color(0.95f, 0.95f, 0.6f);
-		const b2Transform& xf = fixture->GetBody()->GetTransform();
-
-		switch (fixture->GetType())
-		{
-		case b2Shape::e_circle:
-			{
-				b2CircleShape* circle = (b2CircleShape*)fixture->GetShape();
-
-				b2Vec2 center = b2Mul(xf, circle->m_p);
-				float radius = circle->m_radius;
-
-				g_debugDraw->DrawCircle(center, radius, color);
-			}
-			break;
-
-		case b2Shape::e_polygon:
-			{
-				b2PolygonShape* poly = (b2PolygonShape*)fixture->GetShape();
-				int32 vertexCount = poly->m_count;
-				b2Assert(vertexCount <= b2_maxPolygonVertices);
-				b2Vec2 vertices[b2_maxPolygonVertices];
-
-				for (int32 i = 0; i < vertexCount; ++i)
-				{
-					vertices[i] = b2Mul(xf, poly->m_vertices[i]);
-				}
-
-				g_debugDraw->DrawPolygon(vertices, vertexCount, color);
-			}
-			break;
-				
-		default:
-			break;
-		}
-	}
-
 	/// Called for each fixture found in the query AABB.
 	/// @return false to terminate the query.
 	bool ReportFixture(b2Fixture* fixture) override
@@ -94,10 +55,12 @@ public:
 		b2Shape* shape = fixture->GetShape();
 
 		bool overlap = b2TestOverlap(shape, 0, &m_circle, 0, body->GetTransform(), m_transform);
-
+			
 		if (overlap)
 		{
-			DrawFixture(fixture);
+			b2Color color(0.95f, 0.95f, 0.6f);
+			b2Vec2 center = body->GetWorldCenter();
+			g_debugDraw->DrawPoint(center, 5.0f, color);
 			++m_count;
 		}
 
@@ -280,7 +243,7 @@ public:
 		b2Color color(0.4f, 0.7f, 0.8f);
 		g_debugDraw.DrawCircle(callback.m_circle.m_p, callback.m_circle.m_radius, color);
 
-		g_debugDraw.DrawString(5, m_textLine, "Press 1-5 to drop stuff");
+		g_debugDraw.DrawString(5, m_textLine, "Press 1-5 to drop stuff, maximum of %d overlaps detected", PolygonShapesCallback::e_maxCount);
 		m_textLine += m_textIncrement;
 		g_debugDraw.DrawString(5, m_textLine, "Press 'a' to enable/disable some bodies");
 		m_textLine += m_textIncrement;

--- a/testbed/tests/rope.cpp
+++ b/testbed/tests/rope.cpp
@@ -124,9 +124,9 @@ public:
 			ImGui::EndCombo();
 		}
 
-		ImGui::SliderFloat("Damping##1", &m_tuning1.bendDamping, 0.0f, 4.0f, "%.1f");
-		ImGui::SliderFloat("Hertz##1", &m_tuning1.bendHertz, 0.0f, 60.0f, "%.0f");
-		ImGui::SliderFloat("Stiffness##1", &m_tuning1.bendStiffness, 0.0f, 1.0f, "%.1f");
+		ImGui::SliderFloat("Damping##B1", &m_tuning1.bendDamping, 0.0f, 4.0f, "%.1f");
+		ImGui::SliderFloat("Hertz##B1", &m_tuning1.bendHertz, 0.0f, 60.0f, "%.0f");
+		ImGui::SliderFloat("Stiffness##B1", &m_tuning1.bendStiffness, 0.0f, 1.0f, "%.1f");
 
 		ImGui::Checkbox("Isometric##1", &m_tuning1.isometric);
 		ImGui::Checkbox("Fixed Mass##1", &m_tuning1.fixedEffectiveMass);
@@ -152,9 +152,9 @@ public:
 			ImGui::EndCombo();
 		}
 
-		ImGui::SliderFloat("Damping##1", &m_tuning1.stretchDamping, 0.0f, 4.0f, "%.1f");
-		ImGui::SliderFloat("Hertz##1", &m_tuning1.stretchHertz, 0.0f, 60.0f, "%.0f");
-		ImGui::SliderFloat("Stiffness##1", &m_tuning1.stretchStiffness, 0.0f, 1.0f, "%.1f");
+		ImGui::SliderFloat("Damping##S1", &m_tuning1.stretchDamping, 0.0f, 4.0f, "%.1f");
+		ImGui::SliderFloat("Hertz##S1", &m_tuning1.stretchHertz, 0.0f, 60.0f, "%.0f");
+		ImGui::SliderFloat("Stiffness##S1", &m_tuning1.stretchStiffness, 0.0f, 1.0f, "%.1f");
 
 		ImGui::SliderInt("Iterations##1", &m_iterations1, 1, 100, "%d");
 
@@ -181,9 +181,9 @@ public:
 			ImGui::EndCombo();
 		}
 
-		ImGui::SliderFloat("Damping##2", &m_tuning2.bendDamping, 0.0f, 4.0f, "%.1f");
-		ImGui::SliderFloat("Hertz##2", &m_tuning2.bendHertz, 0.0f, 60.0f, "%.0f");
-		ImGui::SliderFloat("Stiffness##2", &m_tuning2.bendStiffness, 0.0f, 1.0f, "%.1f");
+		ImGui::SliderFloat("Damping##B2", &m_tuning2.bendDamping, 0.0f, 4.0f, "%.1f");
+		ImGui::SliderFloat("Hertz##B2", &m_tuning2.bendHertz, 0.0f, 60.0f, "%.0f");
+		ImGui::SliderFloat("Stiffness##B2", &m_tuning2.bendStiffness, 0.0f, 1.0f, "%.1f");
 
 		ImGui::Checkbox("Isometric##2", &m_tuning2.isometric);
 		ImGui::Checkbox("Fixed Mass##2", &m_tuning2.fixedEffectiveMass);
@@ -209,9 +209,9 @@ public:
 			ImGui::EndCombo();
 		}
 
-		ImGui::SliderFloat("Damping##2", &m_tuning2.stretchDamping, 0.0f, 4.0f, "%.1f");
-		ImGui::SliderFloat("Hertz##2", &m_tuning2.stretchHertz, 0.0f, 60.0f, "%.0f");
-		ImGui::SliderFloat("Stiffness##2", &m_tuning2.stretchStiffness, 0.0f, 1.0f, "%.1f");
+		ImGui::SliderFloat("Damping##S2", &m_tuning2.stretchDamping, 0.0f, 4.0f, "%.1f");
+		ImGui::SliderFloat("Hertz##S2", &m_tuning2.stretchHertz, 0.0f, 60.0f, "%.0f");
+		ImGui::SliderFloat("Stiffness##S2", &m_tuning2.stretchStiffness, 0.0f, 1.0f, "%.1f");
 
 		ImGui::SliderInt("Iterations##2", &m_iterations2, 1, 100, "%d");
 


### PR DESCRIPTION
- Enlarged AABBs can shrink if they get too big
- Use AABB centers instead of transform positions to track displacement
- Removed std::sort from pair update by tracking movement in proxies
- Broadphase cost reduced from 0.52ms to 0.35ms in tumbler benchmark