### PR TITLE
removed unused variables in b2_collision.cpp

### DIFF
--- a/src/collision/b2_collision.cpp
+++ b/src/collision/b2_collision.cpp
@@ -492,7 +492,6 @@ b2Hull b2ComputeHull(const b2Vec2* points, int32 count)
 			b2Vec2 e = p3 - p1;
 			e.Normalize();
 
-			b2Vec2 v = p2 - p1;
 			float distance = b2Cross(p2 - p1, e);
 			if (distance <= 2.0f * b2_linearSlop)
 			{
@@ -567,7 +566,6 @@ bool b2ValidateHull(const b2Hull& hull)
 		b2Vec2 e = p3 - p1;
 		e.Normalize();
 
-		b2Vec2 v = p2 - p1;
 		float distance = b2Cross(p2 - p1, e);
 		if (distance <= b2_linearSlop)
 		{


### PR DESCRIPTION
These 2 unused variables were throwing some warnings, so I decided to remove them. 
depending on compiler optimization (probably only issue in debug) in removing or not these variables this might save a b2Vec2 subtraction operation as well.