### PR TITLE
Added runtime tunable restitution velocity threshold

### DIFF
--- a/include/box2d/b2_common.h
+++ b/include/box2d/b2_common.h
@@ -82,10 +82,6 @@
 /// Maximum number of contacts to be handled to solve a TOI impact.
 #define b2_maxTOIContacts			32
 
-/// A velocity threshold for elastic collisions. Any collision with a relative linear
-/// velocity below this threshold will be treated as inelastic. Meters per second.
-#define b2_velocityThreshold		(1.0f * b2_lengthUnitsPerMeter)
-
 /// The maximum linear position correction used when solving constraints. This helps to
 /// prevent overshoot. Meters.
 #define b2_maxLinearCorrection		(0.2f * b2_lengthUnitsPerMeter)

--- a/include/box2d/b2_contact.h
+++ b/include/box2d/b2_contact.h
@@ -50,6 +50,12 @@ inline float b2MixRestitution(float restitution1, float restitution2)
 	return restitution1 > restitution2 ? restitution1 : restitution2;
 }
 
+/// Restitution mixing law. This picks the lowest value.
+inline float b2MixRestitutionThreshold(float threshold1, float threshold2)
+{
+	return threshold1 < threshold2 ? threshold1 : threshold2;
+}
+
 typedef b2Contact* b2ContactCreateFcn(	b2Fixture* fixtureA, int32 indexA,
 										b2Fixture* fixtureB, int32 indexB,
 										b2BlockAllocator* allocator);
@@ -139,6 +145,16 @@ public:
 	/// Reset the restitution to the default value.
 	void ResetRestitution();
 
+	/// Override the default restitution velocity threshold mixture. You can call this in b2ContactListener::PreSolve.
+	/// The value persists until you set or reset.
+	void SetRestitutionThreshold(float threshold);
+
+	/// Get the restitution threshold.
+	float GetRestitutionThreshold() const;
+
+	/// Reset the restitution threshold to the default value.
+	void ResetRestitutionThreshold();
+
 	/// Set the desired tangent speed for a conveyor belt behavior. In meters per second.
 	void SetTangentSpeed(float speed);
 
@@ -219,6 +235,7 @@ protected:
 
 	float m_friction;
 	float m_restitution;
+	float m_restitutionThreshold;
 
 	float m_tangentSpeed;
 };
@@ -338,6 +355,21 @@ inline float b2Contact::GetRestitution() const
 inline void b2Contact::ResetRestitution()
 {
 	m_restitution = b2MixRestitution(m_fixtureA->m_restitution, m_fixtureB->m_restitution);
+}
+
+inline void b2Contact::SetRestitutionThreshold(float threshold)
+{
+	m_restitutionThreshold = threshold;
+}
+
+inline float b2Contact::GetRestitutionThreshold() const
+{
+	return m_restitutionThreshold;
+}
+
+inline void b2Contact::ResetRestitutionThreshold()
+{
+	m_restitutionThreshold = b2MixRestitutionThreshold(m_fixtureA->m_restitutionThreshold, m_fixtureB->m_restitutionThreshold);
 }
 
 inline void b2Contact::SetTangentSpeed(float speed)

--- a/include/box2d/b2_fixture.h
+++ b/include/box2d/b2_fixture.h
@@ -65,6 +65,7 @@ struct b2FixtureDef
 		shape = nullptr;
 		friction = 0.2f;
 		restitution = 0.0f;
+		restitutionThreshold = 1.0f * b2_lengthUnitsPerMeter;
 		density = 0.0f;
 		isSensor = false;
 	}
@@ -81,6 +82,10 @@ struct b2FixtureDef
 
 	/// The restitution (elasticity) usually in the range [0,1].
 	float restitution;
+
+	/// Restitution velocity threshold, usually in m/s. Collisions above this
+	/// speed have restitution applied (will bounce).
+	float restitutionThreshold;
 
 	/// The density, usually in kg/m^2.
 	float density;
@@ -188,6 +193,13 @@ public:
 	/// existing contacts.
 	void SetRestitution(float restitution);
 
+	/// Get the restitution velocity threshold.
+	float GetRestitutionThreshold() const;
+
+	/// Set the restitution threshold. This will _not_ change the restitution threshold of
+	/// existing contacts.
+	void SetRestitutionThreshold(float threshold);
+
 	/// Get the fixture's AABB. This AABB may be enlarge and/or stale.
 	/// If you need a more accurate AABB, compute it using the shape and
 	/// the body transform.
@@ -225,6 +237,7 @@ protected:
 
 	float m_friction;
 	float m_restitution;
+	float m_restitutionThreshold;
 
 	b2FixtureProxy* m_proxies;
 	int32 m_proxyCount;
