### PR TITLE
Fix deprecated implicit copy operations (#711)

### DIFF
--- a/include/box2d/b2_block_allocator.h
+++ b/include/box2d/b2_block_allocator.h
@@ -38,6 +38,8 @@ class B2_API b2BlockAllocator
 {
 public:
 	b2BlockAllocator();
+    b2BlockAllocator(const b2BlockAllocator&) = delete;
+    b2BlockAllocator& operator=(const b2BlockAllocator&) = delete;
 	~b2BlockAllocator();
 
 	/// Allocate memory. This will use b2Alloc if the size is larger than b2_maxBlockSize.

--- a/include/box2d/b2_body.h
+++ b/include/box2d/b2_body.h
@@ -418,6 +418,8 @@ private:
 	};
 
 	b2Body(const b2BodyDef* bd, b2World* world);
+    b2Body(const b2Body&) = delete;
+    b2Body& operator=(const b2Body&) = delete;
 	~b2Body();
 
 	void SynchronizeFixtures();

--- a/include/box2d/b2_broad_phase.h
+++ b/include/box2d/b2_broad_phase.h
@@ -47,6 +47,8 @@ public:
 	};
 
 	b2BroadPhase();
+    b2BroadPhase(const b2BroadPhase&) = delete;
+    b2BroadPhase& operator=(const b2BroadPhase&) = delete;
 	~b2BroadPhase();
 
 	/// Create a proxy with an initial AABB. Pairs are not reported until

--- a/include/box2d/b2_chain_shape.h
+++ b/include/box2d/b2_chain_shape.h
@@ -38,6 +38,9 @@ class B2_API b2ChainShape : public b2Shape
 public:
 	b2ChainShape();
 
+    b2ChainShape(const b2ChainShape&) = delete;
+    b2ChainShape& operator=(const b2ChainShape&) = delete;
+
 	/// The destructor frees the vertices using b2Free.
 	~b2ChainShape();
 

--- a/include/box2d/b2_contact.h
+++ b/include/box2d/b2_contact.h
@@ -206,6 +206,8 @@ protected:
 
 	b2Contact() : m_fixtureA(nullptr), m_fixtureB(nullptr) {}
 	b2Contact(b2Fixture* fixtureA, int32 indexA, b2Fixture* fixtureB, int32 indexB);
+    b2Contact(const b2Contact&) = delete;
+    b2Contact& operator=(const b2Contact&) = delete;
 	virtual ~b2Contact() {}
 
 	void Update(b2ContactListener* listener);

--- a/include/box2d/b2_draw.h
+++ b/include/box2d/b2_draw.h
@@ -50,6 +50,9 @@ class B2_API b2Draw
 public:
 	b2Draw();
 
+    b2Draw(const b2Draw&) = default;
+    b2Draw& operator=(const b2Draw&) = default;
+
 	virtual ~b2Draw() {}
 
 	enum

--- a/include/box2d/b2_dynamic_tree.h
+++ b/include/box2d/b2_dynamic_tree.h
@@ -71,6 +71,9 @@ public:
 	/// Constructing the tree initializes the node pool.
 	b2DynamicTree();
 
+    b2DynamicTree(const b2DynamicTree&) = delete;
+    b2DynamicTree& operator=(const b2DynamicTree&) = delete;
+
 	/// Destroy the tree, freeing the node pool.
 	~b2DynamicTree();
 

--- a/include/box2d/b2_growable_stack.h
+++ b/include/box2d/b2_growable_stack.h
@@ -41,6 +41,9 @@ public:
 		m_capacity = N;
 	}
 
