### PR TITLE
Event bookend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,12 @@ if (MSVC OR APPLE)
 			add_compile_options(-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined)
 			add_link_options(-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined)
 		endif()
+	else()
+		if(MSVC)
+			# enable hot reloading
+			add_compile_options("$<$<CONFIG:Debug>:/ZI>")
+			add_link_options("$<$<CONFIG:Debug>:/INCREMENTAL>")
+		endif()
 	endif()
 endif()
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -123,6 +123,7 @@ of the time step:
 
 - body movement events
 - contact begin and end events
+- sensor begin and end events
 - contact hit events
 
 These events allow your application to react to changes in the simulation.

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -969,16 +969,21 @@ typedef struct b2SensorBeginTouchEvent
 } b2SensorBeginTouchEvent;
 
 /// An end touch event is generated when a shape stops overlapping a sensor shape.
-///	You will not get an end event if you do anything that destroys contacts outside
-///	of the world step. These include things like setting the transform, destroying a body
+///	You will get an end event if you do anything that destroys contacts previous to the last
+///	world step.  These include things like setting the transform, destroying a body
 ///	or shape, or changing a filter or body type.
 typedef struct b2SensorEndTouchEvent
 {
 	/// The id of the sensor shape
+	///	@warning this shape may have been destroyed
+	///	@see b2Shape_IsValid
 	b2ShapeId sensorShapeId;
 
 	/// The id of the dynamic shape that stopped touching the sensor shape
+	///	@warning this shape may have been destroyed
+	///	@see b2Shape_IsValid
 	b2ShapeId visitorShapeId;
+
 } b2SensorEndTouchEvent;
 
 /// Sensor events are buffered in the Box2D world and are available
@@ -1013,15 +1018,19 @@ typedef struct b2ContactBeginTouchEvent
 } b2ContactBeginTouchEvent;
 
 /// An end touch event is generated when two shapes stop touching.
-///	You will not get an end event if you do anything that destroys contacts outside
-///	of the world step. These include things like setting the transform, destroying a body
+///	You will get an end event if you do anything that destroys contacts previous to the last
+///	world step. These include things like setting the transform, destroying a body
 ///	or shape, or changing a filter or body type.
 typedef struct b2ContactEndTouchEvent
 {
 	/// Id of the first shape
+	///	@warning this shape may have been destroyed
+	///	@see b2Shape_IsValid
 	b2ShapeId shapeIdA;
 
 	/// Id of the second shape
+	///	@warning this shape may have been destroyed
+	///	@see b2Shape_IsValid
 	b2ShapeId shapeIdB;
 } b2ContactEndTouchEvent;
 

--- a/samples/sample_events.cpp
+++ b/samples/sample_events.cpp
@@ -14,7 +14,7 @@
 #include <imgui.h>
 #include <vector>
 
-class SensorEvent : public Sample
+class SensorFunnel : public Sample
 {
 public:
 	enum
@@ -24,7 +24,7 @@ public:
 		e_count = 32
 	};
 
-	explicit SensorEvent( Settings& settings )
+	explicit SensorFunnel( Settings& settings )
 		: Sample( settings )
 	{
 		if ( settings.restart == false )
@@ -56,7 +56,7 @@ public:
 				{ -8.26825142, 11.906374 },	 { -16.8672504, 17.1978741 },
 			};
 
-			int count = sizeof( points ) / sizeof( points[0] );
+			int count = std::size( points );
 
 			// float scale = 0.25f;
 			// b2Vec2 lower = {FLT_MAX, FLT_MAX};
@@ -101,7 +101,6 @@ public:
 			float y = 14.0f;
 			for ( int i = 0; i < 3; ++i )
 			{
-				b2BodyDef bodyDef = b2DefaultBodyDef();
 				bodyDef.position = { 0.0f, y };
 				bodyDef.type = b2_dynamicBody;
 
@@ -317,7 +316,7 @@ public:
 
 	static Sample* Create( Settings& settings )
 	{
-		return new SensorEvent( settings );
+		return new SensorFunnel( settings );
 	}
 
 	Human m_humans[e_count];
@@ -328,7 +327,146 @@ public:
 	float m_side;
 };
 
