### PR TITLE
Added changeable UserData typedef (#161)

### DIFF
--- a/include/box2d/b2_body.h
+++ b/include/box2d/b2_body.h
@@ -54,9 +54,9 @@ enum b2BodyType
 struct b2BodyDef
 {
 	/// This constructor sets the body definition default values.
-	b2BodyDef()
+	b2BodyDef() :
+	    userData{}
 	{
-		userData = nullptr;
 		position.Set(0.0f, 0.0f);
 		angle = 0.0f;
 		linearVelocity.Set(0.0f, 0.0f);
@@ -121,7 +121,7 @@ struct b2BodyDef
 	bool enabled;
 
 	/// Use this to store application specific body data.
-	void* userData;
+    b2BodyUserData userData;
 
 	/// Scale the gravity applied to this body.
 	float gravityScale;
@@ -379,10 +379,10 @@ public:
 	const b2Body* GetNext() const;
 
 	/// Get the user data pointer that was provided in the body definition.
-	void* GetUserData() const;
+    b2BodyUserData GetUserData() const;
 
 	/// Set the user data. Use this to store your application specific data.
-	void SetUserData(void* data);
+	void SetUserData(b2BodyUserData data);
 
 	/// Get the parent world of this body.
 	b2World* GetWorld();
@@ -471,7 +471,7 @@ private:
 
 	float m_sleepTime;
 
-	void* m_userData;
+    b2BodyUserData m_userData;
 };
 
 inline b2BodyType b2Body::GetType() const
@@ -734,12 +734,12 @@ inline const b2Body* b2Body::GetNext() const
 	return m_next;
 }
 
-inline void b2Body::SetUserData(void* data)
+inline void b2Body::SetUserData(b2BodyUserData data)
 {
 	m_userData = data;
 }
 
-inline void* b2Body::GetUserData() const
+inline b2BodyUserData b2Body::GetUserData() const
 {
 	return m_userData;
 }

--- a/include/box2d/b2_fixture.h
+++ b/include/box2d/b2_fixture.h
@@ -60,10 +60,10 @@ struct b2Filter
 struct b2FixtureDef
 {
 	/// The constructor sets the default fixture definition values.
-	b2FixtureDef()
+	b2FixtureDef() :
+	    userData{}
 	{
 		shape = nullptr;
-		userData = nullptr;
 		friction = 0.2f;
 		restitution = 0.0f;
 		density = 0.0f;
@@ -75,7 +75,7 @@ struct b2FixtureDef
 	const b2Shape* shape;
 
 	/// Use this to store application specific fixture data.
-	void* userData;
+    b2FixtureUserData userData;
 
 	/// The friction coefficient, usually in the range [0,1].
 	float friction;
@@ -151,10 +151,10 @@ public:
 
 	/// Get the user data that was assigned in the fixture definition. Use this to
 	/// store your application specific data.
-	void* GetUserData() const;
+    b2FixtureUserData GetUserData() const;
 
 	/// Set the user data. Use this to store your application specific data.
-	void SetUserData(void* data);
+	void SetUserData(b2FixtureUserData data);
 
 	/// Test a point for containment in this fixture.
 	/// @param p a point in world coordinates.
@@ -237,7 +237,7 @@ protected:
 
 	bool m_isSensor;
 
-	void* m_userData;
+    b2FixtureUserData m_userData;
 };
 
 inline b2Shape::Type b2Fixture::GetType() const
@@ -265,12 +265,12 @@ inline const b2Filter& b2Fixture::GetFilterData() const
 	return m_filter;
 }
 
-inline void* b2Fixture::GetUserData() const
+inline b2FixtureUserData b2Fixture::GetUserData() const
 {
 	return m_userData;
 }
 
-inline void b2Fixture::SetUserData(void* data)
+inline void b2Fixture::SetUserData(b2FixtureUserData data)
 {
 	m_userData = data;
 }

--- a/include/box2d/b2_joint.h
+++ b/include/box2d/b2_joint.h
@@ -70,10 +70,10 @@ struct b2JointEdge
 /// Joint definitions are used to construct joints.
 struct b2JointDef
 {
-	b2JointDef()
+	b2JointDef() :
+	    userData{}
 	{
 		type = e_unknownJoint;
-		userData = nullptr;
 		bodyA = nullptr;
 		bodyB = nullptr;
 		collideConnected = false;
@@ -83,7 +83,7 @@ struct b2JointDef
 	b2JointType type;
 
 	/// Use this to attach application specific data to your joints.
-	void* userData;
+    b2JointUserData userData;
 
 	/// The first attached body.
 	b2Body* bodyA;
@@ -137,10 +137,10 @@ public:
 	const b2Joint* GetNext() const;
 
 	/// Get the user data pointer.
-	void* GetUserData() const;
+    b2JointUserData GetUserData() const;
 
 	/// Set the user data pointer.
-	void SetUserData(void* data);
+	void SetUserData(b2JointUserData data);
 
 	/// Short-cut function to determine if either body is enabled.
 	bool IsEnabled() const;
@@ -190,7 +190,7 @@ protected:
 	bool m_islandFlag;
 	bool m_collideConnected;
 
-	void* m_userData;
+    b2JointUserData m_userData;
 };
 
 inline b2JointType b2Joint::GetType() const
@@ -218,12 +218,12 @@ inline const b2Joint* b2Joint::GetNext() const
 	return m_next;
 }
 
-inline void* b2Joint::GetUserData() const
+inline b2JointUserData b2Joint::GetUserData() const
 {
 	return m_userData;
 }
 
-inline void b2Joint::SetUserData(void* data)
+inline void b2Joint::SetUserData(b2JointUserData data)
 {
 	m_userData = data;
 }

--- a/include/box2d/b2_settings.h
+++ b/include/box2d/b2_settings.h
@@ -40,6 +40,9 @@ typedef signed int int32;
 typedef unsigned char uint8;
 typedef unsigned short uint16;
 typedef unsigned int uint32;
+typedef void* b2BodyUserData;
+typedef void* b2FixtureUserData;
+typedef void* b2JointUserData;
 
 #define	b2_maxFloat		FLT_MAX
 #define	b2_epsilon		FLT_EPSILON

--- a/src/dynamics/b2_fixture.cpp
+++ b/src/dynamics/b2_fixture.cpp
@@ -31,9 +31,9 @@
 #include "box2d/b2_polygon_shape.h"
 #include "box2d/b2_world.h"
 
-b2Fixture::b2Fixture()
+b2Fixture::b2Fixture() :
+    m_userData{}
 {
-	m_userData = nullptr;
 	m_body = nullptr;
 	m_next = nullptr;
 	m_proxies = nullptr;


### PR DESCRIPTION
Based on issue from some time ago. I have wrote typedef definition to change user data type based on their needs.
This code isn't invasive and don't change current behavior in any way.

And now user can change data type in simple way by configuring settings.
Example:

    class b2Virtual;
    typedef std::shared_ptr<b2Virtual> b2BodyUserData;

Future development way:
typedef change based on cmake variable on configure step.