### PR TITLE
Ghost Collision Fix

### DIFF
--- a/include/box2d/b2_chain_shape.h
+++ b/include/box2d/b2_chain_shape.h
@@ -28,11 +28,10 @@
 class b2EdgeShape;
 
 /// A chain shape is a free form sequence of line segments.
-/// The chain has two-sided collision, so you can use inside and outside collision.
-/// Therefore, you may use any winding order.
-/// Since there may be many vertices, they are allocated using b2Alloc.
+/// The chain has one-sided collision, with the surface normal pointing to the right of the edge.
+/// This provides a counter-clockwise winding like the polygon shape.
 /// Connectivity information is used to create smooth collisions.
-/// WARNING: The chain will not collide properly if there are self-intersections.
+/// @warning the chain will not collide properly if there are self-intersections.
 class b2ChainShape : public b2Shape
 {
 public:
@@ -49,18 +48,13 @@ public:
 	/// @param count the vertex count
 	void CreateLoop(const b2Vec2* vertices, int32 count);
 
-	/// Create a chain with isolated end vertices.
+	/// Create a chain with ghost vertices to connect multiple chains together.
 	/// @param vertices an array of vertices, these are copied
 	/// @param count the vertex count
-	void CreateChain(const b2Vec2* vertices, int32 count);
-
-	/// Establish connectivity to a vertex that precedes the first vertex.
-	/// Don't call this for loops.
-	void SetPrevVertex(const b2Vec2& prevVertex);
-
-	/// Establish connectivity to a vertex that follows the last vertex.
-	/// Don't call this for loops.
-	void SetNextVertex(const b2Vec2& nextVertex);
+	/// @param prevVertex previous vertex from chain that connects to the start
+	/// @param nextVertex next vertex from chain that connects to the end
+	void CreateChain(const b2Vec2* vertices, int32 count,
+		const b2Vec2& prevVertex, const b2Vec2& nextVertex);
 
 	/// Implement b2Shape. Vertices are cloned using b2Alloc.
 	b2Shape* Clone(b2BlockAllocator* allocator) const override;
@@ -93,7 +87,6 @@ public:
 	int32 m_count;
 
 	b2Vec2 m_prevVertex, m_nextVertex;
-	bool m_hasPrevVertex, m_hasNextVertex;
 };
 
 inline b2ChainShape::b2ChainShape()
@@ -102,8 +95,6 @@ inline b2ChainShape::b2ChainShape()
 	m_radius = b2_polygonRadius;
 	m_vertices = nullptr;
 	m_count = 0;
-	m_hasPrevVertex = false;
-	m_hasNextVertex = false;
 }
 
 #endif

--- a/include/box2d/b2_edge_shape.h
+++ b/include/box2d/b2_edge_shape.h
@@ -26,7 +26,7 @@
 #include "b2_shape.h"
 
 /// A line segment (edge) shape. These can be connected in chains or loops
-/// to other edge shapes. Edges created indepently are two-sided and do
+/// to other edge shapes. Edges created independently are two-sided and do
 /// no provide smooth movement accross junctions. 
 class b2EdgeShape : public b2Shape
 {

--- a/include/box2d/b2_edge_shape.h
+++ b/include/box2d/b2_edge_shape.h
@@ -26,15 +26,21 @@
 #include "b2_shape.h"
 
 /// A line segment (edge) shape. These can be connected in chains or loops
-/// to other edge shapes. The connectivity information is used to ensure
-/// correct contact normals.
+/// to other edge shapes. Edges created indepently are two-sided and do
+/// no provide smooth movement accross junctions. 
 class b2EdgeShape : public b2Shape
 {
 public:
 	b2EdgeShape();
 
-	/// Set this as an isolated edge.
-	void Set(const b2Vec2& v1, const b2Vec2& v2);
+	/// Set this as a part of a sequence. Vertex v0 precedes the edge and vertex v3
+	/// follows. These extra vertices are used to provide smooth movement
+	/// across junctions. This also makes the collision one-sided. The edge
+	/// normal points to the right looking from v1 to v2.
+	void SetOneSided(const b2Vec2& v0, const b2Vec2& v1,const b2Vec2& v2, const b2Vec2& v3);
+
+	/// Set this as an isolated edge. Collision is two-sided.
+	void SetTwoSided(const b2Vec2& v1, const b2Vec2& v2);
 
 	/// Implement b2Shape.
 	b2Shape* Clone(b2BlockAllocator* allocator) const override;
@@ -60,7 +66,9 @@ public:
 
 	/// Optional adjacent vertices. These are used for smooth collision.
 	b2Vec2 m_vertex0, m_vertex3;
-	bool m_hasVertex0, m_hasVertex3;
+
+	/// Uses m_vertex0 and m_vertex3 to create smooth collision.
+	bool m_oneSided;
 };
 
 inline b2EdgeShape::b2EdgeShape()
@@ -71,8 +79,7 @@ inline b2EdgeShape::b2EdgeShape()
 	m_vertex0.y = 0.0f;
 	m_vertex3.x = 0.0f;
 	m_vertex3.y = 0.0f;
-	m_hasVertex0 = false;
-	m_hasVertex3 = false;
+	m_oneSided = false;
 }
 
 #endif

--- a/src/collision/b2_chain_shape.cpp
+++ b/src/collision/b2_chain_shape.cpp
@@ -63,11 +63,9 @@ void b2ChainShape::CreateLoop(const b2Vec2* vertices, int32 count)
 	m_vertices[count] = m_vertices[0];
 	m_prevVertex = m_vertices[m_count - 2];
 	m_nextVertex = m_vertices[1];
-	m_hasPrevVertex = true;
-	m_hasNextVertex = true;
 }
 
-void b2ChainShape::CreateChain(const b2Vec2* vertices, int32 count)
+void b2ChainShape::CreateChain(const b2Vec2* vertices, int32 count,	const b2Vec2& prevVertex, const b2Vec2& nextVertex)
 {
 	b2Assert(m_vertices == nullptr && m_count == 0);
 	b2Assert(count >= 2);
@@ -81,34 +79,15 @@ void b2ChainShape::CreateChain(const b2Vec2* vertices, int32 count)
 	m_vertices = (b2Vec2*)b2Alloc(count * sizeof(b2Vec2));
 	memcpy(m_vertices, vertices, m_count * sizeof(b2Vec2));
 
-	m_hasPrevVertex = false;
-	m_hasNextVertex = false;
-
-	m_prevVertex.SetZero();
-	m_nextVertex.SetZero();
-}
-
-void b2ChainShape::SetPrevVertex(const b2Vec2& prevVertex)
-{
 	m_prevVertex = prevVertex;
-	m_hasPrevVertex = true;
-}
-
-void b2ChainShape::SetNextVertex(const b2Vec2& nextVertex)
-{
 	m_nextVertex = nextVertex;
-	m_hasNextVertex = true;
 }
 
 b2Shape* b2ChainShape::Clone(b2BlockAllocator* allocator) const
 {
 	void* mem = allocator->Allocate(sizeof(b2ChainShape));
 	b2ChainShape* clone = new (mem) b2ChainShape;
-	clone->CreateChain(m_vertices, m_count);
-	clone->m_prevVertex = m_prevVertex;
-	clone->m_nextVertex = m_nextVertex;
-	clone->m_hasPrevVertex = m_hasPrevVertex;
-	clone->m_hasNextVertex = m_hasNextVertex;
+	clone->CreateChain(m_vertices, m_count, m_prevVertex, m_nextVertex);
 	return clone;
 }
 
@@ -126,27 +105,24 @@ void b2ChainShape::GetChildEdge(b2EdgeShape* edge, int32 index) const
 
 	edge->m_vertex1 = m_vertices[index + 0];
 	edge->m_vertex2 = m_vertices[index + 1];
+	edge->m_oneSided = true;
 
 	if (index > 0)
 	{
 		edge->m_vertex0 = m_vertices[index - 1];
-		edge->m_hasVertex0 = true;
 	}
 	else
 	{
 		edge->m_vertex0 = m_prevVertex;
-		edge->m_hasVertex0 = m_hasPrevVertex;
 	}
 
 	if (index < m_count - 2)
 	{
 		edge->m_vertex3 = m_vertices[index + 2];
-		edge->m_hasVertex3 = true;
 	}
 	else
 	{
 		edge->m_vertex3 = m_nextVertex;
-		edge->m_hasVertex3 = m_hasNextVertex;
 	}
 }
 