+    b2GrowableStack(const b2GrowableStack&) = delete;
+    b2GrowableStack& operator=(const b2GrowableStack&) = delete;
+
 	~b2GrowableStack()
 	{
 		if (m_stack != m_array)

--- a/include/box2d/b2_joint.h
+++ b/include/box2d/b2_joint.h
@@ -166,6 +166,8 @@ protected:
 	static void Destroy(b2Joint* joint, b2BlockAllocator* allocator);
 
 	b2Joint(const b2JointDef* def);
+    b2Joint(const b2Joint&) = delete;
+    b2Joint& operator=(const b2Joint&) = delete;
 	virtual ~b2Joint() {}
 
 	virtual void InitVelocityConstraints(const b2SolverData& data) = 0;

--- a/include/box2d/b2_rope.h
+++ b/include/box2d/b2_rope.h
@@ -104,6 +104,8 @@ class B2_API b2Rope
 {
 public:
 	b2Rope();
+    b2Rope(const b2Rope&) = delete;
+    b2Rope& operator=(const b2Rope&) = delete;
 	~b2Rope();
 
 	///

--- a/include/box2d/b2_shape.h
+++ b/include/box2d/b2_shape.h
@@ -58,6 +58,10 @@ public:
 		e_typeCount = 4
 	};
 
+    b2Shape() = default;
+    b2Shape(const b2Shape&) = default;
+    b2Shape& operator=(const b2Shape&) = default;
+
 	virtual ~b2Shape() {}
 
 	/// Clone the concrete shape using the provided allocator.

--- a/include/box2d/b2_stack_allocator.h
+++ b/include/box2d/b2_stack_allocator.h
@@ -43,6 +43,8 @@ class B2_API b2StackAllocator
 {
 public:
 	b2StackAllocator();
+    b2StackAllocator(const b2StackAllocator&) = delete;
+    b2StackAllocator& operator=(const b2StackAllocator&) = delete;
 	~b2StackAllocator();
 
 	void* Allocate(int32 size);

--- a/include/box2d/b2_world.h
+++ b/include/box2d/b2_world.h
@@ -50,6 +50,9 @@ public:
 	/// @param gravity the world gravity vector.
 	b2World(const b2Vec2& gravity);
 
+    b2World(const b2World&) = delete;
+    b2World& operator=(const b2World&) = delete;
+
 	/// Destruct the world. All physics entities are destroyed and all heap memory is released.
 	~b2World();
 

--- a/include/box2d/b2_world_callbacks.h
+++ b/include/box2d/b2_world_callbacks.h
@@ -41,6 +41,9 @@ struct b2Manifold;
 class B2_API b2DestructionListener
 {
 public:
+    b2DestructionListener() = default;
+    b2DestructionListener(const b2DestructionListener&) = default;
+    b2DestructionListener& operator=(const b2DestructionListener&) = default;
 	virtual ~b2DestructionListener() {}
 
 	/// Called when any joint is about to be destroyed due
@@ -57,6 +60,9 @@ public:
 class B2_API b2ContactFilter
 {
 public:
+    b2ContactFilter() = default;
+    b2ContactFilter(const b2ContactFilter&) = default;
+    b2ContactFilter& operator=(const b2ContactFilter&) = default;
 	virtual ~b2ContactFilter() {}
 
 	/// Return true if contact calculations should be performed between these two shapes.
@@ -86,6 +92,9 @@ struct B2_API b2ContactImpulse
 class B2_API b2ContactListener
 {
 public:
+    b2ContactListener() = default;
+    b2ContactListener(const b2ContactListener&) = default;
+    b2ContactListener& operator=(const b2ContactListener&) = default;
 	virtual ~b2ContactListener() {}
 
 	/// Called when two fixtures begin to touch.
@@ -128,6 +137,9 @@ public:
 class B2_API b2QueryCallback
 {
 public:
+    b2QueryCallback() = default;
+    b2QueryCallback(const b2QueryCallback&) = default;
+    b2QueryCallback& operator=(const b2QueryCallback&) = default;
 	virtual ~b2QueryCallback() {}
 
 	/// Called for each fixture found in the query AABB.
@@ -140,6 +152,9 @@ public:
 class B2_API b2RayCastCallback
 {
 public:
+    b2RayCastCallback() = default;
+    b2RayCastCallback(const b2RayCastCallback&) = default;
+    b2RayCastCallback& operator=(const b2RayCastCallback&) = default;
 	virtual ~b2RayCastCallback() {}
 
 	/// Called for each fixture found in the query. You control how the ray cast

--- a/src/dynamics/b2_chain_circle_contact.h
+++ b/src/dynamics/b2_chain_circle_contact.h
@@ -35,7 +35,6 @@ public:
 	static void Destroy(b2Contact* contact, b2BlockAllocator* allocator);
 
 	b2ChainAndCircleContact(b2Fixture* fixtureA, int32 indexA, b2Fixture* fixtureB, int32 indexB);
-	~b2ChainAndCircleContact() {}
 
 	void Evaluate(b2Manifold* manifold, const b2Transform& xfA, const b2Transform& xfB) override;
 };

--- a/src/dynamics/b2_chain_polygon_contact.h
+++ b/src/dynamics/b2_chain_polygon_contact.h
@@ -35,7 +35,6 @@ public:
 	static void Destroy(b2Contact* contact, b2BlockAllocator* allocator);
 
 	b2ChainAndPolygonContact(b2Fixture* fixtureA, int32 indexA, b2Fixture* fixtureB, int32 indexB);
-	~b2ChainAndPolygonContact() {}
 
 	void Evaluate(b2Manifold* manifold, const b2Transform& xfA, const b2Transform& xfB) override;
 };

--- a/src/dynamics/b2_circle_contact.h
+++ b/src/dynamics/b2_circle_contact.h
@@ -35,7 +35,6 @@ public:
 	static void Destroy(b2Contact* contact, b2BlockAllocator* allocator);
 
 	b2CircleContact(b2Fixture* fixtureA, b2Fixture* fixtureB);
-	~b2CircleContact() {}
 
 	void Evaluate(b2Manifold* manifold, const b2Transform& xfA, const b2Transform& xfB) override;
 };

--- a/src/dynamics/b2_contact_solver.h
+++ b/src/dynamics/b2_contact_solver.h
@@ -75,6 +75,8 @@ class b2ContactSolver
 {
 public:
 	b2ContactSolver(b2ContactSolverDef* def);
+    b2ContactSolver(const b2ContactSolver&) = delete;
+    b2ContactSolver& operator=(const b2ContactSolver&) = delete;
 	~b2ContactSolver();
 
 	void InitializeVelocityConstraints();
@@ -97,4 +99,3 @@ public:
 };
 
 #endif
-

--- a/src/dynamics/b2_edge_circle_contact.h
+++ b/src/dynamics/b2_edge_circle_contact.h
@@ -35,7 +35,6 @@ public:
 	static void Destroy(b2Contact* contact, b2BlockAllocator* allocator);
 
 	b2EdgeAndCircleContact(b2Fixture* fixtureA, b2Fixture* fixtureB);
-	~b2EdgeAndCircleContact() {}
 
 	void Evaluate(b2Manifold* manifold, const b2Transform& xfA, const b2Transform& xfB) override;
 };

--- a/src/dynamics/b2_edge_polygon_contact.h
+++ b/src/dynamics/b2_edge_polygon_contact.h
@@ -35,7 +35,6 @@ public:
 	static void Destroy(b2Contact* contact, b2BlockAllocator* allocator);
 
 	b2EdgeAndPolygonContact(b2Fixture* fixtureA, b2Fixture* fixtureB);
-	~b2EdgeAndPolygonContact() {}
 
 	void Evaluate(b2Manifold* manifold, const b2Transform& xfA, const b2Transform& xfB) override;
 };

--- a/src/dynamics/b2_island.h
+++ b/src/dynamics/b2_island.h
@@ -40,6 +40,8 @@ class b2Island
 public:
 	b2Island(int32 bodyCapacity, int32 contactCapacity, int32 jointCapacity,
 			b2StackAllocator* allocator, b2ContactListener* listener);
+    b2Island(const b2Island&) = delete;
+    b2Island& operator=(const b2Island&) = delete;
 	~b2Island();
 
 	void Clear()

--- a/src/dynamics/b2_polygon_circle_contact.h
+++ b/src/dynamics/b2_polygon_circle_contact.h
@@ -34,7 +34,6 @@ public:
 	static void Destroy(b2Contact* contact, b2BlockAllocator* allocator);
 
 	b2PolygonAndCircleContact(b2Fixture* fixtureA, b2Fixture* fixtureB);
-	~b2PolygonAndCircleContact() {}
 
 	void Evaluate(b2Manifold* manifold, const b2Transform& xfA, const b2Transform& xfB) override;
 };

--- a/src/dynamics/b2_polygon_contact.h
+++ b/src/dynamics/b2_polygon_contact.h
@@ -35,7 +35,6 @@ public:
 	static void Destroy(b2Contact* contact, b2BlockAllocator* allocator);
 
 	b2PolygonContact(b2Fixture* fixtureA, b2Fixture* fixtureB);
-	~b2PolygonContact() {}
 
 	void Evaluate(b2Manifold* manifold, const b2Transform& xfA, const b2Transform& xfB) override;
 };

