### PR TITLE
Change two double literals to float literals

### DIFF
--- a/src/dynamics/b2_contact_solver.cpp
+++ b/src/dynamics/b2_contact_solver.cpp
@@ -775,7 +775,7 @@ bool b2ContactSolver::SolveTOIPositionConstraints(int32 toiIndexA, int32 toiInde
 		}
 
 		float mB = 0.0f;
-		float iB = 0.;
+		float iB = 0.0f;
 		if (indexB == toiIndexA || indexB == toiIndexB)
 		{
 			mB = pc->invMassB;

--- a/src/rope/b2_rope.cpp
+++ b/src/rope/b2_rope.cpp
@@ -243,7 +243,7 @@ void b2Rope::SetTuning(const b2RopeTuning& tuning)
 
 void b2Rope::Step(float dt, int32 iterations, const b2Vec2& position)
 {
-	if (dt == 0.0)
+	if (dt == 0.0f)
 	{
 		return;
 	}


### PR DESCRIPTION
There are two instances of the double-literal `0.0` being used to assign/compare to float values (in `b2_contact_solver.cpp` and `b2_rope.cpp`).