### PR TITLE
Fix and test for issue 636

### DIFF
--- a/src/dynamics/b2_body.cpp
+++ b/src/dynamics/b2_body.cpp
@@ -434,6 +434,9 @@ void b2Body::SetTransform(const b2Vec2& position, float angle)
 	{
 		f->Synchronize(broadPhase, m_xf, m_xf);
 	}
+
+	// Check for new contacts the next step
+	m_world->m_newContacts = true;
 }
 
 void b2Body::SynchronizeFixtures()

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -3,6 +3,7 @@ add_executable(unit_test
     hello_world.cpp
     collision_test.cpp
     math_test.cpp
+    world_test.cpp
 )
 
 set_target_properties(unit_test PROPERTIES
@@ -16,4 +17,4 @@ target_link_libraries(unit_test PUBLIC box2d)
 set_target_properties(unit_test PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES doctest.h
-    hello_world.cpp collision_test.cpp math_test.cpp )
+    hello_world.cpp collision_test.cpp math_test.cpp world_test.cpp )

--- a/unit-test/world_test.cpp
+++ b/unit-test/world_test.cpp
@@ -1,0 +1,73 @@
+// MIT License
+
+// Copyright (c) 2019 Erin Catto
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "box2d/box2d.h"
+#include <stdio.h>
+#include "doctest.h"
+
+static bool begin_contact = false;
+
+class MyContactListener : public b2ContactListener
+{
+public:
+	void BeginContact(b2Contact* contact)
+	{
+		begin_contact = true;
+	}
+};
+
+DOCTEST_TEST_CASE("begin contact")
+{
+	b2World world = b2World(b2Vec2());
+	MyContactListener listener;
+	world.SetContactListener(&listener);
+
+	b2CircleShape circle;
+	circle.m_radius = 5.f;
+
+	b2BodyDef bodyDef;
+	bodyDef.type = b2_dynamicBody;
+
+	b2Body* bodyA = world.CreateBody(&bodyDef);
+	b2Body* bodyB = world.CreateBody(&bodyDef);
+	bodyA->CreateFixture(&circle, 0.0f);
+	bodyB->CreateFixture(&circle, 0.0f);
+
+	bodyA->SetTransform(b2Vec2(0.f, 0.f), 0.f);
+	bodyB->SetTransform(b2Vec2(100.f, 0.f), 0.f);
+
+	const float timeStep = 1.f / 60.f;
+	const int32 velocityIterations = 6;
+	const int32 positionIterations = 2;
+
+	world.Step(timeStep, velocityIterations, positionIterations);
+
+	CHECK(world.GetContactList() == nullptr);
+	CHECK(begin_contact == false);
+	
+	bodyB->SetTransform(b2Vec2(1.f, 0.f), 0.f);
+
+	world.Step(timeStep, velocityIterations, positionIterations);
+
+	CHECK(world.GetContactList() != nullptr);
+	CHECK(begin_contact == true);
+}


### PR DESCRIPTION
b2Body::SetTransform now tells b2World to find new contacts at the beginning of the steps.
Added unit test to ensure this works correctly.