@@ -315,6 +328,16 @@ inline float b2Fixture::GetRestitution() const
 inline void b2Fixture::SetRestitution(float restitution)
 {
 	m_restitution = restitution;
+}
+
+inline float b2Fixture::GetRestitutionThreshold() const
+{
+	return m_restitutionThreshold;
+}
+
+inline void b2Fixture::SetRestitutionThreshold(float threshold)
+{
+	m_restitutionThreshold = threshold;
 }
 
 inline bool b2Fixture::TestPoint(const b2Vec2& p) const

--- a/src/dynamics/b2_contact.cpp
+++ b/src/dynamics/b2_contact.cpp
@@ -156,6 +156,7 @@ b2Contact::b2Contact(b2Fixture* fA, int32 indexA, b2Fixture* fB, int32 indexB)
 
 	m_friction = b2MixFriction(m_fixtureA->m_friction, m_fixtureB->m_friction);
 	m_restitution = b2MixRestitution(m_fixtureA->m_restitution, m_fixtureB->m_restitution);
+	m_restitutionThreshold = b2MixRestitutionThreshold(m_fixtureA->m_restitutionThreshold, m_fixtureB->m_restitutionThreshold);
 
 	m_tangentSpeed = 0.0f;
 }

--- a/src/dynamics/b2_contact_solver.cpp
+++ b/src/dynamics/b2_contact_solver.cpp
@@ -80,6 +80,7 @@ b2ContactSolver::b2ContactSolver(b2ContactSolverDef* def)
 		b2ContactVelocityConstraint* vc = m_velocityConstraints + i;
 		vc->friction = contact->m_friction;
 		vc->restitution = contact->m_restitution;
+		vc->threshold = contact->m_restitutionThreshold;
 		vc->tangentSpeed = contact->m_tangentSpeed;
 		vc->indexA = bodyA->m_islandIndex;
 		vc->indexB = bodyB->m_islandIndex;
@@ -213,7 +214,7 @@ void b2ContactSolver::InitializeVelocityConstraints()
 			// Setup a velocity bias for restitution.
 			vcp->velocityBias = 0.0f;
 			float vRel = b2Dot(vc->normal, vB + b2Cross(wB, vcp->rB) - vA - b2Cross(wA, vcp->rA));
-			if (vRel < -b2_velocityThreshold)
+			if (vRel < -vc->threshold)
 			{
 				vcp->velocityBias = -vc->restitution * vRel;
 			}

--- a/src/dynamics/b2_contact_solver.h
+++ b/src/dynamics/b2_contact_solver.h
@@ -55,6 +55,7 @@ struct b2ContactVelocityConstraint
 	float invIA, invIB;
 	float friction;
 	float restitution;
+	float threshold;
 	float tangentSpeed;
 	int32 pointCount;
 	int32 contactIndex;

--- a/src/dynamics/b2_fixture.cpp
+++ b/src/dynamics/b2_fixture.cpp
@@ -46,6 +46,7 @@ void b2Fixture::Create(b2BlockAllocator* allocator, b2Body* body, const b2Fixtur
 	m_userData = def->userData;
 	m_friction = def->friction;
 	m_restitution = def->restitution;
+	m_restitutionThreshold = def->restitutionThreshold;
 
 	m_body = body;
 	m_next = nullptr;
@@ -234,6 +235,7 @@ void b2Fixture::Dump(int32 bodyIndex)
 	b2Dump("    b2FixtureDef fd;\n");
 	b2Dump("    fd.friction = %.9g;\n", m_friction);
 	b2Dump("    fd.restitution = %.9g;\n", m_restitution);
+	b2Dump("    fd.restitutionThreshold = %.9g;\n", m_restitutionThreshold);
 	b2Dump("    fd.density = %.9g;\n", m_density);
 	b2Dump("    fd.isSensor = bool(%d);\n", m_isSensor);
 	b2Dump("    fd.filter.categoryBits = uint16(%d);\n", m_filter.categoryBits);

--- a/testbed/tests/restitution.cpp
+++ b/testbed/tests/restitution.cpp
@@ -30,13 +30,19 @@ public:
 
 	Restitution()
 	{
+		const float threshold = 10.0f;
+
 		{
 			b2BodyDef bd;
 			b2Body* ground = m_world->CreateBody(&bd);
 
 			b2EdgeShape shape;
 			shape.SetTwoSided(b2Vec2(-40.0f, 0.0f), b2Vec2(40.0f, 0.0f));
-			ground->CreateFixture(&shape, 0.0f);
+			
+			b2FixtureDef fd;
+			fd.shape = &shape;
+			fd.restitutionThreshold = threshold;
+			ground->CreateFixture(&fd);
 		}
 
 		{
@@ -58,6 +64,7 @@ public:
 				b2Body* body = m_world->CreateBody(&bd);
 
 				fd.restitution = restitution[i];
+				fd.restitutionThreshold = threshold;
 				body->CreateFixture(&fd);
 			}
 		}


### PR DESCRIPTION
Address issue #601
Each fixture has its own restitution velocity threshold.
The minimum threshold of the two touching fixtures is used by the associated contact.
