### PR TITLE
Fix relative include in b2_island.cpp

### DIFF
--- a/src/dynamics/b2_island.cpp
+++ b/src/dynamics/b2_island.cpp
@@ -30,7 +30,7 @@
 #include "box2d/b2_world.h"
 
 #include "b2_island.h"
-#include "dynamics/b2_contact_solver.h"
+#include "b2_contact_solver.h"
 
 /*
 Position Correction Notes


### PR DESCRIPTION
I believe this should not be included with the folder in the path - no other include is done like that.

What this change does is that it is now possible to build the lib with, for example, Visual Studio without following cmake guide, but just throwing files at it & building. Otherwise src dir will have to be added as an additional include path to the solution 🤔 