### PR TITLE
Initialize variables properly for b2RopeTuning

### DIFF
--- a/include/box2d/b2_rope.h
+++ b/include/box2d/b2_rope.h
@@ -55,6 +55,8 @@ struct B2_API b2RopeTuning
 		bendingModel = b2_pbdAngleBendingModel;
 		damping = 0.0f;
 		stretchStiffness = 1.0f;
+		stretchHertz = 1.0f;
+		stretchDamping = 0.0f;
 		bendStiffness = 0.5f;
 		bendHertz = 1.0f;
 		bendDamping = 0.0f;


### PR DESCRIPTION
`stretchHertz` and `stretchDamping` were not initialized for `b2RopeTuning` and these can cause floating point exceptions on embedded systems if they for example result in unimplemented operations such as multiplication by denormalized floats. I'm not sure on the actual values and I can open an issue if necessary.