-static int sampleSensorEvent = RegisterSample( "Events", "Sensor", SensorEvent::Create );
+static int sampleSensorBeginEvent = RegisterSample( "Events", "Sensor Funnel", SensorFunnel::Create );
+
+class SensorBookend : public Sample
+{
+public:
+
+	explicit SensorBookend( Settings& settings )
+		: Sample( settings )
+	{
+		if ( settings.restart == false )
+		{
+			g_camera.m_center = { 0.0f, 8.0f };
+			g_camera.m_zoom = 10.0f;
+		}
+
+		{
+			b2BodyDef bodyDef = b2DefaultBodyDef();
+			b2BodyId groundId = b2CreateBody( m_worldId, &bodyDef );
+			b2ShapeDef shapeDef = b2DefaultShapeDef();
+
+			b2Segment groundSegment = { { -10.0f, 0.0f }, { 10.0f, 0.0f } };
+			b2CreateSegmentShape( groundId, &shapeDef, &groundSegment );
+
+			groundSegment = { { -10.0f, 0.0f }, { -10.0f, 10.0f } };
+			b2CreateSegmentShape( groundId, &shapeDef, &groundSegment );
+
+			groundSegment = { { 10.0f, 0.0f }, { 10.0f, 10.0f } };
+			b2CreateSegmentShape( groundId, &shapeDef, &groundSegment );
+
+			m_isVisiting = false;
+		}
+
+		CreateSensor();
+
+		CreateVisitor();
+	}
+
+	void CreateSensor()
+	{
+		b2BodyDef bodyDef = b2DefaultBodyDef();
+
+		bodyDef.position = { 0.0f, 1.0f };
+		m_sensorBodyId = b2CreateBody( m_worldId, &bodyDef );
+
+		b2ShapeDef shapeDef = b2DefaultShapeDef();
+		shapeDef.isSensor = true;
+		b2Polygon box = b2MakeSquare( 1.0f );
+		m_sensorShapeId = b2CreatePolygonShape( m_sensorBodyId, &shapeDef, &box );
+	}
+
+	void CreateVisitor()
+	{
+		b2BodyDef bodyDef = b2DefaultBodyDef();
+		bodyDef.position = {-4.0f, 1.0f };
+		bodyDef.type = b2_dynamicBody;
+
+		m_visitorBodyId = b2CreateBody( m_worldId, &bodyDef );
+
+		b2ShapeDef shapeDef = b2DefaultShapeDef();
+		shapeDef.enableSensorEvents = true;
+
+		b2Circle circle = { { 0.0f, 0.0f }, 0.5f };
+		m_visitorShapeId = b2CreateCircleShape( m_visitorBodyId, &shapeDef, &circle );
+	}
+
+	void UpdateUI() override
+	{
+		float height = 90.0f;
+		ImGui::SetNextWindowPos( ImVec2( 10.0f, g_camera.m_height - height - 50.0f ), ImGuiCond_Once );
+		ImGui::SetNextWindowSize( ImVec2( 140.0f, height ) );
+
+		ImGui::Begin( "Sensor Bookend", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize );
+
+		if ( B2_IS_NULL(m_visitorBodyId) )
+		{
+			if ( ImGui::Button( "create visitor" ) )
+			{
+				CreateVisitor();
+			}
+		}
+		else
+		{
+			if ( ImGui::Button( "destroy visitor" ) )
+			{
+				b2DestroyBody( m_visitorBodyId );
+				m_visitorBodyId = b2_nullBodyId;
+				m_visitorShapeId = b2_nullShapeId;
+			}
+		}
+
+		ImGui::End();
+	}
+
+	void Step( Settings& settings ) override
+	{
+		Sample::Step( settings );
+
+		b2SensorEvents sensorEvents = b2World_GetSensorEvents( m_worldId );
+		for ( int i = 0; i < sensorEvents.beginCount; ++i )
+		{
+			b2SensorBeginTouchEvent event = sensorEvents.beginEvents[i];
+			b2ShapeId visitorId = event.visitorShapeId;
+
+			if ( B2_ID_EQUALS(visitorId, m_visitorShapeId) )
+			{
+				assert( m_isVisiting == false );
+				m_isVisiting = true;
+			}
+		}
+
+		for ( int i = 0; i < sensorEvents.endCount; ++i )
+		{
+			b2SensorEndTouchEvent event = sensorEvents.endEvents[i];
+			b2ShapeId visitorId = event.visitorShapeId;
+
+			if ( B2_ID_EQUALS(visitorId, m_visitorShapeId) )
+			{
+				assert( m_isVisiting == true );
+				m_isVisiting = false;
+			}
+		}
+
+		g_draw.DrawString( 5, m_textLine, "visiting == %s", m_isVisiting ? "true" : "false" );
+		m_textLine += m_textIncrement;
+	}
+
+	static Sample* Create( Settings& settings )
+	{
+		return new SensorBookend( settings );
+	}
+
+	b2BodyId m_sensorBodyId;
+	b2ShapeId m_sensorShapeId;
+
+	b2BodyId m_visitorBodyId;
+	b2ShapeId m_visitorShapeId;
+	bool m_isVisiting;
+};
+
+static int sampleSensorBookendEvent = RegisterSample( "Events", "Sensor Bookend", SensorBookend::Create );
 
 struct BodyUserData
 {

--- a/samples/sample_events.cpp
+++ b/samples/sample_events.cpp
@@ -332,14 +332,13 @@ static int sampleSensorBeginEvent = RegisterSample( "Events", "Sensor Funnel", S
 class SensorBookend : public Sample
 {
 public:
-
 	explicit SensorBookend( Settings& settings )
 		: Sample( settings )
 	{
 		if ( settings.restart == false )
 		{
-			g_camera.m_center = { 0.0f, 8.0f };
-			g_camera.m_zoom = 10.0f;
+			g_camera.m_center = { 0.0f, 6.0f };
+			g_camera.m_zoom = 7.5f;
 		}
 
 		{
@@ -380,7 +379,7 @@ public:
 	void CreateVisitor()
 	{
 		b2BodyDef bodyDef = b2DefaultBodyDef();
-		bodyDef.position = {-4.0f, 1.0f };
+		bodyDef.position = { -4.0f, 1.0f };
 		bodyDef.type = b2_dynamicBody;
 
 		m_visitorBodyId = b2CreateBody( m_worldId, &bodyDef );
@@ -400,7 +399,7 @@ public:
 
 		ImGui::Begin( "Sensor Bookend", nullptr, ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize );
 
-		if ( B2_IS_NULL(m_visitorBodyId) )
+		if ( B2_IS_NULL( m_visitorBodyId ) )
 		{
 			if ( ImGui::Button( "create visitor" ) )
 			{
@@ -417,6 +416,23 @@ public:
 			}
 		}
 
+		if ( B2_IS_NULL( m_sensorBodyId ) )
+		{
+			if ( ImGui::Button( "create sensor" ) )
+			{
+				CreateSensor();
+			}
+		}
+		else
+		{
+			if ( ImGui::Button( "destroy sensor" ) )
+			{
+				b2DestroyBody( m_sensorBodyId );
+				m_sensorBodyId = b2_nullBodyId;
+				m_sensorShapeId = b2_nullShapeId;
+			}
+		}
+
 		ImGui::End();
 	}
 
@@ -428,9 +444,8 @@ public:
 		for ( int i = 0; i < sensorEvents.beginCount; ++i )
 		{
 			b2SensorBeginTouchEvent event = sensorEvents.beginEvents[i];
-			b2ShapeId visitorId = event.visitorShapeId;
 
-			if ( B2_ID_EQUALS(visitorId, m_visitorShapeId) )
+			if ( B2_ID_EQUALS( event.visitorShapeId, m_visitorShapeId ) )
 			{
 				assert( m_isVisiting == false );
 				m_isVisiting = true;
@@ -440,9 +455,9 @@ public:
 		for ( int i = 0; i < sensorEvents.endCount; ++i )
 		{
 			b2SensorEndTouchEvent event = sensorEvents.endEvents[i];
-			b2ShapeId visitorId = event.visitorShapeId;
 
-			if ( B2_ID_EQUALS(visitorId, m_visitorShapeId) )
+			bool wasVisitorDestroyed = b2Shape_IsValid( event.visitorShapeId ) == false;
+			if ( B2_ID_EQUALS( event.visitorShapeId, m_visitorShapeId ) || wasVisitorDestroyed )
 			{
 				assert( m_isVisiting == true );
 				m_isVisiting = false;
@@ -1065,7 +1080,8 @@ public:
 
 		b2ContactData contactData = {};
 		int contactCount = b2Body_GetContactData( m_platformId, &contactData, 1 );
-		g_draw.DrawString( 5, m_textLine, "Platform contact count = %d, point count = %d", contactCount, contactData.manifold.pointCount );
+		g_draw.DrawString( 5, m_textLine, "Platform contact count = %d, point count = %d", contactCount,
+						   contactData.manifold.pointCount );
 		m_textLine += m_textIncrement;
 
 		g_draw.DrawString( 5, m_textLine, "Movement: A/D/Space" );

--- a/src/contact.c
+++ b/src/contact.c
@@ -367,10 +367,31 @@ void b2DestroyContact( b2World* world, b2Contact* contact, bool wakeBodies )
 	b2Body* bodyA = b2BodyArray_Get( &world->bodies, bodyIdA );
 	b2Body* bodyB = b2BodyArray_Get( &world->bodies, bodyIdB );
 
-	// if (contactListener && contact->IsTouching())
-	//{
-	//	contactListener->EndContact(contact);
-	// }
+	const b2Shape* shapeA = b2ShapeArray_Get(&world->shapes, contact->shapeIdA);
+	const b2Shape* shapeB = b2ShapeArray_Get(&world->shapes, contact->shapeIdB);
+	b2ShapeId shapeIdA = { shapeA->id + 1, worldId, shapeA->revision };
+	b2ShapeId shapeIdB = { shapeB->id + 1, worldId, shapeB->revision };
+	uint32_t flags = contact->flags;
+
+					// Was touching?
+	if ( ( flags & b2_contactTouchingFlag ) != 0 && ( flags & b2_contactEnableContactEvents ) != 0 )
+	{
+		b2ContactEndTouchEvent event = { shapeIdA, shapeIdB };
+		b2ContactEndTouchEventArray_Push( &world->contactEndEvents, event );
+	}
+
+	if ( ( flags & b2_contactSensorTouchingFlag ) != 0 && ( flags & b2_contactEnableSensorEvents ) != 0 )
+	{
+		b2SensorEndTouchEvent event = { shapeIdA, shapeIdB };
+		b2SensorEndTouchEventArray_Push( &world->sensorEndEvents, event );
+	}
+
+
+	world->contactEndEvents;
+	if (contactListener && contact->IsTouching())
+	{
+		contactListener->EndContact(contact);
+	}
 
 	// Remove from body A
 	if ( edgeA->prevKey != B2_NULL_INDEX )

--- a/src/solver.c
+++ b/src/solver.c
@@ -1035,36 +1035,11 @@ static void b2SolveContinuous( b2World* world, int bodySimIndex )
 
 			if ( b2AABB_Contains( shape->fatAABB, aabb ) == false )
 			{
-#if 0
-				b2AABB fatAABB = aabb;
-				if ( deltax > 0.0f )
-				{
-					fatAABB.lowerBound.x -= aabbMargin;
-					fatAABB.upperBound.x += deltax + aabbMargin;
-				}
-				else
-				{
-					fatAABB.lowerBound.x += deltax - aabbMargin;
-					fatAABB.upperBound.x += aabbMargin;
-				}
-
-				if ( deltay > 0.0f )
-				{
-					fatAABB.lowerBound.y -= aabbMargin;
-					fatAABB.upperBound.y += deltay + aabbMargin;
-				}
-				else
-				{
-					fatAABB.lowerBound.y += deltay - aabbMargin;
-					fatAABB.upperBound.y += aabbMargin;
-				}
-#else
 				b2AABB fatAABB;
 				fatAABB.lowerBound.x = aabb.lowerBound.x - aabbMargin;
 				fatAABB.lowerBound.y = aabb.lowerBound.y - aabbMargin;
 				fatAABB.upperBound.x = aabb.upperBound.x + aabbMargin;
 				fatAABB.upperBound.y = aabb.upperBound.y + aabbMargin;
-#endif
 				shape->fatAABB = fatAABB;
 
 				shape->enlargedAABB = true;
@@ -1092,36 +1067,11 @@ static void b2SolveContinuous( b2World* world, int bodySimIndex )
 
 			if ( b2AABB_Contains( shape->fatAABB, shape->aabb ) == false )
 			{
-#if 0
-				b2AABB fatAABB = shape->aabb;
-				if ( deltax > 0.0f )
-				{
-					fatAABB.lowerBound.x -= aabbMargin;
-					fatAABB.upperBound.x += deltax + aabbMargin;
-				}
-				else
-				{
-					fatAABB.lowerBound.x += deltax - aabbMargin;
-					fatAABB.upperBound.x += aabbMargin;
-				}
-
-				if ( deltay > 0.0f )
-				{
-					fatAABB.lowerBound.y -= aabbMargin;
-					fatAABB.upperBound.y += deltay + aabbMargin;
-				}
-				else
-				{
-					fatAABB.lowerBound.y += deltay - aabbMargin;
-					fatAABB.upperBound.y += aabbMargin;
-				}
-#else
 				b2AABB fatAABB;
 				fatAABB.lowerBound.x = shape->aabb.lowerBound.x - aabbMargin;
 				fatAABB.lowerBound.y = shape->aabb.lowerBound.y - aabbMargin;
 				fatAABB.upperBound.x = shape->aabb.upperBound.x + aabbMargin;
 				fatAABB.upperBound.y = shape->aabb.upperBound.y + aabbMargin;
-#endif
 				shape->fatAABB = fatAABB;
 
 				shape->enlargedAABB = true;

--- a/src/world.h
+++ b/src/world.h
@@ -100,10 +100,15 @@ typedef struct b2World
 
 	b2BodyMoveEventArray bodyMoveEvents;
 	b2SensorBeginTouchEventArray sensorBeginEvents;
-	b2SensorEndTouchEventArray sensorEndEvents;
 	b2ContactBeginTouchEventArray contactBeginEvents;
-	b2ContactEndTouchEventArray contactEndEvents;
+
+	// End events are double buffered so that the user doesn't need to flush events
+	b2SensorEndTouchEventArray sensorEndEvents[2];
+	b2ContactEndTouchEventArray contactEndEvents[2];
+	int endEventArrayIndex;
+
 	b2ContactHitEventArray contactHitEvents;
+
 
 	// Used to track debug draw
 	b2BitSet debugBodySet;


### PR DESCRIPTION
Sensor and contact end touch events are now generated whenever a contact is destroyed via user operations, such as:
- destroying a body or shape
- changing filters
- changing body type
- disabling a body
- connecting bodies via joints

Enable hot reloading on MSVC.

