### PR TITLE
Removing dead code in b2_chain_shape

### DIFF
--- a/src/collision/b2_chain_shape.cpp
+++ b/src/collision/b2_chain_shape.cpp
@@ -44,10 +44,6 @@ void b2ChainShape::CreateLoop(const b2Vec2* vertices, int32 count)
 {
 	b2Assert(m_vertices == nullptr && m_count == 0);
 	b2Assert(count >= 3);
-	if (count < 3)
-	{
-		return;
-	}
 
 	for (int32 i = 1; i < count; ++i)
 	{


### PR DESCRIPTION
I believe there's a piece of dead code here since there's an assertion at the previous statement that will fail in case it's under 3.

I caught many other places like this one. So I started to think that box2d is designed to run without assert activated. The problem is that at some places in the case of assertion the code continues, is it expected or something that should be changed?

Example:
https://github.com/erincatto/box2d/blob/ee4e1c7a2a21dd2b4ce53a9b61c51f51e8adbc9a/src/collision/b2_chain_shape.cpp#L70-L76