### PR TITLE
Fix: Implicit conversions since Box2D treats warnings as errors.

### DIFF
--- a/src/dynamic_tree.c
+++ b/src/dynamic_tree.c
@@ -1013,7 +1013,7 @@ int32_t b2DynamicTree_GetMaxBalance( const b2DynamicTree* tree )
 
 		int32_t child1 = node->child1;
 		int32_t child2 = node->child2;
-		int32_t balance = b2AbsFloat( tree->nodes[child2].height - tree->nodes[child1].height );
+		int32_t balance = (int32_t)b2AbsFloat( (float)(tree->nodes[child2].height - tree->nodes[child1].height) );
 		maxBalance = b2MaxInt( maxBalance, balance );
 	}
 

--- a/src/hull.c
+++ b/src/hull.c
@@ -94,7 +94,7 @@ b2Hull b2ComputeHull( const b2Vec2* points, int count )
 		return hull;
 	}
 
-	count = b2MinFloat( count, b2_maxPolygonVertices );
+	count = (int)b2MinFloat( (float)count, b2_maxPolygonVertices );
 
 	b2AABB aabb = { { FLT_MAX, FLT_MAX }, { -FLT_MAX, -FLT_MAX } };
 

--- a/src/manifold.c
+++ b/src/manifold.c
@@ -328,7 +328,7 @@ b2Manifold b2CollideCapsules( const b2Capsule* capsuleA, b2Transform xfA, const 
 		return manifold;
 	}
 
-	float distance = sqrt( distanceSquared );
+	float distance = sqrtf( distanceSquared );
 
 	float length1, length2;
 	b2Vec2 u1 = b2GetLengthAndNormalize( &length1, d1 );

--- a/src/world.c
+++ b/src/world.c
@@ -304,7 +304,7 @@ static void b2CollideTask( int startIndex, int endIndex, uint32_t threadIndex, v
 
 	b2StepContext* stepContext = context;
 	b2World* world = stepContext->world;
-	B2_ASSERT( threadIndex < world->workerCount );
+	B2_ASSERT( (int)threadIndex < world->workerCount );
 	b2TaskContext* taskContext = world->taskContexts.data + threadIndex;
 	b2ContactSim** contactSims = stepContext->contacts;
 	b2Shape* shapes = world->shapes.data;


### PR DESCRIPTION
Since Box2D treats warnings as errors, (at least with use of `CMake`) CMake generates `/Wx` parameter for MSVC.
And implicit conversions give warning (at least in MSVC), I get error and this PR fixes that. 
It's really relatively basic and simple thing and won't break anything, just to suppress compiler errors due to implicit conversion.
  