--- a/testbed/draw.h
+++ b/testbed/draw.h
@@ -57,6 +57,8 @@ class DebugDraw : public b2Draw
 {
 public:
 	DebugDraw();
+    DebugDraw(const DebugDraw&) = delete;
+    DebugDraw& operator=(const DebugDraw&) = delete;
 	~DebugDraw();
 
 	void Create();
@@ -76,7 +78,7 @@ public:
 
 	void DrawPoint(const b2Vec2& p, float size, const b2Color& color) override;
 
-	void DrawString(int x, int y, const char* string, ...); 
+	void DrawString(int x, int y, const char* string, ...);
 
 	void DrawString(const b2Vec2& p, const char* string, ...);
 

--- a/testbed/test.h
+++ b/testbed/test.h
@@ -82,6 +82,8 @@ class Test : public b2ContactListener
 public:
 
 	Test();
+    Test(const Test&) = delete;
+    Test& operator=(const Test&) = delete;
 	virtual ~Test();
 
 	void DrawTitle(const char* string);
@@ -95,7 +97,7 @@ public:
 	virtual void MouseMove(const b2Vec2& p);
 	void LaunchBomb();
 	void LaunchBomb(const b2Vec2& position, const b2Vec2& velocity);
-	
+
 	void SpawnBomb(const b2Vec2& worldPt);
 	void CompleteBombSpawn(const b2Vec2& p);
 

--- a/unit-test/joint_test.cpp
+++ b/unit-test/joint_test.cpp
@@ -27,7 +27,7 @@
 DOCTEST_TEST_CASE("joint reactions")
 {
 	b2Vec2 gravity(0, -10.0f);
-	b2World world = b2World(gravity);
+	b2World world{gravity};
 
 	b2BodyDef bodyDef;
 	b2Body* ground = world.CreateBody(&bodyDef);

--- a/unit-test/world_test.cpp
+++ b/unit-test/world_test.cpp
@@ -37,7 +37,7 @@ public:
 
 DOCTEST_TEST_CASE("begin contact")
 {
-	b2World world = b2World(b2Vec2(0.0f, -10.0f));
+	b2World world{b2Vec2(0.0f, -10.0f)};
 	MyContactListener listener;
 	world.SetContactListener(&listener);
 
@@ -63,7 +63,7 @@ DOCTEST_TEST_CASE("begin contact")
 
 	CHECK(world.GetContactList() == nullptr);
 	CHECK(begin_contact == false);
-	
+
 	bodyB->SetTransform(b2Vec2(1.f, 0.f), 0.f);
 
 	world.Step(timeStep, velocityIterations, positionIterations);


### PR DESCRIPTION
Fixes #711 

I went over all classes with custom destructors, and `=delete`d or `=default`ed their copy operations. In cases where that would remove the default constructor, I added it back.