### PR TITLE
Fix uninitialized memory in dynamic_tree.c

### DIFF
--- a/src/dynamic_tree.c
+++ b/src/dynamic_tree.c
@@ -88,6 +88,7 @@ static int32_t b2AllocateNode( b2DynamicTree* tree )
 		tree->nodes = (b2TreeNode*)b2Alloc( tree->nodeCapacity * sizeof( b2TreeNode ) );
 		B2_ASSERT( oldNodes != NULL );
 		memcpy( tree->nodes, oldNodes, tree->nodeCount * sizeof( b2TreeNode ) );
+		memset( tree->nodes + tree->nodeCount, 0, tree->nodeCapacity * sizeof( b2TreeNode ) - tree->nodeCount * sizeof( b2TreeNode ) );
 		b2Free( oldNodes, oldCapcity * sizeof( b2TreeNode ) );
 
 		// Build a linked list for the free list. The parent pointer becomes the "next" pointer.


### PR DESCRIPTION
Pull requests for core Box2D code are generally not accepted. Please consider filing an issue instead.

This fixes that assert from being hit in debug builds
![image](https://github.com/user-attachments/assets/8b8f4c46-47c7-43f2-aad5-6111c3844fa1)