--- a/src/collision/b2_collide_edge.cpp
+++ b/src/collision/b2_collide_edge.cpp
@@ -40,6 +40,16 @@ void b2CollideEdgeAndCircle(b2Manifold* manifold,
 	b2Vec2 A = edgeA->m_vertex1, B = edgeA->m_vertex2;
 	b2Vec2 e = B - A;
 	
+	// Normal points to the right for a CCW winding
+	b2Vec2 n(e.y, -e.x);
+	float offset = b2Dot(n, Q - A);
+
+	bool oneSided = edgeA->m_oneSided;
+	if (oneSided && offset < 0.0f)
+	{
+		return;
+	}
+
 	// Barycentric coordinates
 	float u = b2Dot(e, B - Q);
 	float v = b2Dot(e, Q - A);
@@ -137,8 +147,7 @@ void b2CollideEdgeAndCircle(b2Manifold* manifold,
 		return;
 	}
 	
-	b2Vec2 n(-e.y, e.x);
-	if (b2Dot(n, Q - A) < 0.0f)
+	if (offset < 0.0f)
 	{
 		n.Set(-n.x, -n.y);
 	}
@@ -277,9 +286,8 @@ void b2CollideEdgeAndPolygon(b2Manifold* manifold,
 	b2Vec2 normal1(edge1.y, -edge1.x);
 	float offset1 = b2Dot(normal1, centroidB - v1);
 
-	bool front = offset1 >= 0.0f;
 	bool oneSided = edgeA->m_oneSided;
-	if (oneSided && front == false)
+	if (oneSided && offset1 < 0.0f)
 	{
 		return;
 	}
@@ -412,27 +420,13 @@ void b2CollideEdgeAndPolygon(b2Manifold* manifold,
 		clipPoints[1].id.cf.typeA = b2ContactFeature::e_face;
 		clipPoints[1].id.cf.typeB = b2ContactFeature::e_vertex;
 
-		// TODO does order matter?
-		//if (front)
-		{
-			ref.i1 = 0;
-			ref.i2 = 1;
-			ref.v1 = v1;
-			ref.v2 = v2;
-			ref.normal = primaryAxis.normal;
-			ref.sideNormal1 = -edge1;
-			ref.sideNormal2 = edge1;
-		}
-		//else
-		//{
-		//	ref.i1 = 1;
-		//	ref.i2 = 0;
-		//	ref.v1 = v2;
-		//	ref.v2 = v1;
-		//	ref.normal = primaryAxis.normal;
-		//	ref.sideNormal1 = edge1;
-		//	ref.sideNormal2 = -edge1;
-		//}		
+		ref.i1 = 0;
+		ref.i2 = 1;
+		ref.v1 = v1;
+		ref.v2 = v2;
+		ref.normal = primaryAxis.normal;
+		ref.sideNormal1 = -edge1;
+		ref.sideNormal2 = edge1;
 	}
 	else
 	{

--- a/src/collision/b2_collide_edge.cpp
+++ b/src/collision/b2_collide_edge.cpp
@@ -165,6 +165,7 @@ struct b2EPAxis
 		e_edgeB
 	};
 	
+	b2Vec2 normal;
 	Type type;
 	int32 index;
 	float separation;
@@ -197,11 +198,586 @@ struct b2ReferenceFace
 // This class collides and edge and a polygon, taking into account edge adjacency.
 struct b2EPCollider
 {
-	void Collide(b2Manifold* manifold, const b2EdgeShape* edgeA, const b2Transform& xfA,
-				 const b2PolygonShape* polygonB, const b2Transform& xfB);
-	b2EPAxis ComputeEdgeSeparation();
-	b2EPAxis ComputePolygonSeparation();
-	
+	// Chain has normals pointing to the left
+	// Algorithm:
+	// 1. Classify v1 and v2
+	// 2. Classify polygon centroid as front or back
+	// 3. Flip normal if necessary
+	// 4. Initialize normal range to [-pi, pi] about face normal
+	// 5. Adjust normal range according to adjacent edges
+	// 6. Visit each separating axes, only accept axes within the range
+	// 7. Return if _any_ axis indicates separation
+	// 8. Clip
+	void b2EPCollider::Collide(b2Manifold* manifold,
+		const b2EdgeShape* edgeA, const b2Transform& xfA,
+		const b2PolygonShape* polygonB, const b2Transform& xfB)
+	{
+		m_xf = b2MulT(xfA, xfB);
+
+		m_centroidB = b2Mul(m_xf, polygonB->m_centroid);
+
+		m_v0 = edgeA->m_vertex0;
+		m_v1 = edgeA->m_vertex1;
+		m_v2 = edgeA->m_vertex2;
+		m_v3 = edgeA->m_vertex3;
+
+		bool hasVertex0 = edgeA->m_hasVertex0;
+		bool hasVertex3 = edgeA->m_hasVertex3;
+
+		b2Vec2 edge1 = m_v2 - m_v1;
+		edge1.Normalize();
+		m_normal1.Set(-edge1.y, edge1.x);
+		float offset1 = b2Dot(m_normal1, m_centroidB - m_v1);
+		float offset0 = 0.0f, offset2 = 0.0f;
+		bool convex1 = false, convex2 = false;
+
+		// Is there a preceding edge?
+		if (hasVertex0)
+		{
+			b2Vec2 edge0 = m_v1 - m_v0;
+			edge0.Normalize();
+			m_normal0.Set(-edge0.y, edge0.x);
+			convex1 = b2Cross(edge0, edge1) <= 0.0f;
+			offset0 = b2Dot(m_normal0, m_centroidB - m_v0);
+		}
+
+		// Is there a following edge?
+		if (hasVertex3)
+		{
+			b2Vec2 edge2 = m_v3 - m_v2;
+			edge2.Normalize();
+			m_normal2.Set(-edge2.y, edge2.x);
+			convex2 = b2Cross(edge1, edge2) <= 0.0f;
+			offset2 = b2Dot(m_normal2, m_centroidB - m_v2);
+		}
+
+		// Determine front or back collision. Determine collision normal limits.
+		if (hasVertex0 && hasVertex3)
+		{
+			bool front0 = offset0 >= 0.0f;
+			bool front1 = offset1 >= 0.0f;
+			bool front2 = offset2 >= 0.0f;
+
+			if (convex1 && convex2)
+			{
+				// convex-convex
+				m_front = front0 || front1 || front2;
+			}
+			else if (convex1)
+			{
+				// convex-concave
+				if (front2)
+				{
+					if (front1)
+					{
+						if (front0 == true)
+						{
+							// FFF
+							m_front = true;
+						}
+						else
+						{
+							// BFF
+							m_front = true;
+						}
+					}
+					else
+					{
+						if (front0 == true)
+						{
+							// FBF
+							m_front = true;
+							return;
+						}
+						else
+						{
+							// BBF
+							m_front = false;
+						}
+					}
+				}
+				else
+				{
+					if (front1)
+					{
+						if (front0 == true)
+						{
+							// FFB
+							m_front = false;
+							return;
+						}
+						else
+						{
+							// BFB
+							m_front = false;
+							return;
+						}
+					}
+					else
+					{
+						if (front0 == true)
+						{
+							// FBB
+							m_front = true;
+							return;
+						}
+						else
+						{
+							// BBB
+							m_front = false;
+						}
+					}
+				}
+			}
+			else if (convex2)
+			{
+				// concave-convex
+				if (front0)
+				{
+					if (front1)
+					{
+						if (front2 == true)
+						{
+							// FFF
+							m_front = true;
+						}
+						else
+						{
+							// FFB
+							m_front = true;
+						}
+					}
+					else
+					{
+						if (front2 == true)
+						{
+							// FBF
+							m_front = true;
+							return;
+						}
+						else
+						{
+							// FBB
+							m_front = false;
+						}
+					}
+				}
+				else
+				{
+					if (front1)
+					{
+						if (front2 == true)
+						{
+							// BFF
+							m_front = false;
+							return;
+						}
+						else
+						{
+							// BFB
+							m_front = false;
+							return;
+						}
+					}
+					else
+					{
+						if (front2 == true)
+						{
+							// BBF
+							m_front = true;
+							return;
+						}
+						else
+						{
+							// BBB
+							m_front = false;
+						}
+					}
+				}
+			}
+			else
+			{
+				// concave-concave
+				m_front = front0 && front1 && front2;
+			}
+		}
+		else if (hasVertex0)
+		{
+			b2Assert(false);
+			if (convex1)
+			{
+				m_front = offset0 >= 0.0f || offset1 >= 0.0f;
+				if (m_front)
+				{
+					m_normal = m_normal1;
+					m_lowerLimit = m_normal0;
+					m_upperLimit = -m_normal1;
+				}
+				else
+				{
+					m_normal = -m_normal1;
+					m_lowerLimit = m_normal1;
+					m_upperLimit = -m_normal1;
+				}
+			}
+			else
+			{
+				m_front = offset0 >= 0.0f && offset1 >= 0.0f;
+				if (m_front)
+				{
+					m_normal = m_normal1;
+					m_lowerLimit = m_normal1;
+					m_upperLimit = -m_normal1;
+				}
+				else
+				{
+					m_normal = -m_normal1;
+					m_lowerLimit = m_normal1;
+					m_upperLimit = -m_normal0;
+				}
+			}
+		}
+		else if (hasVertex3)
+		{
+			b2Assert(false);
+			if (convex2)
+			{
+				m_front = offset1 >= 0.0f || offset2 >= 0.0f;
+				if (m_front)
+				{
+					m_normal = m_normal1;
+					m_lowerLimit = -m_normal1;
+					m_upperLimit = m_normal2;
+				}
+				else
+				{
+					m_normal = -m_normal1;
+					m_lowerLimit = -m_normal1;
+					m_upperLimit = m_normal1;
+				}
+			}
+			else
+			{
+				m_front = offset1 >= 0.0f && offset2 >= 0.0f;
+				if (m_front)
+				{
+					m_normal = m_normal1;
+					m_lowerLimit = -m_normal1;
+					m_upperLimit = m_normal1;
+				}
+				else
+				{
+					m_normal = -m_normal1;
+					m_lowerLimit = -m_normal2;
+					m_upperLimit = m_normal1;
+				}
+			}		
+		}
+		else
+		{
+			m_front = offset1 >= 0.0f;
+			if (m_front)
+			{
+				m_normal = m_normal1;
+				m_lowerLimit = -m_normal1;
+				m_upperLimit = -m_normal1;
+			}
+			else
+			{
+				m_normal = -m_normal1;
+				m_lowerLimit = m_normal1;
+				m_upperLimit = m_normal1;
+			}
+		}
+
+		// Get polygonB in frameA
+		m_polygonB.count = polygonB->m_count;
+		for (int32 i = 0; i < polygonB->m_count; ++i)
+		{
+			m_polygonB.vertices[i] = b2Mul(m_xf, polygonB->m_vertices[i]);
+			m_polygonB.normals[i] = b2Mul(m_xf.q, polygonB->m_normals[i]);
+		}
+
+		m_radius = polygonB->m_radius + edgeA->m_radius;
+
+		manifold->pointCount = 0;
+
+		if (m_front)
+		{
+			m_normal = m_normal1;
+		}
+		else
+		{
+			m_normal = -m_normal2;
+		}
+
+		b2EPAxis edgeAxis = ComputeEdgeSeparation();
+		if (edgeAxis.separation > m_radius)
+		{
+			return;
+		}
+
+		b2EPAxis polygonAxis = ComputePolygonSeparation();
+		if (polygonAxis.separation > m_radius)
+		{
+			return;
+		}
+
+		// Use hysteresis for jitter reduction.
+		const float k_relativeTol = 0.98f;
+		const float k_absoluteTol = 0.001f;
+
+		b2EPAxis primaryAxis;
+		if (polygonAxis.separation > k_relativeTol * edgeAxis.separation + k_absoluteTol)
+		{
+			primaryAxis = polygonAxis;
+		}
+		else
+		{
+			primaryAxis = edgeAxis;
+		}
+
+		if (hasVertex0 && hasVertex3 && primaryAxis.type == b2EPAxis::e_edgeB)
+		{
+			// Check Gauss Map
+			if (m_front)
+			{
+				if (convex1)
+				{
+					if (b2Cross(primaryAxis.normal, m_normal0) < 0.0f && b2Cross(primaryAxis.normal, -m_normal1) >= 0.0f)
+					{
+						return;
+					}
+				}
+				else
+				{
+					if ()
+				}
+			}
+		}
+
+		b2ClipVertex ie[2];
+		b2ReferenceFace rf;
+		if (primaryAxis.type == b2EPAxis::e_edgeA)
+		{
+			manifold->type = b2Manifold::e_faceA;
+
+			// Search for the polygon normal that is most anti-parallel to the edge normal.
+			int32 bestIndex = 0;
+			float bestValue = b2Dot(m_normal, m_polygonB.normals[0]);
+			for (int32 i = 1; i < m_polygonB.count; ++i)
+			{
+				float value = b2Dot(m_normal, m_polygonB.normals[i]);
+				if (value < bestValue)
+				{
+					bestValue = value;
+					bestIndex = i;
+				}
+			}
+
+			int32 i1 = bestIndex;
+			int32 i2 = i1 + 1 < m_polygonB.count ? i1 + 1 : 0;
+
+			ie[0].v = m_polygonB.vertices[i1];
+			ie[0].id.cf.indexA = 0;
+			ie[0].id.cf.indexB = static_cast<uint8>(i1);
+			ie[0].id.cf.typeA = b2ContactFeature::e_face;
+			ie[0].id.cf.typeB = b2ContactFeature::e_vertex;
+
+			ie[1].v = m_polygonB.vertices[i2];
+			ie[1].id.cf.indexA = 0;
+			ie[1].id.cf.indexB = static_cast<uint8>(i2);
+			ie[1].id.cf.typeA = b2ContactFeature::e_face;
+			ie[1].id.cf.typeB = b2ContactFeature::e_vertex;
+
+			if (m_front)
+			{
+				rf.i1 = 0;
+				rf.i2 = 1;
+				rf.v1 = m_v1;
+				rf.v2 = m_v2;
+				rf.normal = m_normal1;
+			}
+			else
+			{
+				rf.i1 = 1;
+				rf.i2 = 0;
+				rf.v1 = m_v2;
+				rf.v2 = m_v1;
+				rf.normal = -m_normal1;
+			}		
+		}
+		else
+		{
+			manifold->type = b2Manifold::e_faceB;
+
+			ie[0].v = m_v1;
+			ie[0].id.cf.indexA = 0;
+			ie[0].id.cf.indexB = static_cast<uint8>(primaryAxis.index);
+			ie[0].id.cf.typeA = b2ContactFeature::e_vertex;
+			ie[0].id.cf.typeB = b2ContactFeature::e_face;
+
+			ie[1].v = m_v2;
+			ie[1].id.cf.indexA = 0;
+			ie[1].id.cf.indexB = static_cast<uint8>(primaryAxis.index);		
+			ie[1].id.cf.typeA = b2ContactFeature::e_vertex;
+			ie[1].id.cf.typeB = b2ContactFeature::e_face;
+
+			rf.i1 = primaryAxis.index;
+			rf.i2 = rf.i1 + 1 < m_polygonB.count ? rf.i1 + 1 : 0;
+			rf.v1 = m_polygonB.vertices[rf.i1];
+			rf.v2 = m_polygonB.vertices[rf.i2];
+			rf.normal = m_polygonB.normals[rf.i1];
+		}
+
+		rf.sideNormal1.Set(rf.normal.y, -rf.normal.x);
+		rf.sideNormal2 = -rf.sideNormal1;
+		rf.sideOffset1 = b2Dot(rf.sideNormal1, rf.v1);
+		rf.sideOffset2 = b2Dot(rf.sideNormal2, rf.v2);
+
+		// Clip incident edge against extruded edge1 side edges.
+		b2ClipVertex clipPoints1[2];
+		b2ClipVertex clipPoints2[2];
+		int32 np;
+
+		// Clip to box side 1
+		np = b2ClipSegmentToLine(clipPoints1, ie, rf.sideNormal1, rf.sideOffset1, rf.i1);
+
+		if (np < b2_maxManifoldPoints)
+		{
+			return;
+		}
+
+		// Clip to negative box side 1
+		np = b2ClipSegmentToLine(clipPoints2, clipPoints1, rf.sideNormal2, rf.sideOffset2, rf.i2);
+
+		if (np < b2_maxManifoldPoints)
+		{
+			return;
+		}
+
+		// Now clipPoints2 contains the clipped points.
+		if (primaryAxis.type == b2EPAxis::e_edgeA)
+		{
+			manifold->localNormal = rf.normal;
+			manifold->localPoint = rf.v1;
+		}
+		else
+		{
+			manifold->localNormal = polygonB->m_normals[rf.i1];
+			manifold->localPoint = polygonB->m_vertices[rf.i1];
+		}
+
+		int32 pointCount = 0;
+		for (int32 i = 0; i < b2_maxManifoldPoints; ++i)
+		{
+			float separation;
+
+			separation = b2Dot(rf.normal, clipPoints2[i].v - rf.v1);
+
+			if (separation <= m_radius)
+			{
+				b2ManifoldPoint* cp = manifold->points + pointCount;
+
+				if (primaryAxis.type == b2EPAxis::e_edgeA)
+				{
+					cp->localPoint = b2MulT(m_xf, clipPoints2[i].v);
+					cp->id = clipPoints2[i].id;
+				}
+				else
+				{
+					cp->localPoint = clipPoints2[i].v;
+					cp->id.cf.typeA = clipPoints2[i].id.cf.typeB;
+					cp->id.cf.typeB = clipPoints2[i].id.cf.typeA;
+					cp->id.cf.indexA = clipPoints2[i].id.cf.indexB;
+					cp->id.cf.indexB = clipPoints2[i].id.cf.indexA;
+				}
+
+				++pointCount;
+			}
+		}
+
+		manifold->pointCount = pointCount;
+	}
+
+	b2EPAxis ComputeEdgeSeparation()
+	{
+		b2EPAxis axis;
+		axis.type = b2EPAxis::e_edgeA;
+		axis.index = m_front ? 0 : 1;
+		axis.separation = FLT_MAX;
+		axis.normal = m_normal;
+
+		for (int32 i = 0; i < m_polygonB.count; ++i)
+		{
+			float s = b2Dot(m_normal, m_polygonB.vertices[i] - m_v1);
+			if (s < axis.separation)
+			{
+				axis.separation = s;
+			}
+		}
+
+		return axis;
+	}
+
+	b2EPAxis ComputePolygonSeparation()
+	{
+		b2EPAxis axis;
+		axis.type = b2EPAxis::e_unknown;
+		axis.index = -1;
+		axis.separation = -FLT_MAX;
+		axis.normal.SetZero();
+
+		b2Vec2 perp(-m_normal.y, m_normal.x);
+
+		for (int32 i = 0; i < m_polygonB.count; ++i)
+		{
+			b2Vec2 n = -m_polygonB.normals[i];
+
+			float s1 = b2Dot(n, m_polygonB.vertices[i] - m_v1);
+			float s2 = b2Dot(n, m_polygonB.vertices[i] - m_v2);
+			float s = b2Min(s1, s2);
+
+			if (s > m_radius)
+			{
+				// No collision
+				axis.type = b2EPAxis::e_edgeB;
+				axis.index = i;
+				axis.separation = s;
+				axis.normal = n;
+				return axis;
+			}
+
+#if 0
+			// Adjacency
+			if (b2Dot(n, perp) >= 0.0f)
+			{
+				if (b2Dot(n - m_upperLimit, m_normal) < -b2_angularSlop)
+				{
+					continue;
+				}
+			}
+			else
+			{
+				if (b2Dot(n - m_lowerLimit, m_normal) < -b2_angularSlop)
+				{
+					continue;
+				}
+			}
+#endif
+
+			if (s > axis.separation)
+			{
+				axis.type = b2EPAxis::e_edgeB;
+				axis.index = i;
+				axis.separation = s;
+				axis.normal = n;
+			}
+		}
+
+		return axis;
+	}
+
 	enum VertexType
 	{
 		e_isolated,
@@ -221,477 +797,6 @@ struct b2EPCollider
 	float m_radius;
 	bool m_front;
 };
-
-// Algorithm:
-// 1. Classify v1 and v2
-// 2. Classify polygon centroid as front or back
-// 3. Flip normal if necessary
-// 4. Initialize normal range to [-pi, pi] about face normal
-// 5. Adjust normal range according to adjacent edges
-// 6. Visit each separating axes, only accept axes within the range
-// 7. Return if _any_ axis indicates separation
-// 8. Clip
-void b2EPCollider::Collide(b2Manifold* manifold, const b2EdgeShape* edgeA, const b2Transform& xfA,
-						   const b2PolygonShape* polygonB, const b2Transform& xfB)
-{
-	m_xf = b2MulT(xfA, xfB);
-	
-	m_centroidB = b2Mul(m_xf, polygonB->m_centroid);
-	
-	m_v0 = edgeA->m_vertex0;
-	m_v1 = edgeA->m_vertex1;
-	m_v2 = edgeA->m_vertex2;
-	m_v3 = edgeA->m_vertex3;
-	
-	bool hasVertex0 = edgeA->m_hasVertex0;
-	bool hasVertex3 = edgeA->m_hasVertex3;
-	
-	b2Vec2 edge1 = m_v2 - m_v1;
-	edge1.Normalize();
-	m_normal1.Set(edge1.y, -edge1.x);
-	float offset1 = b2Dot(m_normal1, m_centroidB - m_v1);
-	float offset0 = 0.0f, offset2 = 0.0f;
-	bool convex1 = false, convex2 = false;
-	
-	// Is there a preceding edge?
-	if (hasVertex0)
-	{
-		b2Vec2 edge0 = m_v1 - m_v0;
-		edge0.Normalize();
-		m_normal0.Set(edge0.y, -edge0.x);
-		convex1 = b2Cross(edge0, edge1) >= 0.0f;
-		offset0 = b2Dot(m_normal0, m_centroidB - m_v0);
-	}
-	
-	// Is there a following edge?
-	if (hasVertex3)
-	{
-		b2Vec2 edge2 = m_v3 - m_v2;
-		edge2.Normalize();
-		m_normal2.Set(edge2.y, -edge2.x);
-		convex2 = b2Cross(edge1, edge2) > 0.0f;
-		offset2 = b2Dot(m_normal2, m_centroidB - m_v2);
-	}
-	
-	// Determine front or back collision. Determine collision normal limits.
-	if (hasVertex0 && hasVertex3)
-	{
-		if (convex1 && convex2)
-		{
-			m_front = offset0 >= 0.0f || offset1 >= 0.0f || offset2 >= 0.0f;
-			if (m_front)
-			{
-				m_normal = m_normal1;
-				m_lowerLimit = m_normal0;
-				m_upperLimit = m_normal2;
-			}
-			else
-			{
-				m_normal = -m_normal1;
-				m_lowerLimit = -m_normal1;
-				m_upperLimit = -m_normal1;
-			}
-		}
-		else if (convex1)
-		{
-			m_front = offset0 >= 0.0f || (offset1 >= 0.0f && offset2 >= 0.0f);
-			if (m_front)
-			{
-				m_normal = m_normal1;
-				m_lowerLimit = m_normal0;
-				m_upperLimit = m_normal1;
-			}
-			else
-			{
-				m_normal = -m_normal1;
-				m_lowerLimit = -m_normal2;
-				m_upperLimit = -m_normal1;
-			}
-		}
-		else if (convex2)
-		{
-			m_front = offset2 >= 0.0f || (offset0 >= 0.0f && offset1 >= 0.0f);
-			if (m_front)
-			{
-				m_normal = m_normal1;
-				m_lowerLimit = m_normal1;
-				m_upperLimit = m_normal2;
-			}
-			else
-			{
-				m_normal = -m_normal1;
-				m_lowerLimit = -m_normal1;
-				m_upperLimit = -m_normal0;
-			}
-		}
-		else
-		{
-			m_front = offset0 >= 0.0f && offset1 >= 0.0f && offset2 >= 0.0f;
-			if (m_front)
-			{
-				m_normal = m_normal1;
-				m_lowerLimit = m_normal1;
-				m_upperLimit = m_normal1;
-			}
-			else
-			{
-				m_normal = -m_normal1;
-				m_lowerLimit = -m_normal2;
-				m_upperLimit = -m_normal0;
-			}
-		}
-	}
-	else if (hasVertex0)
-	{
-		if (convex1)
-		{
-			m_front = offset0 >= 0.0f || offset1 >= 0.0f;
-			if (m_front)
-			{
-				m_normal = m_normal1;
-				m_lowerLimit = m_normal0;
-				m_upperLimit = -m_normal1;
-			}
-			else
-			{
-				m_normal = -m_normal1;
-				m_lowerLimit = m_normal1;
-				m_upperLimit = -m_normal1;
-			}
-		}
-		else
-		{
-			m_front = offset0 >= 0.0f && offset1 >= 0.0f;
-			if (m_front)
-			{
-				m_normal = m_normal1;
-				m_lowerLimit = m_normal1;
-				m_upperLimit = -m_normal1;
-			}
-			else
-			{
-				m_normal = -m_normal1;
-				m_lowerLimit = m_normal1;
-				m_upperLimit = -m_normal0;
-			}
-		}
-	}
-	else if (hasVertex3)
-	{
-		if (convex2)
-		{
-			m_front = offset1 >= 0.0f || offset2 >= 0.0f;
-			if (m_front)
-			{
-				m_normal = m_normal1;
-				m_lowerLimit = -m_normal1;
-				m_upperLimit = m_normal2;
-			}
-			else
-			{
-				m_normal = -m_normal1;
-				m_lowerLimit = -m_normal1;
-				m_upperLimit = m_normal1;
-			}
-		}
-		else
-		{
-			m_front = offset1 >= 0.0f && offset2 >= 0.0f;
-			if (m_front)
-			{
-				m_normal = m_normal1;
-				m_lowerLimit = -m_normal1;
-				m_upperLimit = m_normal1;
-			}
-			else
-			{
-				m_normal = -m_normal1;
-				m_lowerLimit = -m_normal2;
-				m_upperLimit = m_normal1;
-			}
-		}		
-	}
-	else
-	{
-		m_front = offset1 >= 0.0f;
-		if (m_front)
-		{
-			m_normal = m_normal1;
-			m_lowerLimit = -m_normal1;
-			m_upperLimit = -m_normal1;
-		}
-		else
-		{
-			m_normal = -m_normal1;
-			m_lowerLimit = m_normal1;
-			m_upperLimit = m_normal1;
-		}
-	}
-	
-	// Get polygonB in frameA
-	m_polygonB.count = polygonB->m_count;
-	for (int32 i = 0; i < polygonB->m_count; ++i)
-	{
-		m_polygonB.vertices[i] = b2Mul(m_xf, polygonB->m_vertices[i]);
-		m_polygonB.normals[i] = b2Mul(m_xf.q, polygonB->m_normals[i]);
-	}
-	
-	m_radius = polygonB->m_radius + edgeA->m_radius;
-	
-	manifold->pointCount = 0;
-	
-	b2EPAxis edgeAxis = ComputeEdgeSeparation();
-	
-	// If no valid normal can be found than this edge should not collide.
-	if (edgeAxis.type == b2EPAxis::e_unknown)
-	{
-		return;
-	}
-	
-	if (edgeAxis.separation > m_radius)
-	{
-		return;
-	}
-	
-	b2EPAxis polygonAxis = ComputePolygonSeparation();
-	if (polygonAxis.type != b2EPAxis::e_unknown && polygonAxis.separation > m_radius)
-	{
-		return;
-	}
-	
-	// Use hysteresis for jitter reduction.
-	const float k_relativeTol = 0.98f;
-	const float k_absoluteTol = 0.001f;
-	
-	b2EPAxis primaryAxis;
-	if (polygonAxis.type == b2EPAxis::e_unknown)
-	{
-		primaryAxis = edgeAxis;
-	}
-	else if (polygonAxis.separation > k_relativeTol * edgeAxis.separation + k_absoluteTol)
-	{
-		primaryAxis = polygonAxis;
-	}
-	else
-	{
-		primaryAxis = edgeAxis;
-	}
-	
-	b2ClipVertex ie[2];
-	b2ReferenceFace rf;
-	if (primaryAxis.type == b2EPAxis::e_edgeA)
-	{
-		manifold->type = b2Manifold::e_faceA;
-		
-		// Search for the polygon normal that is most anti-parallel to the edge normal.
-		int32 bestIndex = 0;
-		float bestValue = b2Dot(m_normal, m_polygonB.normals[0]);
-		for (int32 i = 1; i < m_polygonB.count; ++i)
-		{
-			float value = b2Dot(m_normal, m_polygonB.normals[i]);
-			if (value < bestValue)
-			{
-				bestValue = value;
-				bestIndex = i;
-			}
-		}
-		
-		int32 i1 = bestIndex;
-		int32 i2 = i1 + 1 < m_polygonB.count ? i1 + 1 : 0;
-		
-		ie[0].v = m_polygonB.vertices[i1];
-		ie[0].id.cf.indexA = 0;
-		ie[0].id.cf.indexB = static_cast<uint8>(i1);
-		ie[0].id.cf.typeA = b2ContactFeature::e_face;
-		ie[0].id.cf.typeB = b2ContactFeature::e_vertex;
-		
-		ie[1].v = m_polygonB.vertices[i2];
-		ie[1].id.cf.indexA = 0;
-		ie[1].id.cf.indexB = static_cast<uint8>(i2);
-		ie[1].id.cf.typeA = b2ContactFeature::e_face;
-		ie[1].id.cf.typeB = b2ContactFeature::e_vertex;
-		
-		if (m_front)
-		{
-			rf.i1 = 0;
-			rf.i2 = 1;
-			rf.v1 = m_v1;
-			rf.v2 = m_v2;
-			rf.normal = m_normal1;
-		}
-		else
-		{
-			rf.i1 = 1;
-			rf.i2 = 0;
-			rf.v1 = m_v2;
-			rf.v2 = m_v1;
-			rf.normal = -m_normal1;
-		}		
-	}
-	else
-	{
-		manifold->type = b2Manifold::e_faceB;
-		
-		ie[0].v = m_v1;
-		ie[0].id.cf.indexA = 0;
-		ie[0].id.cf.indexB = static_cast<uint8>(primaryAxis.index);
-		ie[0].id.cf.typeA = b2ContactFeature::e_vertex;
-		ie[0].id.cf.typeB = b2ContactFeature::e_face;
-		
-		ie[1].v = m_v2;
-		ie[1].id.cf.indexA = 0;
-		ie[1].id.cf.indexB = static_cast<uint8>(primaryAxis.index);		
-		ie[1].id.cf.typeA = b2ContactFeature::e_vertex;
-		ie[1].id.cf.typeB = b2ContactFeature::e_face;
-		
-		rf.i1 = primaryAxis.index;
-		rf.i2 = rf.i1 + 1 < m_polygonB.count ? rf.i1 + 1 : 0;
-		rf.v1 = m_polygonB.vertices[rf.i1];
-		rf.v2 = m_polygonB.vertices[rf.i2];
-		rf.normal = m_polygonB.normals[rf.i1];
-	}
-	
-	rf.sideNormal1.Set(rf.normal.y, -rf.normal.x);
-	rf.sideNormal2 = -rf.sideNormal1;
-	rf.sideOffset1 = b2Dot(rf.sideNormal1, rf.v1);
-	rf.sideOffset2 = b2Dot(rf.sideNormal2, rf.v2);
-	
-	// Clip incident edge against extruded edge1 side edges.
-	b2ClipVertex clipPoints1[2];
-	b2ClipVertex clipPoints2[2];
-	int32 np;
-	
-	// Clip to box side 1
-	np = b2ClipSegmentToLine(clipPoints1, ie, rf.sideNormal1, rf.sideOffset1, rf.i1);
-	
-	if (np < b2_maxManifoldPoints)
-	{
-		return;
-	}
-	
-	// Clip to negative box side 1
-	np = b2ClipSegmentToLine(clipPoints2, clipPoints1, rf.sideNormal2, rf.sideOffset2, rf.i2);
-	
-	if (np < b2_maxManifoldPoints)
-	{
-		return;
-	}
-	
-	// Now clipPoints2 contains the clipped points.
-	if (primaryAxis.type == b2EPAxis::e_edgeA)
-	{
-		manifold->localNormal = rf.normal;
-		manifold->localPoint = rf.v1;
-	}
-	else
-	{
-		manifold->localNormal = polygonB->m_normals[rf.i1];
-		manifold->localPoint = polygonB->m_vertices[rf.i1];
-	}
-	
-	int32 pointCount = 0;
-	for (int32 i = 0; i < b2_maxManifoldPoints; ++i)
-	{
-		float separation;
-		
-		separation = b2Dot(rf.normal, clipPoints2[i].v - rf.v1);
-		
-		if (separation <= m_radius)
-		{
-			b2ManifoldPoint* cp = manifold->points + pointCount;
-			
-			if (primaryAxis.type == b2EPAxis::e_edgeA)
-			{
-				cp->localPoint = b2MulT(m_xf, clipPoints2[i].v);
-				cp->id = clipPoints2[i].id;
-			}
-			else
-			{
-				cp->localPoint = clipPoints2[i].v;
-				cp->id.cf.typeA = clipPoints2[i].id.cf.typeB;
-				cp->id.cf.typeB = clipPoints2[i].id.cf.typeA;
-				cp->id.cf.indexA = clipPoints2[i].id.cf.indexB;
-				cp->id.cf.indexB = clipPoints2[i].id.cf.indexA;
-			}
-			
-			++pointCount;
-		}
-	}
-	
-	manifold->pointCount = pointCount;
-}
-
-b2EPAxis b2EPCollider::ComputeEdgeSeparation()
-{
-	b2EPAxis axis;
-	axis.type = b2EPAxis::e_edgeA;
-	axis.index = m_front ? 0 : 1;
-	axis.separation = FLT_MAX;
-	
-	for (int32 i = 0; i < m_polygonB.count; ++i)
-	{
-		float s = b2Dot(m_normal, m_polygonB.vertices[i] - m_v1);
-		if (s < axis.separation)
-		{
-			axis.separation = s;
-		}
-	}
-	
-	return axis;
-}
-
-b2EPAxis b2EPCollider::ComputePolygonSeparation()
-{
-	b2EPAxis axis;
-	axis.type = b2EPAxis::e_unknown;
-	axis.index = -1;
-	axis.separation = -FLT_MAX;
-
-	b2Vec2 perp(-m_normal.y, m_normal.x);
-
-	for (int32 i = 0; i < m_polygonB.count; ++i)
-	{
-		b2Vec2 n = -m_polygonB.normals[i];
-		
-		float s1 = b2Dot(n, m_polygonB.vertices[i] - m_v1);
-		float s2 = b2Dot(n, m_polygonB.vertices[i] - m_v2);
-		float s = b2Min(s1, s2);
-		
-		if (s > m_radius)
-		{
-			// No collision
-			axis.type = b2EPAxis::e_edgeB;
-			axis.index = i;
-			axis.separation = s;
-			return axis;
-		}
-		
-		// Adjacency
-		if (b2Dot(n, perp) >= 0.0f)
-		{
-			if (b2Dot(n - m_upperLimit, m_normal) < -b2_angularSlop)
-			{
-				continue;
-			}
-		}
-		else
-		{
-			if (b2Dot(n - m_lowerLimit, m_normal) < -b2_angularSlop)
-			{
-				continue;
-			}
-		}
-		
-		if (s > axis.separation)
-		{
-			axis.type = b2EPAxis::e_edgeB;
-			axis.index = i;
-			axis.separation = s;
-		}
-	}
-	
-	return axis;
-}
 
 void b2CollideEdgeAndPolygon(	b2Manifold* manifold,
 							 const b2EdgeShape* edgeA, const b2Transform& xfA,

--- a/src/collision/b2_collide_edge.cpp
+++ b/src/collision/b2_collide_edge.cpp
@@ -223,6 +223,13 @@ struct b2EPCollider
 
 		bool hasVertex0 = edgeA->m_hasVertex0;
 		bool hasVertex3 = edgeA->m_hasVertex3;
+		
+		// TODO temp
+		if (hasVertex0 == false || hasVertex3 == false)
+		{
+			hasVertex0 = false;
+			hasVertex3 = false;
+		}
 
 		b2Vec2 edge1 = m_v2 - m_v1;
 		edge1.Normalize();
@@ -520,7 +527,7 @@ struct b2EPCollider
 		const float k_absoluteTol = 0.001f;
 
 		b2EPAxis primaryAxis;
-		if (polygonAxis.separation > k_relativeTol * edgeAxis.separation + k_absoluteTol)
+		if (polygonAxis.separation - m_radius > k_relativeTol * (edgeAxis.separation - m_radius) + k_absoluteTol)
 		{
 			primaryAxis = polygonAxis;
 		}
@@ -529,6 +536,7 @@ struct b2EPCollider
 			primaryAxis = edgeAxis;
 		}
 
+		const float sinTol = 0.1f;
 		if (hasVertex0 && hasVertex3)
 		{
 			bool side1 = b2Dot(primaryAxis.normal, edge1) <= 0.0f;
@@ -540,7 +548,7 @@ struct b2EPCollider
 				{
 					if (convex1)
 					{
-						if (b2Cross(m_normal0, primaryAxis.normal) > 0.0f)
+						if (b2Cross(m_normal0, primaryAxis.normal) > sinTol)
 						{
 							// Skip region
 							return;
@@ -556,7 +564,7 @@ struct b2EPCollider
 				{
 					if (convex2)
 					{
-						if (b2Cross(primaryAxis.normal, m_normal2) > 0.0f)
+						if (b2Cross(primaryAxis.normal, m_normal2) > sinTol)
 						{
 							// Skip region
 							return;
@@ -576,7 +584,7 @@ struct b2EPCollider
 				{
 					if (convex1 == false)
 					{
-						if (b2Cross(primaryAxis.normal, -m_normal0) > 0.0f)
+						if (b2Cross(primaryAxis.normal, -m_normal0) > sinTol)
 						{
 							// Skip region
 							return;
@@ -592,7 +600,7 @@ struct b2EPCollider
 				{
 					if (convex2 == false)
 					{
-						if (b2Cross(-m_normal2, primaryAxis.normal) > 0.0f)
+						if (b2Cross(-m_normal2, primaryAxis.normal) > sinTol)
 						{
 							// Skip region
 							return;
@@ -641,6 +649,7 @@ struct b2EPCollider
 			clipPoints[1].id.cf.typeA = b2ContactFeature::e_face;
 			clipPoints[1].id.cf.typeB = b2ContactFeature::e_vertex;
 
+			// TODO does order matter?
 			if (m_front)
 			{
 				ref.i1 = 1;
@@ -648,8 +657,8 @@ struct b2EPCollider
 				ref.v1 = m_v2;
 				ref.v2 = m_v1;
 				ref.normal = primaryAxis.normal;
-				ref.sideNormal1.Set(ref.normal.y, -ref.normal.x);
-				ref.sideNormal2 = -ref.sideNormal1;
+				ref.sideNormal1 = edge1;
+				ref.sideNormal2 = -edge1;
 			}
 			else
 			{
@@ -658,8 +667,8 @@ struct b2EPCollider
 				ref.v1 = m_v1;
 				ref.v2 = m_v2;
 				ref.normal = primaryAxis.normal;
-				ref.sideNormal1.Set(ref.normal.y, -ref.normal.x);
-				ref.sideNormal2 = -ref.sideNormal1;
+				ref.sideNormal1 = -edge1;
+				ref.sideNormal2 = edge1;
 			}		
 		}
 		else
@@ -683,6 +692,8 @@ struct b2EPCollider
 			ref.v1 = m_polygonB.vertices[ref.i1];
 			ref.v2 = m_polygonB.vertices[ref.i2];
 			ref.normal = m_polygonB.normals[ref.i1];
+
+			// CCW winding
 			ref.sideNormal1.Set(ref.normal.y, -ref.normal.x);
 			ref.sideNormal2 = -ref.sideNormal1;
 		}

--- a/src/collision/b2_collision.cpp
+++ b/src/collision/b2_collision.cpp
@@ -206,32 +206,34 @@ int32 b2ClipSegmentToLine(b2ClipVertex vOut[2], const b2ClipVertex vIn[2],
 						const b2Vec2& normal, float offset, int32 vertexIndexA)
 {
 	// Start with no output points
-	int32 numOut = 0;
+	int32 count = 0;
 
 	// Calculate the distance of end points to the line
 	float distance0 = b2Dot(normal, vIn[0].v) - offset;
 	float distance1 = b2Dot(normal, vIn[1].v) - offset;
 
 	// If the points are behind the plane
-	if (distance0 <= 0.0f) vOut[numOut++] = vIn[0];
-	if (distance1 <= 0.0f) vOut[numOut++] = vIn[1];
+	if (distance0 <= 0.0f) vOut[count++] = vIn[0];
+	if (distance1 <= 0.0f) vOut[count++] = vIn[1];
 
 	// If the points are on different sides of the plane
 	if (distance0 * distance1 < 0.0f)
 	{
 		// Find intersection point of edge and plane
 		float interp = distance0 / (distance0 - distance1);
-		vOut[numOut].v = vIn[0].v + interp * (vIn[1].v - vIn[0].v);
+		vOut[count].v = vIn[0].v + interp * (vIn[1].v - vIn[0].v);
 
 		// VertexA is hitting edgeB.
-		vOut[numOut].id.cf.indexA = static_cast<uint8>(vertexIndexA);
-		vOut[numOut].id.cf.indexB = vIn[0].id.cf.indexB;
-		vOut[numOut].id.cf.typeA = b2ContactFeature::e_vertex;
-		vOut[numOut].id.cf.typeB = b2ContactFeature::e_face;
-		++numOut;
+		vOut[count].id.cf.indexA = static_cast<uint8>(vertexIndexA);
+		vOut[count].id.cf.indexB = vIn[0].id.cf.indexB;
+		vOut[count].id.cf.typeA = b2ContactFeature::e_vertex;
+		vOut[count].id.cf.typeB = b2ContactFeature::e_face;
+		++count;
+
+		b2Assert(count == 2);
 	}
 
-	return numOut;
+	return count;
 }
 
 bool b2TestOverlap(	const b2Shape* shapeA, int32 indexA,

--- a/src/dynamics/b2_fixture.cpp
+++ b/src/dynamics/b2_fixture.cpp
@@ -261,8 +261,7 @@ void b2Fixture::Dump(int32 bodyIndex)
 			b2Dump("    shape.m_vertex1.Set(%.15lef, %.15lef);\n", s->m_vertex1.x, s->m_vertex1.y);
 			b2Dump("    shape.m_vertex2.Set(%.15lef, %.15lef);\n", s->m_vertex2.x, s->m_vertex2.y);
 			b2Dump("    shape.m_vertex3.Set(%.15lef, %.15lef);\n", s->m_vertex3.x, s->m_vertex3.y);
-			b2Dump("    shape.m_hasVertex0 = bool(%d);\n", s->m_hasVertex0);
-			b2Dump("    shape.m_hasVertex3 = bool(%d);\n", s->m_hasVertex3);
+			b2Dump("    shape.m_oneSided = bool(%d);\n", s->m_oneSided);
 		}
 		break;
 
@@ -291,8 +290,6 @@ void b2Fixture::Dump(int32 bodyIndex)
 			b2Dump("    shape.CreateChain(vs, %d);\n", s->m_count);
 			b2Dump("    shape.m_prevVertex.Set(%.15lef, %.15lef);\n", s->m_prevVertex.x, s->m_prevVertex.y);
 			b2Dump("    shape.m_nextVertex.Set(%.15lef, %.15lef);\n", s->m_nextVertex.x, s->m_nextVertex.y);
-			b2Dump("    shape.m_hasPrevVertex = bool(%d);\n", s->m_hasPrevVertex);
-			b2Dump("    shape.m_hasNextVertex = bool(%d);\n", s->m_hasNextVertex);
 		}
 		break;
 

--- a/src/dynamics/b2_world.cpp
+++ b/src/dynamics/b2_world.cpp
@@ -1058,7 +1058,9 @@ void b2World::DrawShape(b2Fixture* fixture, const b2Transform& xf, const b2Color
 			b2Vec2 v1 = b2Mul(xf, edge->m_vertex1);
 			b2Vec2 v2 = b2Mul(xf, edge->m_vertex2);
 			m_debugDraw->DrawSegment(v1, v2, color);
-		}
+			m_debugDraw->DrawPoint(v1, 4.0f, color);
+			m_debugDraw->DrawPoint(v2, 4.0f, color);
+	}
 		break;
 
 	case b2Shape::e_chain:

--- a/src/dynamics/b2_world.cpp
+++ b/src/dynamics/b2_world.cpp
@@ -1038,8 +1038,6 @@ void b2World::RayCast(b2RayCastCallback* callback, const b2Vec2& point1, const b
 
 void b2World::DrawShape(b2Fixture* fixture, const b2Transform& xf, const b2Color& color)
 {
-	b2Color red(1.0f, 0.0f, 0.0f);
-
 	switch (fixture->GetType())
 	{
 	case b2Shape::e_circle:
@@ -1061,22 +1059,10 @@ void b2World::DrawShape(b2Fixture* fixture, const b2Transform& xf, const b2Color
 			b2Vec2 v2 = b2Mul(xf, edge->m_vertex2);
 			m_debugDraw->DrawSegment(v1, v2, color);
 
-			if (edge->m_hasVertex0)
+			if (edge->m_oneSided == false)
 			{
 				m_debugDraw->DrawPoint(v1, 4.0f, color);
-			}
-			else
-			{
-				m_debugDraw->DrawPoint(v1, 4.0f, red);
-			}
-
-			if (edge->m_hasVertex3)
-			{
 				m_debugDraw->DrawPoint(v2, 4.0f, color);
-			}
-			else
-			{
-				m_debugDraw->DrawPoint(v2, 4.0f, red);
 			}
 		}
 		break;
@@ -1087,31 +1073,12 @@ void b2World::DrawShape(b2Fixture* fixture, const b2Transform& xf, const b2Color
 			int32 count = chain->m_count;
 			const b2Vec2* vertices = chain->m_vertices;
 
-			b2Color ghostColor(0.75f * color.r, 0.75f * color.g, 0.75f * color.b, color.a);
-
 			b2Vec2 v1 = b2Mul(xf, vertices[0]);
-			m_debugDraw->DrawPoint(v1, 4.0f, color);
-
-			if (chain->m_hasPrevVertex)
-			{
-				b2Vec2 vp = b2Mul(xf, chain->m_prevVertex);
-				m_debugDraw->DrawSegment(vp, v1, ghostColor);
-				m_debugDraw->DrawCircle(vp, 0.1f, ghostColor);
-			}
-
 			for (int32 i = 1; i < count; ++i)
 			{
 				b2Vec2 v2 = b2Mul(xf, vertices[i]);
 				m_debugDraw->DrawSegment(v1, v2, color);
-				m_debugDraw->DrawPoint(v2, 4.0f, color);
 				v1 = v2;
-			}
-
-			if (chain->m_hasNextVertex)
-			{
-				b2Vec2 vn = b2Mul(xf, chain->m_nextVertex);
-				m_debugDraw->DrawSegment(v1, vn, ghostColor);
-				m_debugDraw->DrawCircle(vn, 0.1f, ghostColor);
 			}
 		}
 		break;
@@ -1131,9 +1098,9 @@ void b2World::DrawShape(b2Fixture* fixture, const b2Transform& xf, const b2Color
 			m_debugDraw->DrawSolidPolygon(vertices, vertexCount, color);
 		}
 		break;
-            
-    default:
-        break;
+
+	default:
+	break;
 	}
 }
 

--- a/src/dynamics/b2_world.cpp
+++ b/src/dynamics/b2_world.cpp
@@ -1038,6 +1038,8 @@ void b2World::RayCast(b2RayCastCallback* callback, const b2Vec2& point1, const b
 
 void b2World::DrawShape(b2Fixture* fixture, const b2Transform& xf, const b2Color& color)
 {
+	b2Color red(1.0f, 0.0f, 0.0f);
+
 	switch (fixture->GetType())
 	{
 	case b2Shape::e_circle:
@@ -1058,9 +1060,25 @@ void b2World::DrawShape(b2Fixture* fixture, const b2Transform& xf, const b2Color
 			b2Vec2 v1 = b2Mul(xf, edge->m_vertex1);
 			b2Vec2 v2 = b2Mul(xf, edge->m_vertex2);
 			m_debugDraw->DrawSegment(v1, v2, color);
-			m_debugDraw->DrawPoint(v1, 4.0f, color);
-			m_debugDraw->DrawPoint(v2, 4.0f, color);
-	}
+
+			if (edge->m_hasVertex0)
+			{
+				m_debugDraw->DrawPoint(v1, 4.0f, color);
+			}
+			else
+			{
+				m_debugDraw->DrawPoint(v1, 4.0f, red);
+			}
+
+			if (edge->m_hasVertex3)
+			{
+				m_debugDraw->DrawPoint(v2, 4.0f, color);
+			}
+			else
+			{
+				m_debugDraw->DrawPoint(v2, 4.0f, red);
+			}
+		}
 		break;
 
 	case b2Shape::e_chain:

--- a/testbed/main.cpp
+++ b/testbed/main.cpp
@@ -512,10 +512,16 @@ int main(int, char**)
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
 	sprintf(buffer, "Box2D Testbed Version %d.%d.%d", b2_version.major, b2_version.minor, b2_version.revision);
-	g_mainWindow = glfwCreateWindow(g_camera.m_width, g_camera.m_height, buffer, NULL, NULL);
-	
-	// Full screen for capture
-	// g_mainWindow = glfwCreateWindow(1920, 1080, buffer, glfwGetPrimaryMonitor(), NULL);
+
+	bool fullscreen = false;
+	if (fullscreen)
+	{
+		g_mainWindow = glfwCreateWindow(1920, 1080, buffer, glfwGetPrimaryMonitor(), NULL);
+	}
+	else
+	{
+		g_mainWindow = glfwCreateWindow(g_camera.m_width, g_camera.m_height, buffer, NULL, NULL);
+	}
 
 	if (g_mainWindow == NULL)
 	{

--- a/testbed/tests/add_pair.cpp
+++ b/testbed/tests/add_pair.cpp
@@ -58,7 +58,7 @@ public:
 			bd.bullet = true;
 			b2Body* body = m_world->CreateBody(&bd);
 			body->CreateFixture(&shape, 1.0f);
-			body->SetLinearVelocity(b2Vec2(150.0f, 0.0f));
+			body->SetLinearVelocity(b2Vec2(10.0f, 0.0f));
 		}
 	}
 

--- a/testbed/tests/apply_force.cpp
+++ b/testbed/tests/apply_force.cpp
@@ -48,19 +48,19 @@ public:
 			sd.restitution = k_restitution;
 
 			// Left vertical
-			shape.Set(b2Vec2(-20.0f, -20.0f), b2Vec2(-20.0f, 20.0f));
+			shape.SetTwoSided(b2Vec2(-20.0f, -20.0f), b2Vec2(-20.0f, 20.0f));
 			ground->CreateFixture(&sd);
 
 			// Right vertical
-			shape.Set(b2Vec2(20.0f, -20.0f), b2Vec2(20.0f, 20.0f));
+			shape.SetTwoSided(b2Vec2(20.0f, -20.0f), b2Vec2(20.0f, 20.0f));
 			ground->CreateFixture(&sd);
 
 			// Top horizontal
-			shape.Set(b2Vec2(-20.0f, 20.0f), b2Vec2(20.0f, 20.0f));
+			shape.SetTwoSided(b2Vec2(-20.0f, 20.0f), b2Vec2(20.0f, 20.0f));
 			ground->CreateFixture(&sd);
 
 			// Bottom horizontal
-			shape.Set(b2Vec2(-20.0f, -20.0f), b2Vec2(20.0f, -20.0f));
+			shape.SetTwoSided(b2Vec2(-20.0f, -20.0f), b2Vec2(20.0f, -20.0f));
 			ground->CreateFixture(&sd);
 		}
 

--- a/testbed/tests/body_types.cpp
+++ b/testbed/tests/body_types.cpp
@@ -33,7 +33,7 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-20.0f, 0.0f), b2Vec2(20.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-20.0f, 0.0f), b2Vec2(20.0f, 0.0f));
 
 			b2FixtureDef fd;
 			fd.shape = &shape;

--- a/testbed/tests/box_stack.cpp
+++ b/testbed/tests/box_stack.cpp
@@ -43,10 +43,10 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 
-			shape.Set(b2Vec2(20.0f, 0.0f), b2Vec2(20.0f, 20.0f));
+			shape.SetTwoSided(b2Vec2(20.0f, 0.0f), b2Vec2(20.0f, 20.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/breakable.cpp
+++ b/testbed/tests/breakable.cpp
@@ -40,7 +40,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/bridge.cpp
+++ b/testbed/tests/bridge.cpp
@@ -39,7 +39,7 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/bullet_test.cpp
+++ b/testbed/tests/bullet_test.cpp
@@ -35,7 +35,7 @@ public:
 
 			b2EdgeShape edge;
 
-			edge.Set(b2Vec2(-10.0f, 0.0f), b2Vec2(10.0f, 0.0f));
+			edge.SetTwoSided(b2Vec2(-10.0f, 0.0f), b2Vec2(10.0f, 0.0f));
 			body->CreateFixture(&edge, 0.0f);
 
 			b2PolygonShape shape;

--- a/testbed/tests/cantilever.cpp
+++ b/testbed/tests/cantilever.cpp
@@ -43,7 +43,7 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/car.cpp
+++ b/testbed/tests/car.cpp
@@ -42,7 +42,7 @@ public:
 			fd.density = 0.0f;
 			fd.friction = 0.6f;
 
-			shape.Set(b2Vec2(-20.0f, 0.0f), b2Vec2(20.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-20.0f, 0.0f), b2Vec2(20.0f, 0.0f));
 			ground->CreateFixture(&fd);
 
 			float hs[10] = {0.25f, 1.0f, 4.0f, 0.0f, 0.0f, -1.0f, -2.0f, -2.0f, -1.25f, 0.0f};
@@ -52,7 +52,7 @@ public:
 			for (int32 i = 0; i < 10; ++i)
 			{
 				float y2 = hs[i];
-				shape.Set(b2Vec2(x, y1), b2Vec2(x + dx, y2));
+				shape.SetTwoSided(b2Vec2(x, y1), b2Vec2(x + dx, y2));
 				ground->CreateFixture(&fd);
 				y1 = y2;
 				x += dx;
@@ -61,29 +61,29 @@ public:
 			for (int32 i = 0; i < 10; ++i)
 			{
 				float y2 = hs[i];
-				shape.Set(b2Vec2(x, y1), b2Vec2(x + dx, y2));
+				shape.SetTwoSided(b2Vec2(x, y1), b2Vec2(x + dx, y2));
 				ground->CreateFixture(&fd);
 				y1 = y2;
 				x += dx;
 			}
 
-			shape.Set(b2Vec2(x, 0.0f), b2Vec2(x + 40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(x, 0.0f), b2Vec2(x + 40.0f, 0.0f));
 			ground->CreateFixture(&fd);
 
 			x += 80.0f;
-			shape.Set(b2Vec2(x, 0.0f), b2Vec2(x + 40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(x, 0.0f), b2Vec2(x + 40.0f, 0.0f));
 			ground->CreateFixture(&fd);
 
 			x += 40.0f;
-			shape.Set(b2Vec2(x, 0.0f), b2Vec2(x + 10.0f, 5.0f));
+			shape.SetTwoSided(b2Vec2(x, 0.0f), b2Vec2(x + 10.0f, 5.0f));
 			ground->CreateFixture(&fd);
 
 			x += 20.0f;
-			shape.Set(b2Vec2(x, 0.0f), b2Vec2(x + 40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(x, 0.0f), b2Vec2(x + 40.0f, 0.0f));
 			ground->CreateFixture(&fd);
 
 			x += 40.0f;
-			shape.Set(b2Vec2(x, 0.0f), b2Vec2(x, 20.0f));
+			shape.SetTwoSided(b2Vec2(x, 0.0f), b2Vec2(x, 20.0f));
 			ground->CreateFixture(&fd);
 		}
 

--- a/testbed/tests/chain.cpp
+++ b/testbed/tests/chain.cpp
@@ -35,7 +35,7 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/chain_problem.cpp
+++ b/testbed/tests/chain_problem.cpp
@@ -28,86 +28,48 @@ public:
 
     ChainProblem()
     {
-        //dump
         {
-            b2Vec2 g(0.000000000000000e+00f, -1.000000000000000e+01f);
+            b2Vec2 g(0.0f, -10.0f);
             m_world->SetGravity(g);
             b2Body** bodies = (b2Body**)b2Alloc(2 * sizeof(b2Body*));
             b2Joint** joints = (b2Joint**)b2Alloc(0 * sizeof(b2Joint*));
             {
                 b2BodyDef bd;
                 bd.type = b2BodyType(0);
-                bd.position.Set(0.000000000000000e+00f, 0.000000000000000e+00f);
-                bd.angle = 0.000000000000000e+00f;
-                bd.linearVelocity.Set(0.000000000000000e+00f, 0.000000000000000e+00f);
-                bd.angularVelocity = 0.000000000000000e+00f;
-                bd.linearDamping = 0.000000000000000e+00f;
-                bd.angularDamping = 0.000000000000000e+00f;
-                bd.allowSleep = bool(4);
-                bd.awake = bool(2);
-                bd.fixedRotation = bool(0);
-                bd.bullet = bool(0);
-                bd.enabled = bool(32);
-                bd.gravityScale = 1.000000000000000e+00f;
                 bodies[0] = m_world->CreateBody(&bd);
 
                 {
                     b2FixtureDef fd;
-                    fd.friction = 2.000000029802322e-01f;
-                    fd.restitution = 0.000000000000000e+00f;
-                    fd.density = 0.000000000000000e+00f;
-                    fd.isSensor = bool(0);
-                    fd.filter.categoryBits = uint16(1);
-                    fd.filter.maskBits = uint16(65535);
-                    fd.filter.groupIndex = int16(0);
-                    b2ChainShape shape;
-                    b2Vec2 vs[3];
-                    vs[0].Set(0.000000000000000e+00f, 1.000000000000000e+00f);
-                    vs[1].Set(0.000000000000000e+00f, 0.000000000000000e+00f);
-                    vs[2].Set(4.000000000000000e+00f, 0.000000000000000e+00f);
-                    shape.CreateChain(vs, 3);
-                    shape.m_prevVertex.Set(4.719737010713663e-34f, 8.266340761211261e-34f);
-                    shape.m_nextVertex.Set(1.401298464324817e-45f, 8.266340761211261e-34f);
-                    shape.m_hasPrevVertex = bool(0);
-                    shape.m_hasNextVertex = bool(0);
 
-                    fd.shape = &shape;
+                    b2Vec2 v1(0.0f, 1.0f);
+                    b2Vec2 v2(0.0f, 0.0f);
+                    b2Vec2 v3(4.0f, 0.0f);
 
-                    bodies[0]->CreateFixture(&fd);
+                    b2EdgeShape shape;
+                    shape.SetTwoSided(v1, v2);
+                    bodies[0]->CreateFixture(&shape, 0.0f);
+
+                    shape.SetTwoSided(v2, v3);
+                    bodies[0]->CreateFixture(&shape, 0.0f);
                 }
             }
             {
                 b2BodyDef bd;
                 bd.type = b2BodyType(2);
-                bd.position.Set(6.033980250358582e-01f, 3.028350114822388e+00f);
-                bd.angle = 0.000000000000000e+00f;
-                bd.linearVelocity.Set(0.000000000000000e+00f, 0.000000000000000e+00f);
-                bd.angularVelocity = 0.000000000000000e+00f;
-                bd.linearDamping = 0.000000000000000e+00f;
-                bd.angularDamping = 0.000000000000000e+00f;
-                bd.allowSleep = bool(4);
-                bd.awake = bool(2);
-                bd.fixedRotation = bool(0);
-                bd.bullet = bool(1);
-                bd.enabled = bool(32);
-                bd.gravityScale = 1.000000000000000e+00f;
+                //bd.position.Set(6.033980250358582e-01f, 3.028350114822388e+00f);
+                bd.position.Set(1.0f, 3.0f);
                 bodies[1] = m_world->CreateBody(&bd);
 
                 {
                     b2FixtureDef fd;
-                    fd.friction = 2.000000029802322e-01f;
-                    fd.restitution = 0.000000000000000e+00f;
-                    fd.density = 1.000000000000000e+01f;
-                    fd.isSensor = bool(0);
-                    fd.filter.categoryBits = uint16(1);
-                    fd.filter.maskBits = uint16(65535);
-                    fd.filter.groupIndex = int16(0);
+                    fd.friction = 0.2f;
+                    fd.density = 10.0f;
                     b2PolygonShape shape;
                     b2Vec2 vs[8];
-                    vs[0].Set(5.000000000000000e-01f, -3.000000000000000e+00f);
-                    vs[1].Set(5.000000000000000e-01f, 3.000000000000000e+00f);
-                    vs[2].Set(-5.000000000000000e-01f, 3.000000000000000e+00f);
-                    vs[3].Set(-5.000000000000000e-01f, -3.000000000000000e+00f);
+                    vs[0].Set(0.5f, -3.0f);
+                    vs[1].Set(0.5f, 3.0f);
+                    vs[2].Set(-0.5f, 3.0f);
+                    vs[3].Set(-0.5f, -3.0f);
                     shape.Set(vs, 4);
 
                     fd.shape = &shape;

--- a/testbed/tests/character_collision.cpp
+++ b/testbed/tests/character_collision.cpp
@@ -36,7 +36,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-20.0f, 0.0f), b2Vec2(20.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-20.0f, 0.0f), b2Vec2(20.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 
@@ -48,11 +48,11 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-8.0f, 1.0f), b2Vec2(-6.0f, 1.0f));
+			shape.SetTwoSided(b2Vec2(-8.0f, 1.0f), b2Vec2(-6.0f, 1.0f));
 			ground->CreateFixture(&shape, 0.0f);
-			shape.Set(b2Vec2(-6.0f, 1.0f), b2Vec2(-4.0f, 1.0f));
+			shape.SetTwoSided(b2Vec2(-6.0f, 1.0f), b2Vec2(-4.0f, 1.0f));
 			ground->CreateFixture(&shape, 0.0f);
-			shape.Set(b2Vec2(-4.0f, 1.0f), b2Vec2(-2.0f, 1.0f));
+			shape.SetTwoSided(b2Vec2(-4.0f, 1.0f), b2Vec2(-2.0f, 1.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 
@@ -68,7 +68,7 @@ public:
 			vs[2].Set(7.0f, 8.0f);
 			vs[3].Set(8.0f, 7.0f);
 			b2ChainShape shape;
-			shape.CreateChain(vs, 4);
+			shape.CreateLoop(vs, 4);
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/circle_stack.cpp
+++ b/testbed/tests/circle_stack.cpp
@@ -38,7 +38,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/collision_filtering.cpp
+++ b/testbed/tests/collision_filtering.cpp
@@ -47,7 +47,7 @@ public:
 		// Ground body
 		{
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 
 			b2FixtureDef sd;
 			sd.shape = &shape;

--- a/testbed/tests/collision_processing.cpp
+++ b/testbed/tests/collision_processing.cpp
@@ -34,7 +34,7 @@ public:
 		// Ground body
 		{
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-50.0f, 0.0f), b2Vec2(50.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-50.0f, 0.0f), b2Vec2(50.0f, 0.0f));
 
 			b2FixtureDef sd;
 			sd.shape = &shape;;

--- a/testbed/tests/compound_shapes.cpp
+++ b/testbed/tests/compound_shapes.cpp
@@ -34,7 +34,7 @@ public:
 			b2Body* body = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(50.0f, 0.0f), b2Vec2(-50.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(50.0f, 0.0f), b2Vec2(-50.0f, 0.0f));
 
 			body->CreateFixture(&shape, 0.0f);
 		}

--- a/testbed/tests/confined.cpp
+++ b/testbed/tests/confined.cpp
@@ -41,19 +41,19 @@ public:
 			b2EdgeShape shape;
 
 			// Floor
-			shape.Set(b2Vec2(-10.0f, 0.0f), b2Vec2(10.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-10.0f, 0.0f), b2Vec2(10.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 
 			// Left wall
-			shape.Set(b2Vec2(-10.0f, 0.0f), b2Vec2(-10.0f, 20.0f));
+			shape.SetTwoSided(b2Vec2(-10.0f, 0.0f), b2Vec2(-10.0f, 20.0f));
 			ground->CreateFixture(&shape, 0.0f);
 
 			// Right wall
-			shape.Set(b2Vec2(10.0f, 0.0f), b2Vec2(10.0f, 20.0f));
+			shape.SetTwoSided(b2Vec2(10.0f, 0.0f), b2Vec2(10.0f, 20.0f));
 			ground->CreateFixture(&shape, 0.0f);
 
 			// Roof
-			shape.Set(b2Vec2(-10.0f, 20.0f), b2Vec2(10.0f, 20.0f));
+			shape.SetTwoSided(b2Vec2(-10.0f, 20.0f), b2Vec2(10.0f, 20.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/continuous_test.cpp
+++ b/testbed/tests/continuous_test.cpp
@@ -35,7 +35,7 @@ public:
 
 			b2EdgeShape edge;
 
-			edge.Set(b2Vec2(-10.0f, 0.0f), b2Vec2(10.0f, 0.0f));
+			edge.SetTwoSided(b2Vec2(-10.0f, 0.0f), b2Vec2(10.0f, 0.0f));
 			body->CreateFixture(&edge, 0.0f);
 
 			b2PolygonShape shape;

--- a/testbed/tests/conveyor_belt.cpp
+++ b/testbed/tests/conveyor_belt.cpp
@@ -34,7 +34,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-20.0f, 0.0f), b2Vec2(20.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-20.0f, 0.0f), b2Vec2(20.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/distance_joint.cpp
+++ b/testbed/tests/distance_joint.cpp
@@ -34,7 +34,7 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/dominos.cpp
+++ b/testbed/tests/dominos.cpp
@@ -31,7 +31,7 @@ public:
 		b2Body* b1;
 		{
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 
 			b2BodyDef bd;
 			b1 = m_world->CreateBody(&bd);

--- a/testbed/tests/edge_shapes.cpp
+++ b/testbed/tests/edge_shapes.cpp
@@ -70,7 +70,7 @@ public:
 				float y2 = 2.0f * cosf(x2 / 10.0f * b2_pi);
 
 				b2EdgeShape shape;
-				shape.Set(b2Vec2(x1, y1), b2Vec2(x2, y2));
+				shape.SetTwoSided(b2Vec2(x1, y1), b2Vec2(x2, y2));
 				ground->CreateFixture(&shape, 0.0f);
 
 				x1 = x2;

--- a/testbed/tests/edge_test.cpp
+++ b/testbed/tests/edge_test.cpp
@@ -76,6 +76,7 @@ public:
 			ground->CreateFixture(&shape, 0.0f);
 		}
 
+#if 0
 		{
 			b2BodyDef bd;
 			bd.type = b2_dynamicBody;
@@ -88,6 +89,7 @@ public:
 
 			body->CreateFixture(&shape, 1.0f);
 		}
+#endif
 
 		{
 			b2BodyDef bd;
@@ -97,7 +99,7 @@ public:
 			b2Body* body = m_world->CreateBody(&bd);
 
 			b2PolygonShape shape;
-			shape.SetAsBox(0.5f, 0.5f);
+			shape.SetAsBox(0.5f, 0.25f);
 
 			body->CreateFixture(&shape, 1.0f);
 		}

--- a/testbed/tests/edge_test.cpp
+++ b/testbed/tests/edge_test.cpp
@@ -29,20 +29,37 @@ public:
 
 	EdgeTest()
 	{
+		b2Vec2 vertices[10] =
 		{
+			{10.0f, -4.0f},
+			{10.0f, 0.0f},
+			{6.0f, 0.0f},
+			{4.0f, 2.0f},
+			{2.0f, 0.0f},
+			{-2.0f, 0.0f},
+			{-6.0f, 0.0f},
+			{-8.0f, -3.0f},
+			{-10.0f, 0.0f},
+			{-10.0f, -4.0f}
+		};
+
+		m_offset1.Set(0.0f, 8.0f);
+		m_offset2.Set(0.0f, 16.0f);
+
+		{
+			b2Vec2 v1 = vertices[0] + m_offset1;
+			b2Vec2 v2 = vertices[1] + m_offset1;
+			b2Vec2 v3 = vertices[2] + m_offset1;
+			b2Vec2 v4 = vertices[3] + m_offset1;
+			b2Vec2 v5 = vertices[4] + m_offset1;
+			b2Vec2 v6 = vertices[5] + m_offset1;
+			b2Vec2 v7 = vertices[6] + m_offset1;
+			b2Vec2 v8 = vertices[7] + m_offset1;
+			b2Vec2 v9 = vertices[8] + m_offset1;
+			b2Vec2 v10 = vertices[9] + m_offset1;
+
 			b2BodyDef bd;
 			b2Body* ground = m_world->CreateBody(&bd);
-
-			b2Vec2 v1(14.0f, -4.0f);
-			b2Vec2 v2(14.0f, 0.0f);
-			b2Vec2 v3(10.0f, 0.0f);
-			b2Vec2 v4(7.0f, 2.0f);
-			b2Vec2 v5(4.0f, 0.0f);
-			b2Vec2 v6(0.0f, 0.0f);
-			b2Vec2 v7(-4.0f, 0.0f);
-			b2Vec2 v8(-7.0f, -2.0f);
-			b2Vec2 v9(-10.0f, 0.0f);
-			b2Vec2 v10(-10.0f, -4.0f);
 
 			b2EdgeShape shape;
 
@@ -78,20 +95,19 @@ public:
 		}
 
 		{
+			b2Vec2 v1 = vertices[0] + m_offset2;
+			b2Vec2 v2 = vertices[1] + m_offset2;
+			b2Vec2 v3 = vertices[2] + m_offset2;
+			b2Vec2 v4 = vertices[3] + m_offset2;
+			b2Vec2 v5 = vertices[4] + m_offset2;
+			b2Vec2 v6 = vertices[5] + m_offset2;
+			b2Vec2 v7 = vertices[6] + m_offset2;
+			b2Vec2 v8 = vertices[7] + m_offset2;
+			b2Vec2 v9 = vertices[8] + m_offset2;
+			b2Vec2 v10 = vertices[9] + m_offset2;
+
 			b2BodyDef bd;
 			b2Body* ground = m_world->CreateBody(&bd);
-
-			float y = 8.0f;
-			b2Vec2 v1(14.0f, -4.0f + y);
-			b2Vec2 v2(14.0f, 0.0f + y);
-			b2Vec2 v3(10.0f, 0.0f + y);
-			b2Vec2 v4(7.0f, 2.0f + y);
-			b2Vec2 v5(4.0f, 0.0f + y);
-			b2Vec2 v6(0.0f, 0.0f + y);
-			b2Vec2 v7(-4.0f, 0.0f + y);
-			b2Vec2 v8(-7.0f, -2.0f + y);
-			b2Vec2 v9(-10.0f, 0.0f + y);
-			b2Vec2 v10(-10.0f, -4.0f + y);
 
 			b2EdgeShape shape;
 
@@ -149,7 +165,7 @@ public:
 		{
 			b2BodyDef bd;
 			bd.type = b2_dynamicBody;
-			bd.position.Set(12.0f, 2.6f);
+			bd.position = b2Vec2(8.0f, 2.6f) + m_offset1;
 			bd.allowSleep = false;
 			m_body1 = m_world->CreateBody(&bd);
 
@@ -162,7 +178,7 @@ public:
 		{
 			b2BodyDef bd;
 			bd.type = b2_dynamicBody;
-			bd.position.Set(12.0f, 2.6f + 8.0f);
+			bd.position = b2Vec2(8.0f, 2.6f) + m_offset2;
 			bd.allowSleep = false;
 			m_body2 = m_world->CreateBody(&bd);
 
@@ -190,7 +206,7 @@ public:
 		{
 			b2BodyDef bd;
 			bd.type = b2_dynamicBody;
-			bd.position.Set(-0.5f, 0.6f);
+			bd.position = b2Vec2(-0.5f, 0.6f) + m_offset1;
 			bd.allowSleep = false;
 			m_body1 = m_world->CreateBody(&bd);
 
@@ -203,7 +219,7 @@ public:
 		{
 			b2BodyDef bd;
 			bd.type = b2_dynamicBody;
-			bd.position.Set(-0.5f, 0.6f + 8.0f);
+			bd.position = b2Vec2(-0.5f, 0.6f) + m_offset2;
 			bd.allowSleep = false;
 			m_body2 = m_world->CreateBody(&bd);
 
@@ -257,6 +273,7 @@ public:
 		return new EdgeTest;
 	}
 
+	b2Vec2 m_offset1, m_offset2;
 	b2Body* m_body1;
 	b2Body* m_body2;
 	bool m_boxes;

--- a/testbed/tests/edge_test.cpp
+++ b/testbed/tests/edge_test.cpp
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 #include "test.h"
+#include "imgui/imgui.h"
 
 class EdgeTest : public Test
 {
@@ -32,83 +33,233 @@ public:
 			b2BodyDef bd;
 			b2Body* ground = m_world->CreateBody(&bd);
 
-			b2Vec2 v1(-10.0f, 0.0f), v2(-7.0f, -2.0f), v3(-4.0f, 0.0f);
-			b2Vec2 v4(0.0f, 0.0f), v5(4.0f, 0.0f), v6(7.0f, 2.0f), v7(10.0f, 0.0f);
+			b2Vec2 v1(14.0f, -4.0f);
+			b2Vec2 v2(14.0f, 0.0f);
+			b2Vec2 v3(10.0f, 0.0f);
+			b2Vec2 v4(7.0f, 2.0f);
+			b2Vec2 v5(4.0f, 0.0f);
+			b2Vec2 v6(0.0f, 0.0f);
+			b2Vec2 v7(-4.0f, 0.0f);
+			b2Vec2 v8(-7.0f, -2.0f);
+			b2Vec2 v9(-10.0f, 0.0f);
+			b2Vec2 v10(-10.0f, -4.0f);
 
 			b2EdgeShape shape;
 
-			shape.Set(v1, v2);
-			shape.m_hasVertex3 = true;
-			shape.m_vertex3 = v3;
+			shape.SetOneSided(v10, v1, v2, v3);
 			ground->CreateFixture(&shape, 0.0f);
 
-			shape.Set(v2, v3);
-			shape.m_hasVertex0 = true;
-			shape.m_hasVertex3 = true;
-			shape.m_vertex0 = v1;
-			shape.m_vertex3 = v4;
+			shape.SetOneSided(v1, v2, v3, v4);
 			ground->CreateFixture(&shape, 0.0f);
 
-			shape.Set(v3, v4);
-			shape.m_hasVertex0 = true;
-			shape.m_hasVertex3 = true;
-			shape.m_vertex0 = v2;
-			shape.m_vertex3 = v5;
+			shape.SetOneSided(v2, v3, v4, v5);
 			ground->CreateFixture(&shape, 0.0f);
 
-			shape.Set(v4, v5);
-			shape.m_hasVertex0 = true;
-			shape.m_hasVertex3 = true;
-			shape.m_vertex0 = v3;
-			shape.m_vertex3 = v6;
+			shape.SetOneSided(v3, v4, v5, v6);
 			ground->CreateFixture(&shape, 0.0f);
 
-			shape.Set(v5, v6);
-			shape.m_hasVertex0 = true;
-			shape.m_hasVertex3 = true;
-			shape.m_vertex0 = v4;
-			shape.m_vertex3 = v7;
+			shape.SetOneSided(v4, v5, v6, v7);
 			ground->CreateFixture(&shape, 0.0f);
 
-			shape.Set(v6, v7);
-			shape.m_hasVertex0 = true;
-			shape.m_vertex0 = v5;
+			shape.SetOneSided(v5, v6, v7, v8);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetOneSided(v6, v7, v8, v9);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetOneSided(v7, v8, v9, v10);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetOneSided(v8, v9, v10, v1);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetOneSided(v9, v10, v1, v2);
 			ground->CreateFixture(&shape, 0.0f);
 		}
 
-#if 0
+		{
+			b2BodyDef bd;
+			b2Body* ground = m_world->CreateBody(&bd);
+
+			float y = 8.0f;
+			b2Vec2 v1(14.0f, -4.0f + y);
+			b2Vec2 v2(14.0f, 0.0f + y);
+			b2Vec2 v3(10.0f, 0.0f + y);
+			b2Vec2 v4(7.0f, 2.0f + y);
+			b2Vec2 v5(4.0f, 0.0f + y);
+			b2Vec2 v6(0.0f, 0.0f + y);
+			b2Vec2 v7(-4.0f, 0.0f + y);
+			b2Vec2 v8(-7.0f, -2.0f + y);
+			b2Vec2 v9(-10.0f, 0.0f + y);
+			b2Vec2 v10(-10.0f, -4.0f + y);
+
+			b2EdgeShape shape;
+
+			shape.SetTwoSided(v1, v2);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetTwoSided(v2, v3);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetTwoSided(v3, v4);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetTwoSided(v4, v5);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetTwoSided(v5, v6);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetTwoSided(v6, v7);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetTwoSided(v7, v8);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetTwoSided(v8, v9);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetTwoSided(v9, v10);
+			ground->CreateFixture(&shape, 0.0f);
+
+			shape.SetTwoSided(v10, v1);
+			ground->CreateFixture(&shape, 0.0f);
+		}
+
+		m_body1 = nullptr;
+		m_body2 = nullptr;
+		CreateBoxes();
+		m_boxes = true;
+	}
+
+	void CreateBoxes()
+	{
+		if (m_body1)
+		{
+			m_world->DestroyBody(m_body1);
+			m_body1 = nullptr;
+		}
+
+		if (m_body2)
+		{
+			m_world->DestroyBody(m_body2);
+			m_body2 = nullptr;
+		}
+
+		{
+			b2BodyDef bd;
+			bd.type = b2_dynamicBody;
+			bd.position.Set(12.0f, 2.6f);
+			bd.allowSleep = false;
+			m_body1 = m_world->CreateBody(&bd);
+
+			b2PolygonShape shape;
+			shape.SetAsBox(0.5f, 1.0f);
+
+			m_body1->CreateFixture(&shape, 1.0f);
+		}
+
+		{
+			b2BodyDef bd;
+			bd.type = b2_dynamicBody;
+			bd.position.Set(12.0f, 2.6f + 8.0f);
+			bd.allowSleep = false;
+			m_body2 = m_world->CreateBody(&bd);
+
+			b2PolygonShape shape;
+			shape.SetAsBox(0.5f, 1.0f);
+
+			m_body2->CreateFixture(&shape, 1.0f);
+		}
+	}
+
+	void CreateCircles()
+	{
+		if (m_body1)
+		{
+			m_world->DestroyBody(m_body1);
+			m_body1 = nullptr;
+		}
+
+		if (m_body2)
+		{
+			m_world->DestroyBody(m_body2);
+			m_body2 = nullptr;
+		}
+
 		{
 			b2BodyDef bd;
 			bd.type = b2_dynamicBody;
 			bd.position.Set(-0.5f, 0.6f);
 			bd.allowSleep = false;
-			b2Body* body = m_world->CreateBody(&bd);
+			m_body1 = m_world->CreateBody(&bd);
 
 			b2CircleShape shape;
 			shape.m_radius = 0.5f;
 
-			body->CreateFixture(&shape, 1.0f);
+			m_body1->CreateFixture(&shape, 1.0f);
 		}
-#endif
 
 		{
 			b2BodyDef bd;
 			bd.type = b2_dynamicBody;
-			bd.position.Set(1.0f, 0.6f);
+			bd.position.Set(-0.5f, 0.6f + 8.0f);
 			bd.allowSleep = false;
-			b2Body* body = m_world->CreateBody(&bd);
+			m_body2 = m_world->CreateBody(&bd);
 
-			b2PolygonShape shape;
-			shape.SetAsBox(0.5f, 0.25f);
+			b2CircleShape shape;
+			shape.m_radius = 0.5f;
 
-			body->CreateFixture(&shape, 1.0f);
+			m_body2->CreateFixture(&shape, 1.0f);
 		}
+	}
+
+	void UpdateUI() override
+	{
+		ImGui::SetNextWindowPos(ImVec2(10.0f, 100.0f));
+		ImGui::SetNextWindowSize(ImVec2(200.0f, 100.0f));
+		ImGui::Begin("Custom Controls", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize);
+
+		if (ImGui::RadioButton("Boxes", m_boxes == true))
+		{
+			CreateBoxes();
+			m_boxes = true;
+		}
+
+		if (ImGui::RadioButton("Circles", m_boxes == false))
+		{
+			CreateCircles();
+			m_boxes = false;
+		}
+
+		ImGui::End();
+	}
+
+	void Step(Settings& settings) override
+	{
+		if (glfwGetKey(g_mainWindow, GLFW_KEY_A) == GLFW_PRESS)
+		{
+			m_body1->ApplyForceToCenter(b2Vec2(-10.0f, 0.0f), true);
+			m_body2->ApplyForceToCenter(b2Vec2(-10.0f, 0.0f), true);
+		}
+
+		if (glfwGetKey(g_mainWindow, GLFW_KEY_D) == GLFW_PRESS)
+		{
+			m_body1->ApplyForceToCenter(b2Vec2(10.0f, 0.0f), true);
+			m_body2->ApplyForceToCenter(b2Vec2(10.0f, 0.0f), true);
+		}
+
+		Test::Step(settings);
 	}
 
 	static Test* Create()
 	{
 		return new EdgeTest;
 	}
+
+	b2Body* m_body1;
+	b2Body* m_body2;
+	bool m_boxes;
 };
 
 static int testIndex = RegisterTest("Geometry", "Edge Test", EdgeTest::Create);

--- a/testbed/tests/friction.cpp
+++ b/testbed/tests/friction.cpp
@@ -33,7 +33,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/gear_joint.cpp
+++ b/testbed/tests/gear_joint.cpp
@@ -33,7 +33,7 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(50.0f, 0.0f), b2Vec2(-50.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(50.0f, 0.0f), b2Vec2(-50.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/heavy1.cpp
+++ b/testbed/tests/heavy1.cpp
@@ -33,7 +33,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
             
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
         

--- a/testbed/tests/heavy2.cpp
+++ b/testbed/tests/heavy2.cpp
@@ -33,7 +33,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
             
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
         

--- a/testbed/tests/motor_joint.cpp
+++ b/testbed/tests/motor_joint.cpp
@@ -37,7 +37,7 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-20.0f, 0.0f), b2Vec2(20.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-20.0f, 0.0f), b2Vec2(20.0f, 0.0f));
 
 			b2FixtureDef fd;
 			fd.shape = &shape;

--- a/testbed/tests/pinball.cpp
+++ b/testbed/tests/pinball.cpp
@@ -36,11 +36,11 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2Vec2 vs[5];
-			vs[0].Set(0.0f, -2.0f);
-			vs[1].Set(8.0f, 6.0f);
+			vs[0].Set(-8.0f, 6.0f);
+			vs[1].Set(-8.0f, 20.0f);
 			vs[2].Set(8.0f, 20.0f);
-			vs[3].Set(-8.0f, 20.0f);
-			vs[4].Set(-8.0f, 6.0f);
+			vs[3].Set(8.0f, 6.0f);
+			vs[4].Set(0.0f, -2.0f);
 
 			b2ChainShape loop;
 			loop.CreateLoop(vs, 5);

--- a/testbed/tests/platformer.cpp
+++ b/testbed/tests/platformer.cpp
@@ -41,7 +41,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-20.0f, 0.0f), b2Vec2(20.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-20.0f, 0.0f), b2Vec2(20.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/polygon_collision.cpp
+++ b/testbed/tests/polygon_collision.cpp
@@ -78,6 +78,8 @@ public:
 		{
 			g_debugDraw.DrawPoint(worldManifold.points[i], 4.0f, b2Color(0.9f, 0.3f, 0.3f));
 		}
+
+		Test::Step(settings);
 	}
 
 	void Keyboard(int key) override

--- a/testbed/tests/polygon_shapes.cpp
+++ b/testbed/tests/polygon_shapes.cpp
@@ -90,7 +90,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/prismatic_joint.cpp
+++ b/testbed/tests/prismatic_joint.cpp
@@ -36,7 +36,7 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/pulley_joint.cpp
+++ b/testbed/tests/pulley_joint.cpp
@@ -37,10 +37,6 @@ public:
 			b2BodyDef bd;
 			ground = m_world->CreateBody(&bd);
 
-			b2EdgeShape edge;
-			edge.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
-			//ground->CreateFixture(&shape, 0.0f);
-
 			b2CircleShape circle;
 			circle.m_radius = 2.0f;
 

--- a/testbed/tests/pyramid.cpp
+++ b/testbed/tests/pyramid.cpp
@@ -37,7 +37,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/ray_cast.cpp
+++ b/testbed/tests/ray_cast.cpp
@@ -183,7 +183,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 
@@ -230,7 +230,7 @@ public:
 		}
 
 		{
-			m_edge.Set(b2Vec2(-1.0f, 0.0f), b2Vec2(1.0f, 0.0f));
+			m_edge.SetTwoSided(b2Vec2(-1.0f, 0.0f), b2Vec2(1.0f, 0.0f));
 		}
 
 		m_bodyIndex = 0;

--- a/testbed/tests/restitution.cpp
+++ b/testbed/tests/restitution.cpp
@@ -35,7 +35,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/revolute_joint.cpp
+++ b/testbed/tests/revolute_joint.cpp
@@ -33,7 +33,7 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 
 			b2FixtureDef fd;
 			fd.shape = &shape;

--- a/testbed/tests/rope_joint.cpp
+++ b/testbed/tests/rope_joint.cpp
@@ -41,7 +41,7 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/sensor.cpp
+++ b/testbed/tests/sensor.cpp
@@ -40,7 +40,7 @@ public:
 
 			{
 				b2EdgeShape shape;
-				shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+				shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 				ground->CreateFixture(&shape, 0.0f);
 			}
 

--- a/testbed/tests/shape_editing.cpp
+++ b/testbed/tests/shape_editing.cpp
@@ -33,7 +33,7 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/skier.cpp
+++ b/testbed/tests/skier.cpp
@@ -50,10 +50,10 @@ public:
 			b2Vec2 v4(v3.x + SlopeLength * cosf(Slope2Incline), v3.y - SlopeLength * sinf(Slope2Incline));
 			b2Vec2 v5(v4.x, v4.y - 1.0f);
 
-			b2Vec2 verts[5] = { v5, v4, v3, v2, v1 };
+			b2Vec2 vertices[5] = { v5, v4, v3, v2, v1 };
 
 			b2ChainShape shape;
-			shape.CreateLoop(verts, 5);
+			shape.CreateLoop(vertices, 5);
 			b2FixtureDef fd;
 			fd.shape = &shape;
 			fd.density = 0.0f;

--- a/testbed/tests/skier.cpp
+++ b/testbed/tests/skier.cpp
@@ -43,71 +43,26 @@ public:
 
 			m_platform_width = PlatformWidth;
 
-			std::vector< b2Vec2 > verts;
-
 			// Horizontal platform
-			verts.emplace_back(-PlatformWidth, 0.0f);
-			verts.emplace_back(0.0f, 0.0f);
+			b2Vec2 v1(-PlatformWidth, 0.0f);
+			b2Vec2 v2(0.0f, 0.0f);
+			b2Vec2 v3(SlopeLength * cosf(Slope1Incline), -SlopeLength * sinf(Slope1Incline));
+			b2Vec2 v4(v3.x + SlopeLength * cosf(Slope2Incline), v3.y - SlopeLength * sinf(Slope2Incline));
+			b2Vec2 v5(v4.x, v4.y - 1.0f);
 
-			// Slope
-			verts.emplace_back(
-				verts.back().x + SlopeLength * cosf(Slope1Incline),
-				verts.back().y - SlopeLength * sinf(Slope1Incline)
-				);
+			b2Vec2 verts[5] = { v5, v4, v3, v2, v1 };
 
-			verts.emplace_back(
-				verts.back().x + SlopeLength * cosf(Slope2Incline),
-				verts.back().y - SlopeLength * sinf(Slope2Incline)
-				);
+			b2ChainShape shape;
+			shape.CreateLoop(verts, 5);
+			b2FixtureDef fd;
+			fd.shape = &shape;
+			fd.density = 0.0f;
+			fd.friction = SurfaceFriction;
 
-			{
-				b2EdgeShape shape;
-				shape.Set(verts[0], verts[1]);
-				shape.m_hasVertex3 = true;
-				shape.m_vertex3 = verts[2];
-
-				b2FixtureDef fd;
-				fd.shape = &shape;
-				fd.density = 0.0f;
-				fd.friction = SurfaceFriction;
-
-				ground->CreateFixture(&fd);
-			}
-
-			{
-				b2EdgeShape shape;
-				shape.Set(verts[1], verts[2]);
-				shape.m_hasVertex0 = true;
-				shape.m_hasVertex3 = true;
-				shape.m_vertex0 = verts[0];
-				shape.m_vertex3 = verts[3];
-
-				b2FixtureDef fd;
-				fd.shape = &shape;
-				fd.density = 0.0f;
-				fd.friction = SurfaceFriction;
-
-				ground->CreateFixture(&fd);
-			}
-			
-			{
-				b2EdgeShape shape;
-				shape.Set(verts[2], verts[3]);
-				shape.m_hasVertex0 = true;
-				shape.m_vertex0 = verts[1];
-
-				b2FixtureDef fd;
-				fd.shape = &shape;
-				fd.density = 0.0f;
-				fd.friction = SurfaceFriction;
-
-				ground->CreateFixture(&fd);
-			}
+			ground->CreateFixture(&fd);
 		}
 
 		{
-			bool const EnableCircularSkiTips = false;
-
 			float const BodyWidth = 1.0f;
 			float const BodyHeight = 2.5f;
 			float const SkiLength = 3.0f;
@@ -124,52 +79,26 @@ public:
 			bd.type = b2_dynamicBody;
 
 			float initial_y = BodyHeight / 2 + SkiThickness;
-			if(EnableCircularSkiTips)
-			{
-				initial_y += SkiThickness / 6;
-			}
 			bd.position.Set(-m_platform_width / 2, initial_y);
 
 			b2Body* skier = m_world->CreateBody(&bd);
 
-			b2PolygonShape body;
-			body.SetAsBox(BodyWidth / 2, BodyHeight / 2);
-
 			b2PolygonShape ski;
-			std::vector< b2Vec2 > verts;
-			verts.emplace_back(-SkiLength / 2 - SkiThickness, -BodyHeight / 2);
-			verts.emplace_back(-SkiLength / 2, -BodyHeight / 2 - SkiThickness);
-			verts.emplace_back(SkiLength / 2, -BodyHeight / 2 - SkiThickness);
-			verts.emplace_back(SkiLength / 2 + SkiThickness, -BodyHeight / 2);
-			ski.Set(verts.data(), (int32)verts.size());
-
-			b2CircleShape ski_back_shape;
-			ski_back_shape.m_p.Set(-SkiLength / 2.0f, -BodyHeight / 2 - SkiThickness * (2.0f / 3));
-			ski_back_shape.m_radius = SkiThickness / 2;
-
-			b2CircleShape ski_front_shape;
-			ski_front_shape.m_p.Set(SkiLength / 2, -BodyHeight / 2 - SkiThickness * (2.0f / 3));
-			ski_front_shape.m_radius = SkiThickness / 2;
+			b2Vec2 verts[4];
+			verts[0].Set(-SkiLength / 2 - SkiThickness, -BodyHeight / 2);
+			verts[1].Set(-SkiLength / 2, -BodyHeight / 2 - SkiThickness);
+			verts[2].Set(SkiLength / 2, -BodyHeight / 2 - SkiThickness);
+			verts[3].Set(SkiLength / 2 + SkiThickness, -BodyHeight / 2);
+			ski.Set(verts, 4);
 
 			b2FixtureDef fd;
-			fd.shape = &body;
 			fd.density = 1.0f;
-			skier->CreateFixture(&fd);
 
 			fd.friction = SkiFriction;
 			fd.restitution = SkiRestitution;
 
 			fd.shape = &ski;
 			skier->CreateFixture(&fd);
-
-			if(EnableCircularSkiTips)
-			{
-				fd.shape = &ski_back_shape;
-				skier->CreateFixture(&fd);
-
-				fd.shape = &ski_front_shape;
-				skier->CreateFixture(&fd);
-			}
 
 			skier->SetLinearVelocity(b2Vec2(0.5f, 0.0f));
 

--- a/testbed/tests/slider_crank_2.cpp
+++ b/testbed/tests/slider_crank_2.cpp
@@ -36,7 +36,7 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/theo_jansen.cpp
+++ b/testbed/tests/theo_jansen.cpp
@@ -132,13 +132,13 @@ public:
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-50.0f, 0.0f), b2Vec2(50.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-50.0f, 0.0f), b2Vec2(50.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 
-			shape.Set(b2Vec2(-50.0f, 0.0f), b2Vec2(-50.0f, 10.0f));
+			shape.SetTwoSided(b2Vec2(-50.0f, 0.0f), b2Vec2(-50.0f, 10.0f));
 			ground->CreateFixture(&shape, 0.0f);
 
-			shape.Set(b2Vec2(50.0f, 0.0f), b2Vec2(50.0f, 10.0f));
+			shape.SetTwoSided(b2Vec2(50.0f, 0.0f), b2Vec2(50.0f, 10.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 

--- a/testbed/tests/wheel_joint.cpp
+++ b/testbed/tests/wheel_joint.cpp
@@ -36,7 +36,7 @@ public:
 			ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
-			shape.Set(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
+			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
 			ground->CreateFixture(&shape, 0.0f);
 		}
 


### PR DESCRIPTION
- Addresses #553,  #341, and #286
- Edge shapes are now either one-sided or two-sided
- Only one-sided edges support smooth collision and must be connected to other edges on both sides
- Edge and chain shapes APIs updated to reflect changes
