### PR TITLE
Register unit_tests with CTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ script:
     - cd build
     - cmake ..
     - cmake --build .
-    - ./bin/unit_test
+    - ctest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ if (DOXYGEN_FOUND AND BOX2D_BUILD_DOCS)
 endif()
 
 if (BOX2D_BUILD_UNIT_TESTS)
+	enable_testing()
 	add_subdirectory(unit-test)
 endif()
 

--- a/unit-test/CMakeLists.txt
+++ b/unit-test/CMakeLists.txt
@@ -13,6 +13,7 @@ set_target_properties(unit_test PROPERTIES
     CXX_EXTENSIONS NO
 )
 target_link_libraries(unit_test PUBLIC box2d)
+add_test(NAME unit_test COMMAND unit_test)
 
 source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES doctest.h
     hello_world.cpp collision_test.cpp joint_test.cpp math_test.cpp world_test.cpp )


### PR DESCRIPTION
@erincatto,

This lets us run `ctest` in the binary dir or build the `test` target to automatically run all tests. This means CI scripts don't need updating when tests are added and new developers have an easier time making sure they run all tests.