### PR TITLE
Fix null being passed to memcpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 # Box2D 
 Box2D is a 2D physics engine for games.
 
+[![Box2D Version 3.0 Release Demo](https://img.youtube.com/vi/dAoM-xjOWtA/0.jpg)](https://www.youtube.com/watch?v=dAoM-xjOWtA)
+
 ## Features
 
 ### Collision

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -343,6 +343,7 @@ typedef struct b2ShapeDef
 	/// Normally shapes on static bodies don't invoke contact creation when they are added to the world. This overrides
 	///	that behavior and causes contact creation. This significantly slows down static body creation which can be important
 	///	when there are many static shapes.
+	/// This is implicitly always true for sensors.
 	bool forceContactCreation;
 
 	/// Used internally to detect a valid definition. DO NOT SET.

--- a/samples/sample_continuous.cpp
+++ b/samples/sample_continuous.cpp
@@ -67,6 +67,8 @@ public:
 		m_bodyId = b2_nullBodyId;
 		m_enableHitEvents = true;
 
+		memset( m_hitEvents, 0, sizeof( m_hitEvents ) );
+
 		Launch();
 	}
 

--- a/src/bitset.c
+++ b/src/bitset.c
@@ -49,7 +49,8 @@ void b2GrowBitSet( b2BitSet* bitSet, uint32_t blockCount )
 		bitSet->blockCapacity = blockCount + blockCount / 2;
 		uint64_t* newBits = b2Alloc( bitSet->blockCapacity * sizeof( uint64_t ) );
 		memset( newBits, 0, bitSet->blockCapacity * sizeof( uint64_t ) );
-		memcpy( newBits, bitSet->bits, bitSet->blockCount * sizeof( uint64_t ) );
+		B2_ASSERT( bitSet->bits != NULL );
+		memcpy( newBits, bitSet->bits, oldCapacity * sizeof( uint64_t ) );
 		b2Free( bitSet->bits, oldCapacity * sizeof( uint64_t ) );
 		bitSet->bits = newBits;
 	}

--- a/src/bitset.h
+++ b/src/bitset.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-// Bit set provides fast operations on large arrays of bits
+// Bit set provides fast operations on large arrays of bits.
 typedef struct b2BitSet
 {
 	uint64_t* bits;

--- a/src/block_array.c
+++ b/src/block_array.c
@@ -102,6 +102,7 @@ b2BodySim* b2AddBodySim( b2BodySimArray* array )
 	{
 		int newCapacity = 2 * array->capacity;
 		b2BodySim* newElements = b2Alloc( newCapacity * elementSize );
+		B2_ASSERT( array->data != NULL );
 		memcpy( newElements, array->data, array->capacity * elementSize );
 		b2Free( array->data, array->capacity * elementSize );
 		array->data = newElements;
@@ -126,6 +127,7 @@ b2BodyState* b2AddBodyState( b2BodyStateArray* array )
 	{
 		int newCapacity = 2 * array->capacity;
 		b2BodyState* newElements = b2Alloc( newCapacity * elementSize );
+		B2_ASSERT( array->data != NULL );
 		memcpy( newElements, array->data, array->capacity * elementSize );
 		b2Free( array->data, array->capacity * elementSize );
 		array->data = newElements;
@@ -150,6 +152,7 @@ b2ContactSim* b2AddContact( b2ContactArray* array )
 	{
 		int newCapacity = 2 * array->capacity;
 		b2ContactSim* newElements = b2Alloc( newCapacity * elementSize );
+		B2_ASSERT( array->data != NULL );
 		memcpy( newElements, array->data, array->capacity * elementSize );
 		b2Free( array->data, array->capacity * elementSize );
 		array->data = newElements;
@@ -174,6 +177,7 @@ b2JointSim* b2AddJoint( b2JointArray* array )
 	{
 		int newCapacity = 2 * array->capacity;
 		b2JointSim* newElements = b2Alloc( newCapacity * elementSize );
+		B2_ASSERT( array->data != NULL );
 		memcpy( newElements, array->data, array->capacity * elementSize );
 		b2Free( array->data, array->capacity * elementSize );
 		array->data = newElements;
@@ -198,6 +202,7 @@ b2IslandSim* b2AddIsland( b2IslandArray* array )
 	{
 		int newCapacity = 2 * array->capacity;
 		b2IslandSim* newElements = b2Alloc( newCapacity * elementSize );
+		B2_ASSERT( array->data != NULL );
 		memcpy( newElements, array->data, array->capacity * elementSize );
 		b2Free( array->data, array->capacity * elementSize );
 		array->data = newElements;

--- a/src/constraint_graph.h
+++ b/src/constraint_graph.h
@@ -22,8 +22,9 @@ typedef struct b2World b2World;
 
 typedef struct b2GraphColor
 {
-	// base on bodyId so this is over-sized to encompass static bodies
+	// This bitset is indexed by bodyId so this is over-sized to encompass static bodies
 	// however I never traverse these bits or use the bit count for anything
+	// This bitset is unused on the overflow color.
 	b2BitSet bodySet;
 
 	// cache friendly arrays

--- a/src/dynamic_tree.c
+++ b/src/dynamic_tree.c
@@ -87,6 +87,7 @@ static int32_t b2AllocateNode( b2DynamicTree* tree )
 		int32_t oldCapcity = tree->nodeCapacity;
 		tree->nodeCapacity += oldCapcity >> 1;
 		tree->nodes = (b2TreeNode*)b2Alloc( tree->nodeCapacity * sizeof( b2TreeNode ) );
+		B2_ASSERT( oldNodes != NULL );
 		memcpy( tree->nodes, oldNodes, tree->nodeCount * sizeof( b2TreeNode ) );
 		b2Free( oldNodes, oldCapcity * sizeof( b2TreeNode ) );
 

--- a/src/shape.c
+++ b/src/shape.c
@@ -131,7 +131,7 @@ static b2Shape* b2CreateShapeInternal( b2World* world, b2Body* body, b2Transform
 	if ( body->setIndex != b2_disabledSet )
 	{
 		b2BodyType proxyType = body->type;
-		b2CreateShapeProxy( shape, &world->broadPhase, proxyType, transform, def->forceContactCreation );
+		b2CreateShapeProxy( shape, &world->broadPhase, proxyType, transform, def->forceContactCreation || def->isSensor );
 	}
 
 	// Add to shape doubly linked list


### PR DESCRIPTION
Joints were incorrectly using the body bit-set for the overflow color.

