### PR TITLE
Tunable joint stiffness

### DIFF
--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -149,13 +149,6 @@ B2_API void b2World_Explode( b2WorldId worldId, const b2ExplosionDef* explosionD
 /// @note Advanced feature
 B2_API void b2World_SetContactTuning( b2WorldId worldId, float hertz, float dampingRatio, float pushSpeed );
 
-/// Adjust joint tuning parameters
-/// @param worldId The world id
-/// @param hertz The joint stiffness (cycles per second)
-/// @param dampingRatio The joint bounciness with 1 being critical damping (non-dimensional)
-/// @note Advanced feature
-B2_API void b2World_SetJointTuning( b2WorldId worldId, float hertz, float dampingRatio );
-
 /// Set the maximum linear speed. Usually in m/s.
 B2_API void b2World_SetMaximumLinearSpeed( b2WorldId worldId, float maximumLinearSpeed );
 
@@ -802,6 +795,15 @@ B2_API float b2Joint_GetLinearSeparation( b2JointId jointId );
 
 /// Get the current angular separation error for this joint. Does not consider admissible movement. Usually in meters.
 B2_API float b2Joint_GetAngularSeparation( b2JointId jointId );
+
+/// Get the joint constraint tuning. Advanced feature.
+B2_API void b2Joint_GetConstraintTuning( b2JointId jointId, float* hertz, float* dampingRatio );
+
+/// Set the joint constraint tuning. Advanced feature.
+/// @param jointId the joint
+/// @param hertz the stiffness in Hertz (cycles per second)
+/// @param dampingRatio the non-dimensional damping ratio (one for critical damping)
+B2_API void b2Joint_SetConstraintTuning( b2JointId jointId, float hertz, float dampingRatio );
 
 /**
  * @defgroup distance_joint Distance Joint

--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -151,8 +151,8 @@ B2_API void b2World_SetContactTuning( b2WorldId worldId, float hertz, float damp
 
 /// Adjust joint tuning parameters
 /// @param worldId The world id
-/// @param hertz The contact stiffness (cycles per second)
-/// @param dampingRatio The contact bounciness with 1 being critical damping (non-dimensional)
+/// @param hertz The joint stiffness (cycles per second)
+/// @param dampingRatio The joint bounciness with 1 being critical damping (non-dimensional)
 /// @note Advanced feature
 B2_API void b2World_SetJointTuning( b2WorldId worldId, float hertz, float dampingRatio );
 
@@ -764,6 +764,18 @@ B2_API void b2Joint_SetLocalAnchorB( b2JointId jointId, b2Vec2 localAnchor );
 /// Get the local anchor on bodyB
 B2_API b2Vec2 b2Joint_GetLocalAnchorB( b2JointId jointId );
 
+/// Get the weld joint reference angle in radians (revolute, prismatic, and weld)
+B2_API float b2Joint_GetReferenceAngle( b2JointId jointId );
+
+/// Set the weld joint reference angle in radians, must be in [-pi,pi]. (revolute, prismatic, and weld)
+B2_API void b2Joint_SetReferenceAngle( b2JointId jointId, float angleInRadians );
+
+/// Set the local axis on bodyA (prismatic and wheel)
+B2_API void b2Joint_SetLocalAxisA( b2JointId jointId, b2Vec2 localAxis );
+
+/// Get the local axis on bodyA (prismatic and wheel)
+B2_API b2Vec2 b2Joint_GetLocalAxisA( b2JointId jointId );
+
 /// Toggle collision between connected bodies
 B2_API void b2Joint_SetCollideConnected( b2JointId jointId, bool shouldCollide );
 
@@ -1147,12 +1159,6 @@ B2_API float b2RevoluteJoint_GetMaxMotorTorque( b2JointId jointId );
 /// Create a weld joint
 /// @see b2WeldJointDef for details
 B2_API b2JointId b2CreateWeldJoint( b2WorldId worldId, const b2WeldJointDef* def );
-
-/// Get the weld joint reference angle in radians
-B2_API float b2WeldJoint_GetReferenceAngle( b2JointId jointId );
-
-/// Set the weld joint reference angle in radians, must be in [-pi,pi].
-B2_API void b2WeldJoint_SetReferenceAngle( b2JointId jointId, float angleInRadians );
 
 /// Set the weld joint linear stiffness in Hertz. 0 is rigid.
 B2_API void b2WeldJoint_SetLinearHertz( b2JointId jointId, float hertz );

--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -757,10 +757,10 @@ B2_API void b2Joint_SetLocalAnchorB( b2JointId jointId, b2Vec2 localAnchor );
 /// Get the local anchor on bodyB
 B2_API b2Vec2 b2Joint_GetLocalAnchorB( b2JointId jointId );
 
-/// Get the weld joint reference angle in radians (revolute, prismatic, and weld)
+/// Get the joint reference angle in radians (revolute, prismatic, and weld)
 B2_API float b2Joint_GetReferenceAngle( b2JointId jointId );
 
-/// Set the weld joint reference angle in radians, must be in [-pi,pi]. (revolute, prismatic, and weld)
+/// Set the joint reference angle in radians, must be in [-pi,pi]. (revolute, prismatic, and weld)
 B2_API void b2Joint_SetReferenceAngle( b2JointId jointId, float angleInRadians );
 
 /// Set the local axis on bodyA (prismatic and wheel)

--- a/include/box2d/collision.h
+++ b/include/box2d/collision.h
@@ -518,10 +518,6 @@ typedef struct b2ManifoldPoint
 	/// The friction impulse
 	float tangentImpulse;
 
-	/// todo_erin testing
-	float previousNormalImpulse;
-	float previousTangentImpulse;
-
 	/// The total normal impulse applied across sub-stepping and restitution. This is important
 	/// to identify speculative contact points that had an interaction in the time step.
 	float totalNormalImpulse;

--- a/include/box2d/collision.h
+++ b/include/box2d/collision.h
@@ -518,6 +518,10 @@ typedef struct b2ManifoldPoint
 	/// The friction impulse
 	float tangentImpulse;
 
+	/// todo_erin testing
+	float previousNormalImpulse;
+	float previousTangentImpulse;
+
 	/// The total normal impulse applied across sub-stepping and restitution. This is important
 	/// to identify speculative contact points that had an interaction in the time step.
 	float totalNormalImpulse;
@@ -813,18 +817,18 @@ typedef struct b2CollisionPlane
 /// Result returned by b2SolvePlanes
 typedef struct b2PlaneSolverResult
 {
-	/// The final position of the mover
-	b2Vec2 position;
+	/// The translation of the mover
+	b2Vec2 translation;
 
 	/// The number of iterations used by the plane solver. For diagnostics.
 	int iterationCount;
 } b2PlaneSolverResult;
 
 /// Solves the position of a mover that satisfies the given collision planes.
-/// @param position this must be the position used to generate the collision planes
+/// @param targetDelta the desired movement from the position used to generate the collision planes
 /// @param planes the collision planes
 /// @param count the number of collision planes
-B2_API b2PlaneSolverResult b2SolvePlanes( b2Vec2 position, b2CollisionPlane* planes, int count );
+B2_API b2PlaneSolverResult b2SolvePlanes( b2Vec2 targetDelta, b2CollisionPlane* planes, int count );
 
 /// Clips the velocity against the given collision planes. Planes with zero push or clipVelocity
 /// set to false are skipped.

--- a/include/box2d/id.h
+++ b/include/box2d/id.h
@@ -89,6 +89,19 @@ static const b2JointId b2_nullJointId = B2_ZERO_INIT;
 /// Compare two ids for equality. Doesn't work for b2WorldId.
 #define B2_ID_EQUALS( id1, id2 ) ( id1.index1 == id2.index1 && id1.world0 == id2.world0 && id1.generation == id2.generation )
 
+/// Store a world id into a uint32_t.
+B2_INLINE uint32_t b2StoreWorldId( b2WorldId id )
+{
+	return ( (uint32_t)id.index1 << 16 ) | (uint32_t)id.generation;
+}
+
+/// Load a uint32_t into a body id.
+B2_INLINE b2WorldId b2LoadWorldId( uint32_t x )
+{
+	b2WorldId id = { (uint16_t)( x >> 16 ), (uint16_t)( x ) };
+	return id;
+}
+
 /// Store a body id into a uint64_t.
 B2_INLINE uint64_t b2StoreBodyId( b2BodyId id )
 {

--- a/include/box2d/id.h
+++ b/include/box2d/id.h
@@ -95,7 +95,7 @@ B2_INLINE uint32_t b2StoreWorldId( b2WorldId id )
 	return ( (uint32_t)id.index1 << 16 ) | (uint32_t)id.generation;
 }
 
-/// Load a uint32_t into a body id.
+/// Load a uint32_t into a world id.
 B2_INLINE b2WorldId b2LoadWorldId( uint32_t x )
 {
 	b2WorldId id = { (uint16_t)( x >> 16 ), (uint16_t)( x ) };

--- a/include/box2d/math_functions.h
+++ b/include/box2d/math_functions.h
@@ -645,6 +645,18 @@ B2_INLINE float b2PlaneSeparation( b2Plane plane, b2Vec2 point )
 	return b2Dot( plane.normal, point ) - plane.offset;
 }
 
+/// One-dimensional mass-spring-damper simulation. Returns the new velocity given the position and time step.
+/// You can then compute the new position using:
+/// position += timeStep * newVelocity
+/// This drives towards a zero position. By using implicit integration we get a stable solution
+/// that doesn't require transcendental functions.
+B2_INLINE float b2SpringDamper( float hertz, float dampingRatio, float position, float velocity, float timeStep )
+{
+	float omega = 2.0f * B2_PI * hertz;
+	float omegaH = omega * timeStep;
+	return ( velocity - omega * omegaH * position ) / ( 1.0f + 2.0f * dampingRatio * omegaH + omegaH * omegaH );
+}
+
 /// Box2D bases all length units on meters, but you may need different units for your game.
 /// You can set this value to use different units. This should be done at application startup
 /// and only modified once. Default value is 1.

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -836,6 +836,9 @@ typedef struct b2RevoluteJointDef
 	/// Set this flag to true if the attached bodies should collide
 	bool collideConnected;
 
+	/// todo testing
+	bool stiffSolver;
+
 	/// User data pointer
 	void* userData;
 

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -824,9 +824,6 @@ typedef struct b2RevoluteJointDef
 	/// The desired motor speed in radians per second
 	float motorSpeed;
 
-	/// The constraint stiffness in hertz. Ignored if -1. Advanced feature.
-	float constraintHertz;
-
 	/// Scale the debug draw
 	float drawSize;
 

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -102,12 +102,6 @@ typedef struct b2WorldDef
 	/// decreasing the damping ratio.
 	float maxContactPushSpeed;
 
-	/// Joint stiffness. Cycles per second.
-	float jointHertz;
-
-	/// Joint bounciness. Non-dimensional.
-	float jointDampingRatio;
-
 	/// Maximum linear speed. Usually meters per second.
 	float maximumLinearSpeed;
 
@@ -830,7 +824,7 @@ typedef struct b2RevoluteJointDef
 	/// The desired motor speed in radians per second
 	float motorSpeed;
 
-	/// The constraint stiffness in hertz
+	/// The constraint stiffness in hertz. Ignored if -1. Advanced feature.
 	float constraintHertz;
 
 	/// Scale the debug draw

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -830,14 +830,14 @@ typedef struct b2RevoluteJointDef
 	/// The desired motor speed in radians per second
 	float motorSpeed;
 
+	/// The constraint stiffness in hertz
+	float constraintHertz;
+
 	/// Scale the debug draw
 	float drawSize;
 
 	/// Set this flag to true if the attached bodies should collide
 	bool collideConnected;
-
-	/// todo testing
-	bool stiffSolver;
 
 	/// User data pointer
 	void* userData;

--- a/samples/doohickey.cpp
+++ b/samples/doohickey.cpp
@@ -30,6 +30,8 @@ void Doohickey::Spawn( b2WorldId worldId, b2Vec2 position, float scale )
 	bodyDef.type = b2_dynamicBody;
 
 	b2ShapeDef shapeDef = b2DefaultShapeDef();
+	shapeDef.material.rollingResistance = 0.1f;
+
 	b2Circle circle = { { 0.0f, 0.0f }, 1.0f * scale };
 	b2Capsule capsule = { { -3.5f * scale, 0.0f }, { 3.5f * scale, 0.0f }, 0.15f * scale };
 

--- a/samples/main.cpp
+++ b/samples/main.cpp
@@ -397,8 +397,8 @@ static void UpdateUI()
 			if ( ImGui::BeginTabItem( "Controls" ) )
 			{
 				ImGui::PushItemWidth( 100.0f );
-				ImGui::SliderInt( "Sub-steps", &s_context.subStepCount, 1, 50 );
-				ImGui::SliderFloat( "Hertz", &s_context.hertz, 5.0f, 120.0f, "%.0f hz" );
+				ImGui::SliderInt( "Sub-steps", &s_context.subStepCount, 1, 64 );
+				ImGui::SliderFloat( "Hertz", &s_context.hertz, 5.0f, 480.0f, "%.0f hz" );
 
 				if ( ImGui::SliderInt( "Workers", &s_context.workerCount, 1, maxWorkers ) )
 				{

--- a/samples/main.cpp
+++ b/samples/main.cpp
@@ -397,8 +397,8 @@ static void UpdateUI()
 			if ( ImGui::BeginTabItem( "Controls" ) )
 			{
 				ImGui::PushItemWidth( 100.0f );
-				ImGui::SliderInt( "Sub-steps", &s_context.subStepCount, 1, 64 );
-				ImGui::SliderFloat( "Hertz", &s_context.hertz, 5.0f, 480.0f, "%.0f hz" );
+				ImGui::SliderInt( "Sub-steps", &s_context.subStepCount, 1, 32 );
+				ImGui::SliderFloat( "Hertz", &s_context.hertz, 5.0f, 240.0f, "%.0f hz" );
 
 				if ( ImGui::SliderInt( "Workers", &s_context.workerCount, 1, maxWorkers ) )
 				{

--- a/samples/sample.cpp
+++ b/samples/sample.cpp
@@ -333,7 +333,7 @@ void Sample::MouseDown( b2Vec2 p, int button, int mod )
 			mouseDef.bodyIdA = m_groundBodyId;
 			mouseDef.bodyIdB = queryContext.bodyId;
 			mouseDef.target = p;
-			mouseDef.hertz = 15.0f;
+			mouseDef.hertz = 10.0f;
 			mouseDef.dampingRatio = 0.7f;
 			mouseDef.maxForce = 1000.0f * b2Body_GetMass( queryContext.bodyId ) * b2Length(b2World_GetGravity(m_worldId));
 			m_mouseJointId = b2CreateMouseJoint( m_worldId, &mouseDef );

--- a/samples/sample.cpp
+++ b/samples/sample.cpp
@@ -333,9 +333,9 @@ void Sample::MouseDown( b2Vec2 p, int button, int mod )
 			mouseDef.bodyIdA = m_groundBodyId;
 			mouseDef.bodyIdB = queryContext.bodyId;
 			mouseDef.target = p;
-			mouseDef.hertz = 5.0f;
+			mouseDef.hertz = 15.0f;
 			mouseDef.dampingRatio = 0.7f;
-			mouseDef.maxForce = 1000.0f * b2Body_GetMass( queryContext.bodyId );
+			mouseDef.maxForce = 1000.0f * b2Body_GetMass( queryContext.bodyId ) * b2Length(b2World_GetGravity(m_worldId));
 			m_mouseJointId = b2CreateMouseJoint( m_worldId, &mouseDef );
 
 			b2Body_SetAwake( queryContext.bodyId, true );

--- a/samples/sample_determinism.cpp
+++ b/samples/sample_determinism.cpp
@@ -2,15 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "determinism.h"
-#include "draw.h"
 #include "sample.h"
 
-#include "box2d/box2d.h"
 #include "box2d/math_functions.h"
-
-#include <GLFW/glfw3.h>
-#include <imgui.h>
-#include <stdio.h>
 
 // This sample provides a visual representation of the cross platform determinism unit test.
 // The scenario is designed to produce a chaotic result engaging:
@@ -46,7 +40,7 @@ public:
 	{
 		Sample::Step();
 
-		if (m_done == false)
+		if (m_context->pause == false && m_done == false)
 		{
 			m_done = UpdateFallingHinges( m_worldId, &m_data );
 		}

--- a/samples/sample_joints.cpp
+++ b/samples/sample_joints.cpp
@@ -1932,6 +1932,8 @@ public:
 		}
 
 		m_impulse = 500.0f;
+		m_jointHertz = 60.0f;
+		m_jointDampingRatio = 2.0f;
 	}
 
 	void UpdateGui() override
@@ -1958,6 +1960,16 @@ public:
 		}
 
 		ImGui::SliderFloat( "magnitude", &m_impulse, 0.0f, 1000.0f, "%.0f" );
+
+		if ( ImGui::SliderFloat( "hertz", &m_jointHertz, 15.0f, 120.0f, "%.0f" ) )
+		{
+			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+		}
+
+		if ( ImGui::SliderFloat( "damping", &m_jointDampingRatio, 0.0f, 10.0f, "%.1f" ) )
+		{
+			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+		}
 
 		ImGui::End();
 	}
@@ -1988,6 +2000,8 @@ public:
 	b2BodyId m_bodyIds[e_count];
 	b2JointId m_jointIds[e_count];
 	float m_impulse;
+	float m_jointHertz;
+	float m_jointDampingRatio;
 };
 
 static int sampleJointSeparation = RegisterSample( "Joints", "Separation", JointSeparation::Create );
@@ -2604,8 +2618,6 @@ public:
 			revoluteDef.bodyIdB = bodyId1;
 			revoluteDef.localAnchorA = baseAnchor1;
 			revoluteDef.localAnchorB = { -2.5f, 0.0f };
-			revoluteDef.enableMotor = false;
-			revoluteDef.maxMotorTorque = 1.0f;
 			revoluteDef.collideConnected = ( i == 0 ) ? true : false;
 
 			b2CreateRevoluteJoint( m_worldId, &revoluteDef );
@@ -2630,8 +2642,6 @@ public:
 				revoluteDef.bodyIdB = bodyId2;
 				revoluteDef.localAnchorA = baseAnchor2;
 				revoluteDef.localAnchorB = { 2.5f, 0.0f };
-				revoluteDef.enableMotor = false;
-				revoluteDef.maxMotorTorque = 1.0f;
 				revoluteDef.collideConnected = false;
 
 				b2CreateRevoluteJoint( m_worldId, &revoluteDef );
@@ -2642,8 +2652,6 @@ public:
 			revoluteDef.bodyIdB = bodyId2;
 			revoluteDef.localAnchorA = { 0.0f, 0.0f };
 			revoluteDef.localAnchorB = { 0.0f, 0.0f };
-			revoluteDef.enableMotor = false;
-			revoluteDef.maxMotorTorque = 1.0f;
 			revoluteDef.collideConnected = false;
 
 			b2CreateRevoluteJoint( m_worldId, &revoluteDef );
@@ -2668,8 +2676,6 @@ public:
 		revoluteDef.bodyIdB = baseId1;
 		revoluteDef.localAnchorA = { -2.5f, -0.4f };
 		revoluteDef.localAnchorB = baseAnchor1;
-		revoluteDef.enableMotor = false;
-		revoluteDef.maxMotorTorque = 1.0f;
 		revoluteDef.collideConnected = true;
 		b2CreateRevoluteJoint( m_worldId, &revoluteDef );
 
@@ -3111,12 +3117,11 @@ public:
 			b2Polygon box = b2MakeBox( 0.1f, 1.5f );
 			b2CreatePolygonShape( m_doorId, &shapeDef, &box );
 
-			b2Vec2 pivot = { 0.0f, 0.0f };
 			b2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
 			jointDef.bodyIdA = groundId;
 			jointDef.bodyIdB = m_doorId;
-			jointDef.localAnchorA = b2Body_GetLocalPoint( jointDef.bodyIdA, pivot );
-			jointDef.localAnchorB = b2Body_GetLocalPoint( jointDef.bodyIdB, pivot );
+			jointDef.localAnchorA = {0.0f, 0.0f};
+			jointDef.localAnchorB = {0.0f, -1.5f};
 			jointDef.targetAngle = 0.0f;
 			jointDef.enableSpring = true;
 			jointDef.hertz = 1.0f;
@@ -3134,6 +3139,10 @@ public:
 
 		m_impulse = 50000.0f;
 		m_translationError = 0.0f;
+		m_jointHertz = 120.0f;
+		m_jointDampingRatio = 1.0f;
+
+		b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
 	}
 
 	void UpdateGui() override
@@ -3156,6 +3165,16 @@ public:
 		if ( ImGui::Checkbox( "limit", &m_enableLimit ) )
 		{
 			b2RevoluteJoint_EnableLimit( m_jointId, m_enableLimit );
+		}
+
+		if ( ImGui::SliderFloat( "hertz", &m_jointHertz, 15.0f, 480.0f, "%.0f" ) )
+		{
+			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+		}
+
+		if ( ImGui::SliderFloat( "damping", &m_jointDampingRatio, 0.0f, 10.0f, "%.1f" ) )
+		{
+			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
 		}
 
 		ImGui::End();
@@ -3185,6 +3204,8 @@ public:
 	b2JointId m_jointId;
 	float m_impulse;
 	float m_translationError;
+	float m_jointHertz;
+	float m_jointDampingRatio;
 	bool m_enableLimit;
 };
 

--- a/samples/sample_joints.cpp
+++ b/samples/sample_joints.cpp
@@ -1003,19 +1003,24 @@ public:
 			b2BodyId bodyId = b2CreateBody( m_worldId, &bodyDef );
 			b2CreateCircleShape( bodyId, &shapeDef, &circle );
 		}
+
+		m_jointHertz = 60.0f;
+		m_jointDampingRatio = 0.0f;
+
+		b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
 	}
 
 	void UpdateGui() override
 	{
-		float height = 80.0f;
+		float height = 140.0f;
 		ImGui::SetNextWindowPos( ImVec2( 10.0f, m_context->camera.m_height - height - 50.0f ), ImGuiCond_Once );
-		ImGui::SetNextWindowSize( ImVec2( 240.0f, height ) );
+		ImGui::SetNextWindowSize( ImVec2( 300.0f, height ) );
 
 		ImGui::Begin( "Bridge", nullptr, ImGuiWindowFlags_NoResize );
 
-		// Slider takes half the window
-		ImGui::PushItemWidth( ImGui::GetWindowWidth() * 0.5f );
-		bool updateFriction = ImGui::SliderFloat( "Joint Friction", &m_frictionTorque, 0.0f, 1000.0f, "%2.f" );
+		ImGui::PushItemWidth( ImGui::GetWindowWidth() * 0.6f );
+
+		bool updateFriction = ImGui::SliderFloat( "Joint Friction", &m_frictionTorque, 0.0f, 10000.0f, "%2.f" );
 		if ( updateFriction )
 		{
 			for ( int i = 0; i <= m_count; ++i )
@@ -1032,6 +1037,18 @@ public:
 			}
 		}
 
+		if ( ImGui::SliderFloat( "hertz", &m_jointHertz, 15.0f, 120.0f, "%.0f" ) )
+		{
+			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+		}
+
+		if ( ImGui::SliderFloat( "damping", &m_jointDampingRatio, 0.0f, 100.0f, "%.1f" ) )
+		{
+			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+		}
+
+		ImGui::PopItemWidth();
+
 		ImGui::End();
 	}
 
@@ -1045,6 +1062,8 @@ public:
 	b2JointId m_jointIds[m_count + 1];
 	float m_frictionTorque;
 	float m_gravityScale;
+	float m_jointHertz;
+	float m_jointDampingRatio;
 };
 
 static int sampleBridgeIndex = RegisterSample( "Joints", "Bridge", Bridge::Create );
@@ -1075,7 +1094,8 @@ public:
 
 			b2ShapeDef shapeDef = b2DefaultShapeDef();
 			shapeDef.density = 20.0f;
-
+			shapeDef.filter.categoryBits = 0x1;
+			shapeDef.filter.maskBits = 0x2;
 			b2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
 
 			int jointIndex = 0;
@@ -1106,8 +1126,10 @@ public:
 			b2BodyDef bodyDef = b2DefaultBodyDef();
 			bodyDef.type = b2_dynamicBody;
 			bodyDef.position = { ( 1.0f + 2.0f * m_count ) * hx + circle.radius - hx, m_count * hx };
-
 			b2BodyId bodyId = b2CreateBody( m_worldId, &bodyDef );
+
+			shapeDef.filter.categoryBits = 0x2;
+			shapeDef.filter.maskBits = 0x1;
 			b2CreateCircleShape( bodyId, &shapeDef, &circle );
 
 			b2Vec2 pivot = { ( 2.0f * m_count ) * hx, m_count * hx };
@@ -2810,7 +2832,7 @@ public:
 		float linkCount = 40;
 		float doorHalfHeight = 1.5f;
 
-		b2Vec2 gearPosition1 = { -4.25f, 10.25f };
+		b2Vec2 gearPosition1 = { -4.25f, 9.75f };
 		b2Vec2 gearPosition2 = gearPosition1 + b2Vec2{ 2.0f, 1.0f };
 		b2Vec2 linkAttachPosition = gearPosition2 + b2Vec2{ gearRadius + 2.0f * toothHalfWidth + toothRadius, 0.0f };
 		b2Vec2 doorPosition = linkAttachPosition - b2Vec2{ 0.0f, 2.0f * linkCount * linkHalfLength + doorHalfHeight };

--- a/samples/sample_joints.cpp
+++ b/samples/sample_joints.cpp
@@ -1009,11 +1009,6 @@ public:
 			b2BodyId bodyId = b2CreateBody( m_worldId, &bodyDef );
 			b2CreateCircleShape( bodyId, &shapeDef, &circle );
 		}
-
-		m_jointHertz = 240.0f;
-		m_jointDampingRatio = 2.0f;
-
-		b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
 	}
 
 	void UpdateGui() override
@@ -1045,12 +1040,18 @@ public:
 
 		if ( ImGui::SliderFloat( "hertz", &m_jointHertz, 15.0f, 240.0f, "%.0f" ) )
 		{
-			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+			for ( int i = 0; i <= m_count; ++i )
+			{
+				b2Joint_SetConstraintTuning( m_jointIds[i], m_jointHertz, m_jointDampingRatio );
+			}
 		}
 
 		if ( ImGui::SliderFloat( "damping", &m_jointDampingRatio, 0.0f, 10.0f, "%.1f" ) )
 		{
-			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+			for ( int i = 0; i <= m_count; ++i )
+			{
+				b2Joint_SetConstraintTuning( m_jointIds[i], m_jointHertz, m_jointDampingRatio );
+			}
 		}
 
 		ImGui::PopItemWidth();
@@ -1995,12 +1996,18 @@ public:
 
 		if ( ImGui::SliderFloat( "hertz", &m_jointHertz, 15.0f, 120.0f, "%.0f" ) )
 		{
-			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+			for ( int i = 0; i < e_count; ++i )
+			{
+				b2Joint_SetConstraintTuning( m_jointIds[i], m_jointHertz, m_jointDampingRatio );
+			}
 		}
 
 		if ( ImGui::SliderFloat( "damping", &m_jointDampingRatio, 0.0f, 10.0f, "%.1f" ) )
 		{
-			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+			for ( int i = 0; i < e_count; ++i )
+			{
+				b2Joint_SetConstraintTuning( m_jointIds[i], m_jointHertz, m_jointDampingRatio );
+			}
 		}
 
 		ImGui::End();
@@ -2452,7 +2459,6 @@ public:
 		Spawn();
 
 		b2World_SetContactTuning( m_worldId, 240.0f, 0.0f, 2.0f );
-		b2World_SetJointTuning( m_worldId, 60.0f, 0.0f );
 	}
 
 	void Spawn()
@@ -3137,6 +3143,10 @@ public:
 		}
 
 		m_enableLimit = true;
+		m_impulse = 50000.0f;
+		m_translationError = 0.0f;
+		m_jointHertz = 240.0f;
+		m_jointDampingRatio = 1.0f;
 
 		{
 			b2BodyDef bodyDef = b2DefaultBodyDef();
@@ -3170,14 +3180,8 @@ public:
 			jointDef.enableLimit = m_enableLimit;
 
 			m_jointId = b2CreateRevoluteJoint( m_worldId, &jointDef );
+			b2Joint_SetConstraintTuning( m_jointId, m_jointHertz, m_jointDampingRatio );
 		}
-
-		m_impulse = 50000.0f;
-		m_translationError = 0.0f;
-		m_jointHertz = 240.0f;
-		m_jointDampingRatio = 1.0f;
-
-		b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
 	}
 
 	void UpdateGui() override
@@ -3204,12 +3208,12 @@ public:
 
 		if ( ImGui::SliderFloat( "hertz", &m_jointHertz, 15.0f, 480.0f, "%.0f" ) )
 		{
-			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+			b2Joint_SetConstraintTuning( m_jointId, m_jointHertz, m_jointDampingRatio );
 		}
 
 		if ( ImGui::SliderFloat( "damping", &m_jointDampingRatio, 0.0f, 10.0f, "%.1f" ) )
 		{
-			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+			b2Joint_SetConstraintTuning( m_jointId, m_jointHertz, m_jointDampingRatio );
 		}
 
 		ImGui::End();

--- a/samples/sample_joints.cpp
+++ b/samples/sample_joints.cpp
@@ -2451,7 +2451,8 @@ public:
 
 		Spawn();
 
-		//b2World_SetJointTuning( m_worldId, 120.0f, 1.0f );
+		b2World_SetContactTuning( m_worldId, 240.0f, 0.0f, 2.0f );
+		b2World_SetJointTuning( m_worldId, 60.0f, 0.0f );
 	}
 
 	void Spawn()
@@ -3311,3 +3312,4 @@ public:
 };
 
 static int sampleScaleRagdoll = RegisterSample( "Joints", "Scale Ragdoll", ScaleRagdoll::Create );
+

--- a/samples/sample_joints.cpp
+++ b/samples/sample_joints.cpp
@@ -956,6 +956,9 @@ public:
 				jointDef.localAnchorB = b2Body_GetLocalPoint( jointDef.bodyIdB, pivot );
 				jointDef.enableMotor = true;
 				jointDef.maxMotorTorque = m_frictionTorque;
+				jointDef.enableSpring = true;
+				jointDef.hertz = 4.0f;
+				jointDef.dampingRatio = 0.7f;
 				m_jointIds[jointIndex++] = b2CreateRevoluteJoint( m_worldId, &jointDef );
 
 				prevBodyId = m_bodyIds[i];
@@ -968,6 +971,9 @@ public:
 			jointDef.localAnchorB = b2Body_GetLocalPoint( jointDef.bodyIdB, pivot );
 			jointDef.enableMotor = true;
 			jointDef.maxMotorTorque = m_frictionTorque;
+			jointDef.enableSpring = true;
+			jointDef.hertz = 4.0f;
+			jointDef.dampingRatio = 0.7f;
 			m_jointIds[jointIndex++] = b2CreateRevoluteJoint( m_worldId, &jointDef );
 
 			assert( jointIndex == m_count + 1 );
@@ -1004,8 +1010,8 @@ public:
 			b2CreateCircleShape( bodyId, &shapeDef, &circle );
 		}
 
-		m_jointHertz = 60.0f;
-		m_jointDampingRatio = 0.0f;
+		m_jointHertz = 240.0f;
+		m_jointDampingRatio = 2.0f;
 
 		b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
 	}
@@ -1037,12 +1043,12 @@ public:
 			}
 		}
 
-		if ( ImGui::SliderFloat( "hertz", &m_jointHertz, 15.0f, 120.0f, "%.0f" ) )
+		if ( ImGui::SliderFloat( "hertz", &m_jointHertz, 15.0f, 240.0f, "%.0f" ) )
 		{
 			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
 		}
 
-		if ( ImGui::SliderFloat( "damping", &m_jointDampingRatio, 0.0f, 100.0f, "%.1f" ) )
+		if ( ImGui::SliderFloat( "damping", &m_jointDampingRatio, 0.0f, 10.0f, "%.1f" ) )
 		{
 			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
 		}
@@ -1114,8 +1120,10 @@ public:
 				jointDef.bodyIdB = bodyId;
 				jointDef.localAnchorA = b2Body_GetLocalPoint( jointDef.bodyIdA, pivot );
 				jointDef.localAnchorB = b2Body_GetLocalPoint( jointDef.bodyIdB, pivot );
-				// jointDef.enableMotor = true;
+				jointDef.enableMotor = true;
 				jointDef.maxMotorTorque = m_frictionTorque;
+				jointDef.enableSpring = i > 0;
+				jointDef.hertz = 4.0f;
 				m_jointIds[jointIndex++] = b2CreateRevoluteJoint( m_worldId, &jointDef );
 
 				prevBodyId = bodyId;
@@ -1139,6 +1147,8 @@ public:
 			jointDef.localAnchorB = b2Body_GetLocalPoint( jointDef.bodyIdB, pivot );
 			jointDef.enableMotor = true;
 			jointDef.maxMotorTorque = m_frictionTorque;
+			jointDef.enableSpring = true;
+			jointDef.hertz = 4.0f;
 			m_jointIds[jointIndex++] = b2CreateRevoluteJoint( m_worldId, &jointDef );
 			assert( jointIndex == m_count + 1 );
 		}
@@ -2440,13 +2450,15 @@ public:
 		m_human = {};
 
 		Spawn();
+
+		//b2World_SetJointTuning( m_worldId, 120.0f, 1.0f );
 	}
 
 	void Spawn()
 	{
 		CreateHuman( &m_human, m_worldId, { 0.0f, 25.0f }, 1.0f, m_jointFrictionTorque, m_jointHertz, m_jointDampingRatio, 1,
 					 nullptr, false );
-		Human_ApplyRandomAngularImpulse( &m_human, 10.0f );
+		//Human_ApplyRandomAngularImpulse( &m_human, 10.0f );
 	}
 
 	void UpdateGui() override
@@ -3161,7 +3173,7 @@ public:
 
 		m_impulse = 50000.0f;
 		m_translationError = 0.0f;
-		m_jointHertz = 120.0f;
+		m_jointHertz = 240.0f;
 		m_jointDampingRatio = 1.0f;
 
 		b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );

--- a/samples/sample_robustness.cpp
+++ b/samples/sample_robustness.cpp
@@ -504,14 +504,14 @@ public:
 		m_chassisId = b2CreateBody( m_worldId, &bodyDef );
 
 		b2ShapeDef shapeDef = b2DefaultShapeDef();
-		shapeDef.density = 1.0;
+		shapeDef.density = 100.0f;
 
 		b2Polygon box = b2MakeOffsetBox( 0.5f, 0.25f, { 0.0f, 0.25f }, b2Rot_identity );
 		b2CreatePolygonShape( m_chassisId, &shapeDef, &box );
 
 		shapeDef = b2DefaultShapeDef();
 		shapeDef.material.rollingResistance = 0.02f;
-		shapeDef.density = 2.0f;
+		shapeDef.density = 10.0f;
 
 		b2Circle circle = { b2Vec2_zero, 0.1f };
 		bodyDef.position = { -0.4f, yBase - 0.15f };

--- a/samples/sample_robustness.cpp
+++ b/samples/sample_robustness.cpp
@@ -380,64 +380,6 @@ public:
 
 static int sampleTinyPyramid = RegisterSample( "Robustness", "Tiny Pyramid", TinyPyramid::Create );
 
-class JointBounce : public Sample
-{
-public:
-	explicit JointBounce( SampleContext* context )
-		: Sample( context )
-	{
-		if ( m_context->restart == false )
-		{
-			m_context->camera.m_center = { 0.0f, 5.0f };
-			m_context->camera.m_zoom = 20.0f;
-		}
-
-		{
-			b2BodyDef bodyDef = b2DefaultBodyDef();
-			b2BodyId groundId = b2CreateBody( m_worldId, &bodyDef );
-
-			b2ShapeDef shapeDef = b2DefaultShapeDef();
-			b2Segment segment = { { -40.0f, 0.0f }, { 40.0f, 0.0f } };
-			b2CreateSegmentShape( groundId, &shapeDef, &segment );
-		}
-
-		{
-			b2Vec2 base = { 0.0f, 20.0f };
-
-			b2BodyDef bodyDef = b2DefaultBodyDef();
-			bodyDef.type = b2_dynamicBody;
-
-			b2Circle circle = {};
-			circle.radius = 0.5f;
-			b2ShapeDef shapeDef = b2DefaultShapeDef();
-
-			bodyDef.position = b2Vec2{ 0.0f, 0.5f } + base;
-			b2BodyId bodyId1 = b2CreateBody( m_worldId, &bodyDef );
-			b2CreateCircleShape( bodyId1, &shapeDef, &circle );
-
-			bodyDef.position = b2Vec2{ 0.25f, 0.75f } + base;
-			bodyDef.rotation = b2MakeRot( -0.5f * B2_PI );
-			b2BodyId bodyId2 = b2CreateBody( m_worldId, &bodyDef );
-			b2CreateCircleShape( bodyId2, &shapeDef, &circle );
-
-			b2WeldJointDef weldDef = b2DefaultWeldJointDef();
-
-			weldDef.bodyIdA = bodyId1;
-			weldDef.bodyIdB = bodyId2;
-			weldDef.localAnchorA = { 0.0f, 0.5f };
-			weldDef.localAnchorA = { 0.0f, -0.5f };
-			b2CreateWeldJoint( m_worldId, &weldDef );
-		}
-	}
-
-	static Sample* Create( SampleContext* context )
-	{
-		return new JointBounce( context );
-	}
-};
-
-static int sampleJointBounce = RegisterSample( "Robustness", "Joint Bounce", JointBounce::Create );
-
 // High gravity and high mass ratio
 class Cart : public Sample
 {

--- a/samples/sample_robustness.cpp
+++ b/samples/sample_robustness.cpp
@@ -200,7 +200,7 @@ public:
 		if ( m_context->restart == false )
 		{
 			m_context->camera.m_center = { 0.0f, 2.5f };
-			m_context->camera.m_zoom = 25.0f * 0.15f;
+			m_context->camera.m_zoom = 3.75f;
 		}
 
 		m_bodyIds = nullptr;
@@ -286,8 +286,8 @@ public:
 		changed = changed || ImGui::SliderFloat( "Extent", &m_extent, 0.1f, 1.0f, "%.1f" );
 		changed = changed || ImGui::SliderInt( "Base Count", &m_baseCount, 1, 10 );
 		changed = changed || ImGui::SliderFloat( "Overlap", &m_overlap, 0.0f, 1.0f, "%.2f" );
-		changed = changed || ImGui::SliderFloat( "Pushout", &m_pushOut, 0.0f, 10.0f, "%.1f" );
-		changed = changed || ImGui::SliderFloat( "Hertz", &m_hertz, 0.0f, 120.0f, "%.f" );
+		changed = changed || ImGui::SliderFloat( "Speed", &m_pushOut, 0.0f, 10.0f, "%.1f" );
+		changed = changed || ImGui::SliderFloat( "Hertz", &m_hertz, 0.0f, 240.0f, "%.f" );
 		changed = changed || ImGui::SliderFloat( "Damping Ratio", &m_dampingRatio, 0.0f, 20.0f, "%.1f" );
 		changed = changed || ImGui::Button( "Reset Scene" );
 
@@ -437,3 +437,164 @@ public:
 };
 
 static int sampleJointBounce = RegisterSample( "Robustness", "Joint Bounce", JointBounce::Create );
+
+// High gravity and high mass ratio
+class Cart : public Sample
+{
+public:
+	explicit Cart( SampleContext* context )
+		: Sample( context )
+	{
+		if ( m_context->restart == false )
+		{
+			m_context->camera.m_center = { 0.0f, 1.0f };
+			m_context->camera.m_zoom = 1.5f;
+		}
+
+		b2BodyId groundId;
+		{
+			b2BodyDef bodyDef = b2DefaultBodyDef();
+			bodyDef.position = { 0.0f, -1.0f };
+			groundId = b2CreateBody( m_worldId, &bodyDef );
+
+			b2ShapeDef shapeDef = b2DefaultShapeDef();
+			b2Polygon groundBox = b2MakeBox( 20.0f, 1.0f );
+			b2CreatePolygonShape( groundId, &shapeDef, &groundBox );
+		}
+
+		b2World_SetGravity( m_worldId, { 0, -22 } );
+
+		m_contactHertz = 30.0f;
+		m_contactDampingRatio = 10.0f;
+		m_contactSpeed = 3.0f;
+		b2World_SetContactTuning( m_worldId, m_contactHertz, m_contactDampingRatio, m_contactSpeed );
+
+		m_jointHertz = 60.0f;
+		m_jointDampingRatio = 1.0f;
+		b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+
+		m_chassisId = {};
+		m_wheelId1 = {};
+		m_wheelId2 = {};
+
+		CreateScene();
+	}
+
+	void CreateScene()
+	{
+		if (B2_IS_NON_NULL(m_chassisId))
+		{
+			b2DestroyBody( m_chassisId );
+		}
+
+		if (B2_IS_NON_NULL(m_wheelId1))
+		{
+			b2DestroyBody( m_wheelId1 );
+		}
+
+		if (B2_IS_NON_NULL(m_wheelId2))
+		{
+			b2DestroyBody( m_wheelId2 );
+		}
+
+		float yBase = 2.0f;
+
+		b2BodyDef bodyDef = b2DefaultBodyDef();
+		bodyDef.type = b2_dynamicBody;
+		bodyDef.position = { 0.0f, yBase };
+		m_chassisId = b2CreateBody( m_worldId, &bodyDef );
+
+		b2ShapeDef shapeDef = b2DefaultShapeDef();
+		shapeDef.density = 1.0;
+
+		b2Polygon box = b2MakeOffsetBox( 0.5f, 0.25f, { 0.0f, 0.25f }, b2Rot_identity );
+		b2CreatePolygonShape( m_chassisId, &shapeDef, &box );
+
+		shapeDef = b2DefaultShapeDef();
+		shapeDef.material.rollingResistance = 0.02f;
+		shapeDef.density = 2.0f;
+
+		b2Circle circle = { b2Vec2_zero, 0.1f };
+		bodyDef.position = { -0.4f, yBase - 0.15f };
+		m_wheelId1 = b2CreateBody( m_worldId, &bodyDef );
+		b2CreateCircleShape( m_wheelId1, &shapeDef, &circle );
+
+		bodyDef.position = { 0.4f, yBase - 0.15f };
+		m_wheelId2 = b2CreateBody( m_worldId, &bodyDef );
+		b2CreateCircleShape( m_wheelId2, &shapeDef, &circle );
+
+		b2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
+		jointDef.bodyIdA = m_chassisId;
+		jointDef.bodyIdB = m_wheelId1;
+		jointDef.localAnchorA = { -0.4f, -0.15f };
+		jointDef.localAnchorB = { 0.0f, 0.0f };
+
+		b2CreateRevoluteJoint( m_worldId, &jointDef );
+
+		jointDef.bodyIdA = m_chassisId;
+		jointDef.bodyIdB = m_wheelId2;
+		jointDef.localAnchorA = { 0.4f, -0.15f };
+		jointDef.localAnchorB = { 0.0f, 0.0f };
+
+		b2CreateRevoluteJoint( m_worldId, &jointDef );
+	}
+
+	void UpdateGui() override
+	{
+		float height = 240.0f;
+		ImGui::SetNextWindowPos( ImVec2( 10.0f, m_context->camera.m_height - height - 50.0f ), ImGuiCond_Once );
+		ImGui::SetNextWindowSize( ImVec2( 320.0f, height ) );
+
+		ImGui::Begin( "Cart", nullptr, ImGuiWindowFlags_NoResize );
+		ImGui::PushItemWidth( 200.0f );
+
+		bool changed = false;
+		ImGui::Text( "Contact" );
+		changed = changed || ImGui::SliderFloat( "Hertz##contact", &m_contactHertz, 0.0f, 240.0f, "%.f" );
+		changed = changed || ImGui::SliderFloat( "Damping Ratio##contact", &m_contactDampingRatio, 0.0f, 1000.0f, "%.f" );
+		changed = changed || ImGui::SliderFloat( "Speed", &m_contactSpeed, 0.0f, 5.0f, "%.1f" );
+
+		if ( changed )
+		{
+			b2World_SetContactTuning( m_worldId, m_contactHertz, m_contactDampingRatio, m_contactSpeed );
+			CreateScene();
+		}
+
+		ImGui::Separator();
+
+		changed = false;
+		ImGui::Text( "Joint" );
+		changed = changed || ImGui::SliderFloat( "Hertz##joint", &m_jointHertz, 0.0f, 240.0f, "%.f" );
+		changed = changed || ImGui::SliderFloat( "Damping Ratio##joint", &m_jointDampingRatio, 0.0f, 1000.0f, "%.f" );
+
+		ImGui::Separator();
+
+		changed = changed || ImGui::Button( "Reset Scene" );
+
+		if ( changed )
+		{
+			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+			CreateScene();
+		}
+
+		ImGui::PopItemWidth();
+		ImGui::End();
+	}
+
+	static Sample* Create( SampleContext* context )
+	{
+		return new Cart( context );
+	}
+
+	b2BodyId m_chassisId;
+	b2BodyId m_wheelId1;
+	b2BodyId m_wheelId2;
+
+	float m_contactHertz;
+	float m_contactDampingRatio;
+	float m_contactSpeed;
+	float m_jointHertz;
+	float m_jointDampingRatio;
+};
+
+static int sampleCart = RegisterSample( "Robustness", "Cart", Cart::Create );

--- a/samples/sample_robustness.cpp
+++ b/samples/sample_robustness.cpp
@@ -471,7 +471,6 @@ public:
 
 		m_jointHertz = 60.0f;
 		m_jointDampingRatio = 1.0f;
-		b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
 
 		m_chassisId = {};
 		m_wheelId1 = {};
@@ -529,14 +528,16 @@ public:
 		jointDef.localAnchorA = { -0.4f, -0.15f };
 		jointDef.localAnchorB = { 0.0f, 0.0f };
 
-		b2CreateRevoluteJoint( m_worldId, &jointDef );
+		m_jointId1 = b2CreateRevoluteJoint( m_worldId, &jointDef );
+		b2Joint_SetConstraintTuning( m_jointId1, m_jointHertz, m_jointDampingRatio );
 
 		jointDef.bodyIdA = m_chassisId;
 		jointDef.bodyIdB = m_wheelId2;
 		jointDef.localAnchorA = { 0.4f, -0.15f };
 		jointDef.localAnchorB = { 0.0f, 0.0f };
 
-		b2CreateRevoluteJoint( m_worldId, &jointDef );
+		m_jointId2 = b2CreateRevoluteJoint( m_worldId, &jointDef );
+		b2Joint_SetConstraintTuning( m_jointId2, m_jointHertz, m_jointDampingRatio );
 	}
 
 	void UpdateGui() override
@@ -573,7 +574,8 @@ public:
 
 		if ( changed )
 		{
-			b2World_SetJointTuning( m_worldId, m_jointHertz, m_jointDampingRatio );
+			b2Joint_SetConstraintTuning( m_jointId1, m_jointHertz, m_jointDampingRatio );
+			b2Joint_SetConstraintTuning( m_jointId2, m_jointHertz, m_jointDampingRatio );
 			CreateScene();
 		}
 
@@ -589,6 +591,8 @@ public:
 	b2BodyId m_chassisId;
 	b2BodyId m_wheelId1;
 	b2BodyId m_wheelId2;
+	b2JointId m_jointId1;
+	b2JointId m_jointId2;
 
 	float m_contactHertz;
 	float m_contactDampingRatio;

--- a/samples/sample_robustness.cpp
+++ b/samples/sample_robustness.cpp
@@ -208,7 +208,7 @@ public:
 		m_baseCount = 4;
 		m_overlap = 0.25f;
 		m_extent = 0.5f;
-		m_pushout = 3.0f;
+		m_pushOut = 3.0f;
 		m_hertz = 30.0f;
 		m_dampingRatio = 10.0f;
 
@@ -237,7 +237,7 @@ public:
 			b2DestroyBody( m_bodyIds[i] );
 		}
 
-		b2World_SetContactTuning( m_worldId, m_hertz, m_dampingRatio, m_pushout );
+		b2World_SetContactTuning( m_worldId, m_hertz, m_dampingRatio, m_pushOut );
 
 		b2BodyDef bodyDef = b2DefaultBodyDef();
 		bodyDef.type = b2_dynamicBody;
@@ -286,7 +286,7 @@ public:
 		changed = changed || ImGui::SliderFloat( "Extent", &m_extent, 0.1f, 1.0f, "%.1f" );
 		changed = changed || ImGui::SliderInt( "Base Count", &m_baseCount, 1, 10 );
 		changed = changed || ImGui::SliderFloat( "Overlap", &m_overlap, 0.0f, 1.0f, "%.2f" );
-		changed = changed || ImGui::SliderFloat( "Pushout", &m_pushout, 0.0f, 10.0f, "%.1f" );
+		changed = changed || ImGui::SliderFloat( "Pushout", &m_pushOut, 0.0f, 10.0f, "%.1f" );
 		changed = changed || ImGui::SliderFloat( "Hertz", &m_hertz, 0.0f, 120.0f, "%.f" );
 		changed = changed || ImGui::SliderFloat( "Damping Ratio", &m_dampingRatio, 0.0f, 20.0f, "%.1f" );
 		changed = changed || ImGui::Button( "Reset Scene" );
@@ -310,7 +310,7 @@ public:
 	int32_t m_baseCount;
 	float m_overlap;
 	float m_extent;
-	float m_pushout;
+	float m_pushOut;
 	float m_hertz;
 	float m_dampingRatio;
 };
@@ -379,3 +379,61 @@ public:
 };
 
 static int sampleTinyPyramid = RegisterSample( "Robustness", "Tiny Pyramid", TinyPyramid::Create );
+
+class JointBounce : public Sample
+{
+public:
+	explicit JointBounce( SampleContext* context )
+		: Sample( context )
+	{
+		if ( m_context->restart == false )
+		{
+			m_context->camera.m_center = { 0.0f, 5.0f };
+			m_context->camera.m_zoom = 20.0f;
+		}
+
+		{
+			b2BodyDef bodyDef = b2DefaultBodyDef();
+			b2BodyId groundId = b2CreateBody( m_worldId, &bodyDef );
+
+			b2ShapeDef shapeDef = b2DefaultShapeDef();
+			b2Segment segment = { { -40.0f, 0.0f }, { 40.0f, 0.0f } };
+			b2CreateSegmentShape( groundId, &shapeDef, &segment );
+		}
+
+		{
+			b2Vec2 base = { 0.0f, 20.0f };
+
+			b2BodyDef bodyDef = b2DefaultBodyDef();
+			bodyDef.type = b2_dynamicBody;
+
+			b2Circle circle = {};
+			circle.radius = 0.5f;
+			b2ShapeDef shapeDef = b2DefaultShapeDef();
+
+			bodyDef.position = b2Vec2{ 0.0f, 0.5f } + base;
+			b2BodyId bodyId1 = b2CreateBody( m_worldId, &bodyDef );
+			b2CreateCircleShape( bodyId1, &shapeDef, &circle );
+
+			bodyDef.position = b2Vec2{ 0.25f, 0.75f } + base;
+			bodyDef.rotation = b2MakeRot( -0.5f * B2_PI );
+			b2BodyId bodyId2 = b2CreateBody( m_worldId, &bodyDef );
+			b2CreateCircleShape( bodyId2, &shapeDef, &circle );
+
+			b2WeldJointDef weldDef = b2DefaultWeldJointDef();
+
+			weldDef.bodyIdA = bodyId1;
+			weldDef.bodyIdB = bodyId2;
+			weldDef.localAnchorA = { 0.0f, 0.5f };
+			weldDef.localAnchorA = { 0.0f, -0.5f };
+			b2CreateWeldJoint( m_worldId, &weldDef );
+		}
+	}
+
+	static Sample* Create( SampleContext* context )
+	{
+		return new JointBounce( context );
+	}
+};
+
+static int sampleJointBounce = RegisterSample( "Robustness", "Joint Bounce", JointBounce::Create );

--- a/samples/sample_shapes.cpp
+++ b/samples/sample_shapes.cpp
@@ -1752,7 +1752,7 @@ public:
 			int count = (int)m_jointIds.size();
 			for ( int i = 0; i < count; ++i )
 			{
-				b2WeldJoint_SetReferenceAngle( m_jointIds[i], m_referenceAngle );
+				b2Joint_SetReferenceAngle( m_jointIds[i], m_referenceAngle );
 			}
 		}
 

--- a/shared/determinism.c
+++ b/shared/determinism.c
@@ -15,7 +15,7 @@ FallingHingeData CreateFallingHinges( b2WorldId worldId )
 		bodyDef.position = (b2Vec2){ 0.0f, -1.0f };
 		b2BodyId groundId = b2CreateBody( worldId, &bodyDef );
 
-		b2Polygon box = b2MakeBox( 20.0f, 1.0f );
+		b2Polygon box = b2MakeBox( 40.0f, 1.0f );
 		b2ShapeDef shapeDef = b2DefaultShapeDef();
 		b2CreatePolygonShape( groundId, &shapeDef, &box );
 	}

--- a/shared/determinism.c
+++ b/shared/determinism.c
@@ -15,7 +15,7 @@ FallingHingeData CreateFallingHinges( b2WorldId worldId )
 		bodyDef.position = (b2Vec2){ 0.0f, -1.0f };
 		b2BodyId groundId = b2CreateBody( worldId, &bodyDef );
 
-		b2Polygon box = b2MakeBox( 40.0f, 1.0f );
+		b2Polygon box = b2MakeBox( 20.0f, 1.0f );
 		b2ShapeDef shapeDef = b2DefaultShapeDef();
 		b2CreatePolygonShape( groundId, &shapeDef, &box );
 	}

--- a/src/constants.h
+++ b/src/constants.h
@@ -46,6 +46,12 @@ extern float b2_lengthUnitsPerMeter;
 // The time that a body must be still before it will go to sleep. In seconds.
 #define B2_TIME_TO_SLEEP 0.5f
 
+// The default joint constraint hertz
+#define B2_JOINT_CONSTRAINT_HERTZ 60.0f
+
+// The default joint constraint damping ratio
+#define B2_JOINT_CONSTRAINT_DAMPING_RATIO 2.0f
+
 enum b2TreeNodeFlags
 {
 	b2_allocatedNode = 0x0001,

--- a/src/contact.c
+++ b/src/contact.c
@@ -573,11 +573,16 @@ bool b2UpdateContact( b2World* world, b2ContactSim* contactSim, b2Shape* shapeA,
 			{
 				mp2->normalImpulse = mp1->normalImpulse;
 				mp2->tangentImpulse = mp1->tangentImpulse;
+				mp2->previousNormalImpulse = mp1->previousNormalImpulse;
+				mp2->previousTangentImpulse = mp1->previousTangentImpulse;
+
 				mp2->persisted = true;
 
 				// clear old impulse
 				mp1->normalImpulse = 0.0f;
 				mp1->tangentImpulse = 0.0f;
+				mp1->previousNormalImpulse = 0.0f;
+				mp1->previousTangentImpulse = 0.0f;
 				break;
 			}
 		}

--- a/src/contact.c
+++ b/src/contact.c
@@ -573,7 +573,6 @@ bool b2UpdateContact( b2World* world, b2ContactSim* contactSim, b2Shape* shapeA,
 			{
 				mp2->normalImpulse = mp1->normalImpulse;
 				mp2->tangentImpulse = mp1->tangentImpulse;
-
 				mp2->persisted = true;
 
 				// clear old impulse

--- a/src/contact.c
+++ b/src/contact.c
@@ -573,16 +573,12 @@ bool b2UpdateContact( b2World* world, b2ContactSim* contactSim, b2Shape* shapeA,
 			{
 				mp2->normalImpulse = mp1->normalImpulse;
 				mp2->tangentImpulse = mp1->tangentImpulse;
-				mp2->previousNormalImpulse = mp1->previousNormalImpulse;
-				mp2->previousTangentImpulse = mp1->previousTangentImpulse;
 
 				mp2->persisted = true;
 
 				// clear old impulse
 				mp1->normalImpulse = 0.0f;
 				mp1->tangentImpulse = 0.0f;
-				mp1->previousNormalImpulse = 0.0f;
-				mp1->previousTangentImpulse = 0.0f;
 				break;
 			}
 		}

--- a/src/contact_solver.c
+++ b/src/contact_solver.c
@@ -1460,7 +1460,8 @@ void b2PrepareContactsTask( int startIndex, int endIndex, b2StepContext* context
 
 	float warmStartScale = world->enableWarmStarting ? 1.0f : 0.0f;
 
-	warmStartScale = 0.0f;
+	// todo_erin testing
+	//warmStartScale = 0.0f;
 
 	for ( int i = startIndex; i < endIndex; ++i )
 	{
@@ -1700,7 +1701,8 @@ void b2WarmStartContactsTask( int startIndex, int endIndex, b2StepContext* conte
 	b2ContactConstraintSIMD* constraints = context->graph->colors[colorIndex].simdConstraints;
 
 	// todo_erin testing
-	//b2FloatW ease = b2SplatW(1.0f * context->h);
+	//b2FloatW ease = b2SplatW(0.1f * context->h);
+	//b2FloatW ease = b2SplatW(0.9f);
 	//b2FloatW flipEase = b2SubW( b2SplatW( 1.0f ), ease );
 
 	for ( int i = startIndex; i < endIndex; ++i )
@@ -1714,10 +1716,10 @@ void b2WarmStartContactsTask( int startIndex, int endIndex, b2StepContext* conte
 		//c->normalImpulse2 = b2AddW( b2MulW( flipEase, c->previousNormalImpulse2 ), b2MulW( ease, c->normalImpulse2 ) );
 		//c->tangentImpulse1 = b2AddW( b2MulW( flipEase, c->previousTangentImpulse1 ), b2MulW( ease, c->tangentImpulse1 ) );
 		//c->tangentImpulse2 = b2AddW( b2MulW( flipEase, c->previousTangentImpulse2 ), b2MulW( ease, c->tangentImpulse2 ) );
-		c->previousNormalImpulse1 = c->normalImpulse1;
-		c->previousNormalImpulse2 = c->normalImpulse2;
-		c->previousTangentImpulse1 = c->tangentImpulse1;
-		c->previousTangentImpulse2 = c->tangentImpulse2;
+		//c->previousNormalImpulse1 = c->normalImpulse1;
+		//c->previousNormalImpulse2 = c->normalImpulse2;
+		//c->previousTangentImpulse1 = c->tangentImpulse1;
+		//c->previousTangentImpulse2 = c->tangentImpulse2;
 
 		b2FloatW tangentX = c->normal.Y;
 		b2FloatW tangentY = b2SubW( b2ZeroW(), c->normal.X );
@@ -1771,7 +1773,7 @@ void b2SolveContactsTask( int startIndex, int endIndex, b2StepContext* context, 
 	b2BodyState* states = context->states;
 	b2ContactConstraintSIMD* constraints = context->graph->colors[colorIndex].simdConstraints;
 	b2FloatW inv_h = b2SplatW( context->inv_h );
-	b2FloatW minBiasVel = b2SplatW( -context->world->maxContactPushSpeed );
+	b2FloatW minBiasVel = b2SplatW( -context->world->contactSpeed );
 	b2FloatW oneW = b2SplatW( 1.0f );
 
 	for ( int i = startIndex; i < endIndex; ++i )

--- a/src/contact_solver.c
+++ b/src/contact_solver.c
@@ -43,9 +43,6 @@ void b2PrepareOverflowContacts( b2StepContext* context )
 
 	float warmStartScale = world->enableWarmStarting ? 1.0f : 0.0f;
 
-	// todo_erin testing
-	//warmStartScale = 0.0f;
-
 	for ( int i = 0; i < contactCount; ++i )
 	{
 		b2ContactSim* contactSim = contacts + i;
@@ -1064,11 +1061,6 @@ typedef struct b2ContactConstraintSIMD
 	b2FloatW normalMass2, tangentMass2;
 	b2FloatW restitution;
 	b2FloatW relativeVelocity1, relativeVelocity2;
-
-	b2FloatW previousNormalImpulse1;
-	b2FloatW previousNormalImpulse2;
-	b2FloatW previousTangentImpulse1;
-	b2FloatW previousTangentImpulse2;
 } b2ContactConstraintSIMD;
 
 int b2GetContactConstraintSIMDByteCount( void )
@@ -1460,9 +1452,6 @@ void b2PrepareContactsTask( int startIndex, int endIndex, b2StepContext* context
 
 	float warmStartScale = world->enableWarmStarting ? 1.0f : 0.0f;
 
-	// todo_erin testing
-	//warmStartScale = 0.0f;
-
 	for ( int i = startIndex; i < endIndex; ++i )
 	{
 		b2ContactConstraintSIMD* constraint = constraints + i;
@@ -1623,9 +1612,6 @@ void b2PrepareContactsTask( int startIndex, int endIndex, b2StepContext* context
 					( (float*)&constraint->normalMass2 )[j] = 0.0f;
 					( (float*)&constraint->tangentMass2 )[j] = 0.0f;
 					( (float*)&constraint->relativeVelocity2 )[j] = 0.0f;
-
-					( (float*)&constraint->previousNormalImpulse2 )[j] = 0.0f;
-					( (float*)&constraint->previousTangentImpulse2 )[j] = 0.0f;
 				}
 			}
 			else
@@ -1675,11 +1661,6 @@ void b2PrepareContactsTask( int startIndex, int endIndex, b2StepContext* context
 				( (float*)&constraint->restitution )[j] = 0.0f;
 				( (float*)&constraint->relativeVelocity1 )[j] = 0.0f;
 				( (float*)&constraint->relativeVelocity2 )[j] = 0.0f;
-
-				( (float*)&constraint->previousNormalImpulse1 )[j] = 0.0f;
-				( (float*)&constraint->previousTangentImpulse1 )[j] = 0.0f;
-				( (float*)&constraint->previousNormalImpulse2 )[j] = 0.0f;
-				( (float*)&constraint->previousTangentImpulse2 )[j] = 0.0f;
 			}
 		}
 	}
@@ -1694,26 +1675,11 @@ void b2WarmStartContactsTask( int startIndex, int endIndex, b2StepContext* conte
 	b2BodyState* states = context->states;
 	b2ContactConstraintSIMD* constraints = context->graph->colors[colorIndex].simdConstraints;
 
-	// todo_erin testing
-	//b2FloatW ease = b2SplatW(0.1f * context->h);
-	//b2FloatW ease = b2SplatW(0.9f);
-	//b2FloatW flipEase = b2SubW( b2SplatW( 1.0f ), ease );
-
 	for ( int i = startIndex; i < endIndex; ++i )
 	{
 		b2ContactConstraintSIMD* c = constraints + i;
 		b2BodyStateW bA = b2GatherBodies( states, c->indexA );
 		b2BodyStateW bB = b2GatherBodies( states, c->indexB );
-
-		// todo_erin testing
-		//c->normalImpulse1 = b2AddW( b2MulW( flipEase, c->previousNormalImpulse1 ), b2MulW( ease, c->normalImpulse1 ) );
-		//c->normalImpulse2 = b2AddW( b2MulW( flipEase, c->previousNormalImpulse2 ), b2MulW( ease, c->normalImpulse2 ) );
-		//c->tangentImpulse1 = b2AddW( b2MulW( flipEase, c->previousTangentImpulse1 ), b2MulW( ease, c->tangentImpulse1 ) );
-		//c->tangentImpulse2 = b2AddW( b2MulW( flipEase, c->previousTangentImpulse2 ), b2MulW( ease, c->tangentImpulse2 ) );
-		//c->previousNormalImpulse1 = c->normalImpulse1;
-		//c->previousNormalImpulse2 = c->normalImpulse2;
-		//c->previousTangentImpulse1 = c->tangentImpulse1;
-		//c->previousTangentImpulse2 = c->tangentImpulse2;
 
 		b2FloatW tangentX = c->normal.Y;
 		b2FloatW tangentY = b2SubW( b2ZeroW(), c->normal.X );

--- a/src/contact_solver.c
+++ b/src/contact_solver.c
@@ -1557,9 +1557,6 @@ void b2PrepareContactsTask( int startIndex, int endIndex, b2StepContext* context
 					( (float*)&constraint->tangentImpulse1 )[j] = warmStartScale * mp->tangentImpulse;
 					( (float*)&constraint->totalNormalImpulse1 )[j] = 0.0f;
 
-					( (float*)&constraint->previousNormalImpulse1 )[j] = warmStartScale * mp->previousNormalImpulse;
-					( (float*)&constraint->previousTangentImpulse1 )[j] = warmStartScale * mp->previousTangentImpulse;
-
 					float rnA = b2Cross( rA, normal );
 					float rnB = b2Cross( rB, normal );
 					float kNormal = mA + mB + iA * rnA * rnA + iB * rnB * rnB;
@@ -1596,9 +1593,6 @@ void b2PrepareContactsTask( int startIndex, int endIndex, b2StepContext* context
 					( (float*)&constraint->normalImpulse2 )[j] = warmStartScale * mp->normalImpulse;
 					( (float*)&constraint->tangentImpulse2 )[j] = warmStartScale * mp->tangentImpulse;
 					( (float*)&constraint->totalNormalImpulse2 )[j] = 0.0f;
-
-					( (float*)&constraint->previousNormalImpulse2 )[j] = warmStartScale * mp->previousNormalImpulse;
-					( (float*)&constraint->previousTangentImpulse2 )[j] = warmStartScale * mp->previousTangentImpulse;
 
 					float rnA = b2Cross( rA, normal );
 					float rnB = b2Cross( rB, normal );
@@ -2137,11 +2131,6 @@ void b2StoreImpulsesTask( int startIndex, int endIndex, b2StepContext* context )
 		const float* normalVelocity1 = (float*)&c->relativeVelocity1;
 		const float* normalVelocity2 = (float*)&c->relativeVelocity2;
 
-		const float* previousNormalImpulse1 = (float*)&c->previousNormalImpulse1;
-		const float* previousNormalImpulse2 = (float*)&c->previousNormalImpulse2;
-		const float* previousTangentImpulse1 = (float*)&c->previousTangentImpulse1;
-		const float* previousTangentImpulse2 = (float*)&c->previousTangentImpulse2;
-
 		int baseIndex = B2_SIMD_WIDTH * constraintIndex;
 
 		for ( int laneIndex = 0; laneIndex < B2_SIMD_WIDTH; ++laneIndex )
@@ -2158,11 +2147,6 @@ void b2StoreImpulsesTask( int startIndex, int endIndex, b2StepContext* context )
 			m->points[1].tangentImpulse = tangentImpulse2[laneIndex];
 			m->points[1].totalNormalImpulse = totalNormalImpulse2[laneIndex];
 			m->points[1].normalVelocity = normalVelocity2[laneIndex];
-
-			m->points[0].previousNormalImpulse = previousNormalImpulse1[laneIndex];
-			m->points[0].previousTangentImpulse = previousTangentImpulse1[laneIndex];
-			m->points[1].previousNormalImpulse = previousNormalImpulse2[laneIndex];
-			m->points[1].previousTangentImpulse = previousTangentImpulse2[laneIndex];
 		}
 	}
 

--- a/src/distance_joint.c
+++ b/src/distance_joint.c
@@ -385,9 +385,9 @@ void b2SolveDistanceJoint( b2JointSim* base, b2StepContext* context, bool useBia
 				}
 				else if ( useBias )
 				{
-					bias = context->jointSoftness.biasRate * C;
-					massCoeff = context->jointSoftness.massScale;
-					impulseCoeff = context->jointSoftness.impulseScale;
+					bias = base->constraintSoftness.biasRate * C;
+					massCoeff = base->constraintSoftness.massScale;
+					impulseCoeff = base->constraintSoftness.impulseScale;
 				}
 
 				float impulse = -massCoeff * joint->axialMass * ( Cdot + bias ) - impulseCoeff * joint->lowerImpulse;
@@ -419,9 +419,9 @@ void b2SolveDistanceJoint( b2JointSim* base, b2StepContext* context, bool useBia
 				}
 				else if ( useBias )
 				{
-					bias = context->jointSoftness.biasRate * C;
-					massScale = context->jointSoftness.massScale;
-					impulseScale = context->jointSoftness.impulseScale;
+					bias = base->constraintSoftness.biasRate * C;
+					massScale = base->constraintSoftness.massScale;
+					impulseScale = base->constraintSoftness.impulseScale;
 				}
 
 				float impulse = -massScale * joint->axialMass * ( Cdot + bias ) - impulseScale * joint->upperImpulse;
@@ -467,9 +467,9 @@ void b2SolveDistanceJoint( b2JointSim* base, b2StepContext* context, bool useBia
 		float impulseScale = 0.0f;
 		if ( useBias )
 		{
-			bias = context->jointSoftness.biasRate * C;
-			massScale = context->jointSoftness.massScale;
-			impulseScale = context->jointSoftness.impulseScale;
+			bias = base->constraintSoftness.biasRate * C;
+			massScale = base->constraintSoftness.massScale;
+			impulseScale = base->constraintSoftness.impulseScale;
 		}
 
 		float impulse = -massScale * joint->axialMass * ( Cdot + bias ) - impulseScale * joint->impulse;

--- a/src/joint.c
+++ b/src/joint.c
@@ -876,6 +876,98 @@ b2Vec2 b2Joint_GetLocalAnchorB( b2JointId jointId )
 	return jointSim->localOriginAnchorB;
 }
 
+void b2Joint_SetReferenceAngle( b2JointId jointId, float angleInRadians )
+{
+	B2_ASSERT( b2IsValidFloat( angleInRadians ) );
+
+	b2World* world = b2GetWorld( jointId.world0 );
+	b2Joint* joint = b2GetJointFullId( world, jointId );
+	b2JointSim* jointSim = b2GetJointSim( world, joint );
+
+	switch ( joint->type )
+	{
+		case b2_prismaticJoint:
+			jointSim->prismaticJoint.referenceAngle = angleInRadians;
+			break;
+
+		case b2_revoluteJoint:
+			jointSim->revoluteJoint.referenceAngle = angleInRadians;
+			break;
+
+		case b2_weldJoint:
+			jointSim->weldJoint.referenceAngle = angleInRadians;
+			break;
+
+		default:
+			break;
+	}
+}
+
+float b2Joint_GetReferenceAngle( b2JointId jointId )
+{
+	b2World* world = b2GetWorld( jointId.world0 );
+	b2Joint* joint = b2GetJointFullId( world, jointId );
+	b2JointSim* jointSim = b2GetJointSim( world, joint );
+
+	switch ( joint->type )
+	{
+		case b2_prismaticJoint:
+			return jointSim->prismaticJoint.referenceAngle;
+
+		case b2_revoluteJoint:
+			return jointSim->revoluteJoint.referenceAngle;
+
+		case b2_weldJoint:
+			return jointSim->weldJoint.referenceAngle;
+
+		default:
+			return 0.0f;
+	}
+}
+
+void b2Joint_SetLocalAxisA( b2JointId jointId, b2Vec2 localAxis )
+{
+	B2_ASSERT( b2IsValidVec2( localAxis ) );
+	B2_ASSERT( b2IsNormalized( localAxis ) );
+
+	b2World* world = b2GetWorld( jointId.world0 );
+	b2Joint* joint = b2GetJointFullId( world, jointId );
+	b2JointSim* jointSim = b2GetJointSim( world, joint );
+
+	switch ( joint->type )
+	{
+		case b2_prismaticJoint:
+			jointSim->prismaticJoint.localAxisA = localAxis;
+			break;
+
+		case b2_wheelJoint:
+			jointSim->wheelJoint.localAxisA = localAxis;
+			break;
+
+		default:
+			break;
+	}
+}
+
+b2Vec2 b2Joint_GetLocalAxisA( b2JointId jointId )
+{
+	b2World* world = b2GetWorld( jointId.world0 );
+	b2Joint* joint = b2GetJointFullId( world, jointId );
+	b2JointSim* jointSim = b2GetJointSim( world, joint );
+
+	switch ( joint->type )
+	{
+		case b2_prismaticJoint:
+			return jointSim->prismaticJoint.localAxisA;
+
+		case b2_wheelJoint:
+			return jointSim->wheelJoint.localAxisA;
+
+		default:
+			return b2Vec2_zero;
+	}
+}
+
 void b2Joint_SetCollideConnected( b2JointId jointId, bool shouldCollide )
 {
 	b2World* world = b2GetWorldLocked( jointId.world0 );

--- a/src/joint.c
+++ b/src/joint.c
@@ -288,6 +288,11 @@ static b2JointPair b2CreateJoint( b2World* world, b2Body* bodyA, b2Body* bodyB, 
 
 	jointSim->constraintHertz = B2_JOINT_CONSTRAINT_HERTZ;
 	jointSim->constraintDampingRatio = B2_JOINT_CONSTRAINT_DAMPING_RATIO;
+	jointSim->constraintSoftness = (b2Softness){
+		.biasRate = 0.0f,
+		.massScale = 1.0f,
+		.impulseScale = 0.0f,
+	};
 
 	B2_ASSERT( jointSim->jointId == jointId );
 	B2_ASSERT( jointSim->bodyIdA == bodyIdA );
@@ -845,8 +850,8 @@ b2WorldId b2Joint_GetWorld( b2JointId jointId )
 
 void b2Joint_SetLocalAnchorA( b2JointId jointId, b2Vec2 localAnchor )
 {
-	B2_ASSERT(b2IsValidVec2(localAnchor));
-	
+	B2_ASSERT( b2IsValidVec2( localAnchor ) );
+
 	b2World* world = b2GetWorld( jointId.world0 );
 	b2Joint* joint = b2GetJointFullId( world, jointId );
 	b2JointSim* jointSim = b2GetJointSim( world, joint );
@@ -863,8 +868,8 @@ b2Vec2 b2Joint_GetLocalAnchorA( b2JointId jointId )
 
 void b2Joint_SetLocalAnchorB( b2JointId jointId, b2Vec2 localAnchor )
 {
-	B2_ASSERT(b2IsValidVec2(localAnchor));
-	
+	B2_ASSERT( b2IsValidVec2( localAnchor ) );
+
 	b2World* world = b2GetWorld( jointId.world0 );
 	b2Joint* joint = b2GetJointFullId( world, jointId );
 	b2JointSim* jointSim = b2GetJointSim( world, joint );
@@ -1129,7 +1134,7 @@ float b2Joint_GetConstraintTorque( b2JointId jointId )
 	}
 }
 
-float b2Joint_GetLinearSeparation(b2JointId jointId)
+float b2Joint_GetLinearSeparation( b2JointId jointId )
 {
 	b2World* world = b2GetWorld( jointId.world0 );
 	b2Joint* joint = b2GetJointFullId( world, jointId );
@@ -1138,8 +1143,8 @@ float b2Joint_GetLinearSeparation(b2JointId jointId)
 	b2Transform xfA = b2GetBodyTransform( world, joint->edges[0].bodyId );
 	b2Transform xfB = b2GetBodyTransform( world, joint->edges[1].bodyId );
 
-	b2Vec2 pA = b2TransformPoint(xfA, base->localOriginAnchorA);
-	b2Vec2 pB = b2TransformPoint(xfB, base->localOriginAnchorB);
+	b2Vec2 pA = b2TransformPoint( xfA, base->localOriginAnchorA );
+	b2Vec2 pB = b2TransformPoint( xfB, base->localOriginAnchorB );
 	b2Vec2 dp = b2Sub( pB, pA );
 
 	switch ( joint->type )
@@ -1148,15 +1153,15 @@ float b2Joint_GetLinearSeparation(b2JointId jointId)
 		{
 			b2DistanceJoint* distanceJoint = &base->distanceJoint;
 			float length = b2Length( dp );
-			if (distanceJoint->enableSpring)
+			if ( distanceJoint->enableSpring )
 			{
-				if (distanceJoint->enableLimit)
+				if ( distanceJoint->enableLimit )
 				{
-					if (length < distanceJoint->minLength)
+					if ( length < distanceJoint->minLength )
 					{
 						return distanceJoint->minLength - length;
 					}
-					else if (length > distanceJoint->maxLength)
+					else if ( length > distanceJoint->maxLength )
 					{
 						return length - distanceJoint->maxLength;
 					}
@@ -1184,18 +1189,18 @@ float b2Joint_GetLinearSeparation(b2JointId jointId)
 			b2PrismaticJoint* prismaticJoint = &base->prismaticJoint;
 			b2Vec2 axisA = b2RotateVector( xfA.q, prismaticJoint->localAxisA );
 			b2Vec2 perpA = b2LeftPerp( axisA );
-			float perpendicularSeparation = b2AbsFloat(b2Dot( perpA, dp ));
+			float perpendicularSeparation = b2AbsFloat( b2Dot( perpA, dp ) );
 			float limitSeparation = 0.0f;
 
-			if (prismaticJoint->enableLimit)
+			if ( prismaticJoint->enableLimit )
 			{
 				float translation = b2Dot( axisA, dp );
-				if (translation < prismaticJoint->lowerTranslation)
+				if ( translation < prismaticJoint->lowerTranslation )
 				{
 					limitSeparation = prismaticJoint->lowerTranslation - translation;
 				}
 
-				if (prismaticJoint->upperTranslation < translation)
+				if ( prismaticJoint->upperTranslation < translation )
 				{
 					limitSeparation = translation - prismaticJoint->upperTranslation;
 				}
@@ -1282,15 +1287,15 @@ float b2Joint_GetAngularSeparation( b2JointId jointId )
 		case b2_revoluteJoint:
 		{
 			b2RevoluteJoint* revoluteJoint = &base->revoluteJoint;
-			if (revoluteJoint->enableLimit)
+			if ( revoluteJoint->enableLimit )
 			{
 				float angle = b2UnwindAngle( relativeAngle - revoluteJoint->referenceAngle );
-				if (angle < revoluteJoint->lowerAngle)
+				if ( angle < revoluteJoint->lowerAngle )
 				{
 					return revoluteJoint->lowerAngle - angle;
 				}
 
-				if (revoluteJoint->upperAngle < angle)
+				if ( revoluteJoint->upperAngle < angle )
 				{
 					return angle - revoluteJoint->upperAngle;
 				}
@@ -1319,7 +1324,7 @@ float b2Joint_GetAngularSeparation( b2JointId jointId )
 	}
 }
 
-void b2Joint_GetConstraintTuning(b2JointId jointId, float* hertz, float* dampingRatio)
+void b2Joint_GetConstraintTuning( b2JointId jointId, float* hertz, float* dampingRatio )
 {
 	b2World* world = b2GetWorld( jointId.world0 );
 	b2Joint* joint = b2GetJointFullId( world, jointId );
@@ -1328,7 +1333,7 @@ void b2Joint_GetConstraintTuning(b2JointId jointId, float* hertz, float* damping
 	*dampingRatio = base->constraintDampingRatio;
 }
 
-void b2Joint_SetConstraintTuning(b2JointId jointId, float hertz, float dampingRatio)
+void b2Joint_SetConstraintTuning( b2JointId jointId, float hertz, float dampingRatio )
 {
 	B2_ASSERT( b2IsValidFloat( hertz ) && hertz >= 0.0f );
 	B2_ASSERT( b2IsValidFloat( dampingRatio ) && dampingRatio >= 0.0f );
@@ -1342,6 +1347,7 @@ void b2Joint_SetConstraintTuning(b2JointId jointId, float hertz, float dampingRa
 
 void b2PrepareJoint( b2JointSim* joint, b2StepContext* context )
 {
+	// Clamp joint hertz based on the time step to reduce jitter.
 	float hertz = b2MinFloat( joint->constraintHertz, 0.25f * context->inv_h );
 	joint->constraintSoftness = b2MakeSoft( hertz, joint->constraintDampingRatio, context->h );
 

--- a/src/joint.c
+++ b/src/joint.c
@@ -1342,7 +1342,7 @@ void b2Joint_SetConstraintTuning(b2JointId jointId, float hertz, float dampingRa
 
 void b2PrepareJoint( b2JointSim* joint, b2StepContext* context )
 {
-	float hertz = b2MinFloat( joint->constraintHertz, 0.5f * context->inv_h );
+	float hertz = b2MinFloat( joint->constraintHertz, 0.25f * context->inv_h );
 	joint->constraintSoftness = b2MakeSoft( hertz, joint->constraintDampingRatio, context->h );
 
 	switch ( joint->type )

--- a/src/joint.h
+++ b/src/joint.h
@@ -175,13 +175,6 @@ typedef struct b2RevoluteJoint
 	float lowerAngle;
 	float upperAngle;
 
-	b2Vec2 previousLinearImpulse;
-	float previousLowerImpulse;
-	float previousUpperImpulse;
-	b2Vec2 linearImpulseVelocity;
-	float lowerImpulseVelocity;
-	float upperImpulseVelocity;
-
 	int indexA;
 	int indexB;
 	b2Vec2 anchorA;

--- a/src/joint.h
+++ b/src/joint.h
@@ -187,6 +187,7 @@ typedef struct b2RevoluteJoint
 	bool enableSpring;
 	bool enableMotor;
 	bool enableLimit;
+	bool stiffSolver;
 } b2RevoluteJoint;
 
 typedef struct b2WeldJoint

--- a/src/joint.h
+++ b/src/joint.h
@@ -175,6 +175,13 @@ typedef struct b2RevoluteJoint
 	float lowerAngle;
 	float upperAngle;
 
+	b2Vec2 previousLinearImpulse;
+	float previousLowerImpulse;
+	float previousUpperImpulse;
+	b2Vec2 linearImpulseVelocity;
+	float lowerImpulseVelocity;
+	float upperImpulseVelocity;
+
 	int indexA;
 	int indexB;
 	b2Vec2 anchorA;

--- a/src/joint.h
+++ b/src/joint.h
@@ -194,7 +194,6 @@ typedef struct b2RevoluteJoint
 	bool enableSpring;
 	bool enableMotor;
 	bool enableLimit;
-	bool stiffSolver;
 } b2RevoluteJoint;
 
 typedef struct b2WeldJoint

--- a/src/joint.h
+++ b/src/joint.h
@@ -267,6 +267,11 @@ typedef struct b2JointSim
 	float invMassA, invMassB;
 	float invIA, invIB;
 
+	float constraintHertz;
+	float constraintDampingRatio;
+
+	b2Softness constraintSoftness;
+
 	union
 	{
 		b2DistanceJoint distanceJoint;

--- a/src/mover.c
+++ b/src/mover.c
@@ -5,14 +5,14 @@
 
 #include "box2d/collision.h"
 
-b2PlaneSolverResult b2SolvePlanes( b2Vec2 position, b2CollisionPlane* planes, int count )
+b2PlaneSolverResult b2SolvePlanes( b2Vec2 targetDelta, b2CollisionPlane* planes, int count )
 {
 	for ( int i = 0; i < count; ++i )
 	{
 		planes[i].push = 0.0f;
 	}
 
-	b2Vec2 delta = b2Vec2_zero;
+	b2Vec2 delta = targetDelta;
 	float tolerance = B2_LINEAR_SLOP;
 
 	int iteration;
@@ -49,7 +49,7 @@ b2PlaneSolverResult b2SolvePlanes( b2Vec2 position, b2CollisionPlane* planes, in
 	}
 
 	return (b2PlaneSolverResult){
-		.position = b2Add( delta, position ),
+		.translation = delta,
 		.iterationCount = iteration,
 	};
 }

--- a/src/prismatic_joint.c
+++ b/src/prismatic_joint.c
@@ -484,9 +484,9 @@ void b2SolvePrismaticJoint( b2JointSim* base, b2StepContext* context, bool useBi
 			}
 			else if ( useBias )
 			{
-				bias = context->jointSoftness.biasRate * C;
-				massScale = context->jointSoftness.massScale;
-				impulseScale = context->jointSoftness.impulseScale;
+				bias = base->constraintSoftness.biasRate * C;
+				massScale = base->constraintSoftness.massScale;
+				impulseScale = base->constraintSoftness.impulseScale;
 			}
 
 			float oldImpulse = joint->lowerImpulse;
@@ -522,9 +522,9 @@ void b2SolvePrismaticJoint( b2JointSim* base, b2StepContext* context, bool useBi
 			}
 			else if ( useBias )
 			{
-				bias = context->jointSoftness.biasRate * C;
-				massScale = context->jointSoftness.massScale;
-				impulseScale = context->jointSoftness.impulseScale;
+				bias = base->constraintSoftness.biasRate * C;
+				massScale = base->constraintSoftness.massScale;
+				impulseScale = base->constraintSoftness.impulseScale;
 			}
 
 			float oldImpulse = joint->upperImpulse;
@@ -567,9 +567,9 @@ void b2SolvePrismaticJoint( b2JointSim* base, b2StepContext* context, bool useBi
 			C.x = b2Dot( perpA, d );
 			C.y = b2RelativeAngle( stateB->deltaRotation, stateA->deltaRotation ) + joint->deltaAngle;
 
-			bias = b2MulSV( context->jointSoftness.biasRate, C );
-			massScale = context->jointSoftness.massScale;
-			impulseScale = context->jointSoftness.impulseScale;
+			bias = b2MulSV( base->constraintSoftness.biasRate, C );
+			massScale = base->constraintSoftness.massScale;
+			impulseScale = base->constraintSoftness.impulseScale;
 		}
 
 		float k11 = mA + mB + iA * s1 * s1 + iB * s2 * s2;

--- a/src/revolute_joint.c
+++ b/src/revolute_joint.c
@@ -287,44 +287,6 @@ void b2WarmStartRevoluteJoint( b2JointSim* base, b2StepContext* context )
 	b2Vec2 rA = b2RotateVector( stateA->deltaRotation, joint->anchorA );
 	b2Vec2 rB = b2RotateVector( stateB->deltaRotation, joint->anchorB );
 
-#if 0
-	// todo_erin testing
-	float hertz = 0.01f;
-	float zeta = 0.7f;
-	float dt = context->h;
-
-	joint->linearImpulseVelocity.x = b2SpringDamper( hertz, zeta, joint->previousLinearImpulse.x - joint->linearImpulse.x,
-													 joint->linearImpulseVelocity.x, dt );
-	joint->linearImpulseVelocity.y = b2SpringDamper( hertz, zeta, joint->previousLinearImpulse.y - joint->linearImpulse.y,
-													 joint->linearImpulseVelocity.y, dt );
-	joint->linearImpulse = b2MulAdd( joint->previousLinearImpulse, dt, joint->linearImpulseVelocity );
-	joint->previousLinearImpulse = joint->linearImpulse;
-
-	joint->lowerImpulseVelocity = b2SpringDamper( hertz, zeta, joint->previousLowerImpulse - joint->lowerImpulse,
-												  joint->lowerImpulseVelocity, dt );
-	joint->lowerImpulse = joint->previousLowerImpulse + dt * joint->lowerImpulseVelocity;
-	joint->previousLowerImpulse = joint->lowerImpulse;
-
-	joint->upperImpulseVelocity = b2SpringDamper( hertz, zeta, joint->previousUpperImpulse - joint->upperImpulse,
-												  joint->upperImpulseVelocity, dt );
-	joint->upperImpulse = joint->previousUpperImpulse + dt * joint->upperImpulseVelocity;
-	joint->previousUpperImpulse = joint->upperImpulse;
-#elif 0
-	float easing = 0.01f * context->dt;
-	joint->linearImpulse = b2Lerp( joint->previousLinearImpulse, joint->linearImpulse, easing );
-	joint->lowerImpulse = ( 1.0f - easing ) * joint->previousLowerImpulse + easing * joint->lowerImpulse;
-	joint->upperImpulse = ( 1.0f - easing ) * joint->previousUpperImpulse + easing * joint->upperImpulse;
-	joint->previousLinearImpulse = joint->linearImpulse;
-	joint->previousLowerImpulse = joint->lowerImpulse;
-	joint->previousUpperImpulse = joint->upperImpulse;
-#elif 0
-	joint->linearImpulse = b2Vec2_zero;
-	joint->lowerImpulse = 0.0f;
-	joint->upperImpulse = 0.0f;
-	joint->motorImpulse = 0.0f;
-	joint->springImpulse = 0.0f;
-#endif
-
 	float axialImpulse = joint->springImpulse + joint->motorImpulse + joint->lowerImpulse - joint->upperImpulse;
 
 	stateA->linearVelocity = b2MulSub( stateA->linearVelocity, mA, joint->linearImpulse );
@@ -407,8 +369,6 @@ void b2SolveRevoluteJoint( b2JointSim* base, b2StepContext* context, bool useBia
 			float bias = 0.0f;
 			float massScale = 1.0f;
 			float impulseScale = 0.0f;
-			// float massScale = context->jointSoftness.massScale;
-			// float impulseScale = context->jointSoftness.impulseScale;
 			if ( C > 0.0f )
 			{
 				// speculation
@@ -416,9 +376,9 @@ void b2SolveRevoluteJoint( b2JointSim* base, b2StepContext* context, bool useBia
 			}
 			else if ( useBias )
 			{
-				bias = context->jointSoftness.biasRate * C;
-				massScale = context->jointSoftness.massScale;
-				impulseScale = context->jointSoftness.impulseScale;
+				bias = base->constraintSoftness.biasRate * C;
+				massScale = base->constraintSoftness.massScale;
+				impulseScale = base->constraintSoftness.impulseScale;
 			}
 
 			float Cdot = wB - wA;
@@ -439,8 +399,8 @@ void b2SolveRevoluteJoint( b2JointSim* base, b2StepContext* context, bool useBia
 			float bias = 0.0f;
 			float massScale = 1.0f;
 			float impulseScale = 0.0f;
-			// float massScale = context->jointSoftness.massScale;
-			// float impulseScale = context->jointSoftness.impulseScale;
+			// float massScale = base->constraintSoftness.massScale;
+			// float impulseScale = base->constraintSoftness.impulseScale;
 			if ( C > 0.0f )
 			{
 				// speculation
@@ -448,9 +408,9 @@ void b2SolveRevoluteJoint( b2JointSim* base, b2StepContext* context, bool useBia
 			}
 			else if ( useBias )
 			{
-				bias = context->jointSoftness.biasRate * C;
-				massScale = context->jointSoftness.massScale;
-				impulseScale = context->jointSoftness.impulseScale;
+				bias = base->constraintSoftness.biasRate * C;
+				massScale = base->constraintSoftness.massScale;
+				impulseScale = base->constraintSoftness.impulseScale;
 			}
 
 			// sign flipped on Cdot
@@ -483,14 +443,14 @@ void b2SolveRevoluteJoint( b2JointSim* base, b2StepContext* context, bool useBia
 		b2Vec2 bias = b2Vec2_zero;
 		float massScale = 1.0f;
 		float impulseScale = 0.0f;
-		// float massScale = context->jointSoftness.massScale;
-		// float impulseScale = context->jointSoftness.impulseScale;
+		// float massScale = base->constraintSoftness.massScale;
+		// float impulseScale = base->constraintSoftness.impulseScale;
 		if ( useBias )
 		{
 			b2Vec2 separation = b2Add( b2Add( b2Sub( dcB, dcA ), b2Sub( rB, rA ) ), joint->deltaCenter );
-			bias = b2MulSV( context->jointSoftness.biasRate, separation );
-			massScale = context->jointSoftness.massScale;
-			impulseScale = context->jointSoftness.impulseScale;
+			bias = b2MulSV( base->constraintSoftness.biasRate, separation );
+			massScale = base->constraintSoftness.massScale;
+			impulseScale = base->constraintSoftness.impulseScale;
 		}
 
 		b2Mat22 K;

--- a/src/revolute_joint.c
+++ b/src/revolute_joint.c
@@ -248,7 +248,7 @@ void b2PrepareRevoluteJoint( b2JointSim* base, b2StepContext* context )
 
 	joint->springSoftness = b2MakeSoft( joint->hertz, joint->dampingRatio, context->h );
 
-	if ( context->enableWarmStarting == false )
+	if ( context->enableWarmStarting == false || k > 0.0f )
 	{
 		joint->linearImpulse = b2Vec2_zero;
 		joint->springImpulse = 0.0f;
@@ -287,9 +287,9 @@ void b2WarmStartRevoluteJoint( b2JointSim* base, b2StepContext* context )
 	b2Vec2 rA = b2RotateVector( stateA->deltaRotation, joint->anchorA );
 	b2Vec2 rB = b2RotateVector( stateB->deltaRotation, joint->anchorB );
 
-#if 1
+#if 0
 	// todo_erin testing
-	float hertz = 1.0f;
+	float hertz = 0.01f;
 	float zeta = 0.7f;
 	float dt = context->h;
 
@@ -309,6 +309,20 @@ void b2WarmStartRevoluteJoint( b2JointSim* base, b2StepContext* context )
 												  joint->upperImpulseVelocity, dt );
 	joint->upperImpulse = joint->previousUpperImpulse + dt * joint->upperImpulseVelocity;
 	joint->previousUpperImpulse = joint->upperImpulse;
+#elif 0
+	float easing = 0.01f * context->dt;
+	joint->linearImpulse = b2Lerp( joint->previousLinearImpulse, joint->linearImpulse, easing );
+	joint->lowerImpulse = ( 1.0f - easing ) * joint->previousLowerImpulse + easing * joint->lowerImpulse;
+	joint->upperImpulse = ( 1.0f - easing ) * joint->previousUpperImpulse + easing * joint->upperImpulse;
+	joint->previousLinearImpulse = joint->linearImpulse;
+	joint->previousLowerImpulse = joint->lowerImpulse;
+	joint->previousUpperImpulse = joint->upperImpulse;
+#elif 0
+	joint->linearImpulse = b2Vec2_zero;
+	joint->lowerImpulse = 0.0f;
+	joint->upperImpulse = 0.0f;
+	joint->motorImpulse = 0.0f;
+	joint->springImpulse = 0.0f;
 #endif
 
 	float axialImpulse = joint->springImpulse + joint->motorImpulse + joint->lowerImpulse - joint->upperImpulse;

--- a/src/solver.c
+++ b/src/solver.c
@@ -24,6 +24,7 @@
 
 // todo testing
 #define ITERATIONS 1
+#define RELAX_ITERATIONS 1
 
 // Compare to SDL_CPUPauseInstruction
 #if ( defined( __GNUC__ ) || defined( __clang__ ) ) && ( defined( __i386__ ) || defined( __x86_64__ ) )
@@ -1052,7 +1053,7 @@ static void b2SolverTask( int startIndex, int endIndex, uint32_t threadIndexIgno
 
 			// relax constraints
 			useBias = false;
-			for ( int j = 0; j < ITERATIONS; ++j )
+			for ( int j = 0; j < RELAX_ITERATIONS; ++j )
 			{
 				b2SolveOverflowJoints( context, useBias );
 				b2SolveOverflowContacts( context, useBias );
@@ -1072,7 +1073,7 @@ static void b2SolverTask( int startIndex, int endIndex, uint32_t threadIndexIgno
 
 		// advance the stage according to the sub-stepping tasks just completed
 		// integrate velocities / warm start / solve / integrate positions / relax
-		stageIndex += 1 + activeColorCount + ITERATIONS * activeColorCount + 1 + activeColorCount;
+		stageIndex += 1 + activeColorCount + ITERATIONS * activeColorCount + 1 + RELAX_ITERATIONS * activeColorCount;
 
 		// Restitution
 		{
@@ -1456,7 +1457,7 @@ void b2Solve( b2World* world, b2StepContext* stepContext )
 		// b2_stageIntegratePositions
 		stageCount += 1;
 		// b2_stageRelax
-		stageCount += ITERATIONS * activeColorCount;
+		stageCount += RELAX_ITERATIONS * activeColorCount;
 		// b2_stageRestitution
 		stageCount += activeColorCount;
 		// b2_stageStoreImpulses
@@ -1635,7 +1636,7 @@ void b2Solve( b2World* world, b2StepContext* stepContext )
 		stage += 1;
 
 		// Relax constraints
-		for ( int j = 0; j < ITERATIONS; ++j )
+		for ( int j = 0; j < RELAX_ITERATIONS; ++j )
 		{
 			for ( int i = 0; i < activeColorCount; ++i )
 			{

--- a/src/solver.c
+++ b/src/solver.c
@@ -771,16 +771,13 @@ static void b2ExecuteBlock( b2SolverStage* stage, b2StepContext* context, b2Solv
 			break;
 
 		case b2_stageWarmStart:
-			if ( context->world->enableWarmStarting )
+			if ( blockType == b2_graphContactBlock )
 			{
-				if ( blockType == b2_graphContactBlock )
-				{
-					b2WarmStartContactsTask( startIndex, endIndex, context, stage->colorIndex );
-				}
-				else if ( blockType == b2_graphJointBlock )
-				{
-					b2WarmStartJointsTask( startIndex, endIndex, context, stage->colorIndex );
-				}
+				b2WarmStartContactsTask( startIndex, endIndex, context, stage->colorIndex );
+			}
+			else if ( blockType == b2_graphJointBlock )
+			{
+				b2WarmStartJointsTask( startIndex, endIndex, context, stage->colorIndex );
 			}
 			break;
 

--- a/src/solver.h
+++ b/src/solver.h
@@ -154,6 +154,27 @@ static inline b2Softness b2MakeSoft( float hertz, float zeta, float h )
 	float a2 = h * omega * a1;
 	float a3 = 1.0f / ( 1.0f + a2 );
 
+	// bias = w / (2 * z + hw)
+	// massScale = hw * (2 * z + hw) / (1 + hw * (2 * z + hw))
+	// impulseScale = 1 / (1 + hw * (2 * z + hw))
+
+	// If z == 0
+	// bias = 1/h
+	// massScale = hw^2 / (1 + hw^2)
+	// impulseScale = 1 / (1 + hw^2)
+
+	// w -> inf
+	// bias = 1/h
+	// massScale = 1
+	// impulseScale = 0
+
+	// if w = pi / 4  * inv_h
+	// massScale = (pi/4)^2 / (1 + (pi/4)^2) = pi^2 / (16 + pi^2) ~= 0.38
+	// impulseScale = 1 / (1 + (pi/4)^2) = 16 / (16 + pi^2) ~= 0.62
+
+	// In all cases:
+	// massScale + impulseScale == 1
+
 	return (b2Softness){
 		.biasRate = omega / a1,
 		.massScale = a2 * a3,

--- a/src/solver.h
+++ b/src/solver.h
@@ -86,7 +86,6 @@ typedef struct b2StepContext
 
 	int subStepCount;
 
-	b2Softness jointSoftness;
 	b2Softness contactSoftness;
 	b2Softness staticSoftness;
 

--- a/src/types.c
+++ b/src/types.c
@@ -14,7 +14,7 @@ b2WorldDef b2DefaultWorldDef( void )
 	def.hitEventThreshold = 1.0f * b2_lengthUnitsPerMeter;
 	def.restitutionThreshold = 1.0f * b2_lengthUnitsPerMeter;
 	def.maxContactPushSpeed = 3.0f * b2_lengthUnitsPerMeter;
-	def.contactHertz = 30.0f;
+	def.contactHertz = 240.0f;
 	def.contactDampingRatio = 10.0f;
 	def.jointHertz = 240.0f;
 	def.jointDampingRatio = 1.0f;

--- a/src/types.c
+++ b/src/types.c
@@ -14,10 +14,10 @@ b2WorldDef b2DefaultWorldDef( void )
 	def.hitEventThreshold = 1.0f * b2_lengthUnitsPerMeter;
 	def.restitutionThreshold = 1.0f * b2_lengthUnitsPerMeter;
 	def.maxContactPushSpeed = 3.0f * b2_lengthUnitsPerMeter;
-	def.contactHertz = 30.0;
+	def.contactHertz = 30.0f;
 	def.contactDampingRatio = 10.0f;
-	def.jointHertz = 60.0;
-	def.jointDampingRatio = 2.0f;
+	def.jointHertz = 60.0f;
+	def.jointDampingRatio = 1.0f;
 	// 400 meters per second, faster than the speed of sound
 	def.maximumLinearSpeed = 400.0f * b2_lengthUnitsPerMeter;
 	def.enableSleep = true;

--- a/src/types.c
+++ b/src/types.c
@@ -16,8 +16,8 @@ b2WorldDef b2DefaultWorldDef( void )
 	def.maxContactPushSpeed = 3.0f * b2_lengthUnitsPerMeter;
 	def.contactHertz = 30.0f;
 	def.contactDampingRatio = 10.0f;
-	def.jointHertz = 60.0f;
-	def.jointDampingRatio = 0.0f;
+	def.jointHertz = 240.0f;
+	def.jointDampingRatio = 1.0f;
 	// 400 meters per second, faster than the speed of sound
 	def.maximumLinearSpeed = 400.0f * b2_lengthUnitsPerMeter;
 	def.enableSleep = true;

--- a/src/types.c
+++ b/src/types.c
@@ -17,7 +17,7 @@ b2WorldDef b2DefaultWorldDef( void )
 	def.contactHertz = 30.0f;
 	def.contactDampingRatio = 10.0f;
 	def.jointHertz = 60.0f;
-	def.jointDampingRatio = 1.0f;
+	def.jointDampingRatio = 0.0f;
 	// 400 meters per second, faster than the speed of sound
 	def.maximumLinearSpeed = 400.0f * b2_lengthUnitsPerMeter;
 	def.enableSleep = true;

--- a/src/types.c
+++ b/src/types.c
@@ -14,12 +14,12 @@ b2WorldDef b2DefaultWorldDef( void )
 	def.hitEventThreshold = 1.0f * b2_lengthUnitsPerMeter;
 	def.restitutionThreshold = 1.0f * b2_lengthUnitsPerMeter;
 	def.maxContactPushSpeed = 3.0f * b2_lengthUnitsPerMeter;
-	def.contactHertz = 240.0f;
+	def.contactHertz = 30.0;
 	def.contactDampingRatio = 10.0f;
-	def.jointHertz = 240.0f;
-	def.jointDampingRatio = 1.0f;
+
 	// 400 meters per second, faster than the speed of sound
 	def.maximumLinearSpeed = 400.0f * b2_lengthUnitsPerMeter;
+
 	def.enableSleep = true;
 	def.enableContinuous = true;
 	def.internalValue = B2_SECRET_COOKIE;

--- a/src/weld_joint.c
+++ b/src/weld_joint.c
@@ -139,7 +139,7 @@ void b2PrepareWeldJoint( b2JointSim* base, b2StepContext* context )
 
 	if ( joint->linearHertz == 0.0f )
 	{
-		joint->linearSoftness = context->jointSoftness;
+		joint->linearSoftness = base->constraintSoftness;
 	}
 	else
 	{
@@ -148,7 +148,7 @@ void b2PrepareWeldJoint( b2JointSim* base, b2StepContext* context )
 
 	if ( joint->angularHertz == 0.0f )
 	{
-		joint->angularSoftness = context->jointSoftness;
+		joint->angularSoftness = base->constraintSoftness;
 	}
 	else
 	{

--- a/src/weld_joint.c
+++ b/src/weld_joint.c
@@ -11,19 +11,6 @@
 // needed for dll export
 #include "box2d/box2d.h"
 
-float b2WeldJoint_GetReferenceAngle( b2JointId jointId )
-{
-	b2JointSim* joint = b2GetJointSimCheckType( jointId, b2_weldJoint );
-	return joint->weldJoint.referenceAngle;
-}
-
-void b2WeldJoint_SetReferenceAngle( b2JointId jointId, float angleInRadians )
-{
-	B2_ASSERT( b2IsValidFloat( angleInRadians ) );
-	b2JointSim* joint = b2GetJointSimCheckType( jointId, b2_weldJoint );
-	joint->weldJoint.referenceAngle = b2ClampFloat(angleInRadians, -B2_PI, B2_PI);
-}
-
 void b2WeldJoint_SetLinearHertz( b2JointId jointId, float hertz )
 {
 	B2_ASSERT( b2IsValidFloat( hertz ) && hertz >= 0.0f );

--- a/src/wheel_joint.c
+++ b/src/wheel_joint.c
@@ -391,9 +391,9 @@ void b2SolveWheelJoint( b2JointSim* base, b2StepContext* context, bool useBias )
 			}
 			else if ( useBias )
 			{
-				bias = context->jointSoftness.biasRate * C;
-				massScale = context->jointSoftness.massScale;
-				impulseScale = context->jointSoftness.impulseScale;
+				bias = base->constraintSoftness.biasRate * C;
+				massScale = base->constraintSoftness.massScale;
+				impulseScale = base->constraintSoftness.impulseScale;
 			}
 
 			float Cdot = b2Dot( axisA, b2Sub( vB, vA ) ) + a2 * wB - a1 * wA;
@@ -429,9 +429,9 @@ void b2SolveWheelJoint( b2JointSim* base, b2StepContext* context, bool useBias )
 			}
 			else if ( useBias )
 			{
-				bias = context->jointSoftness.biasRate * C;
-				massScale = context->jointSoftness.massScale;
-				impulseScale = context->jointSoftness.impulseScale;
+				bias = base->constraintSoftness.biasRate * C;
+				massScale = base->constraintSoftness.massScale;
+				impulseScale = base->constraintSoftness.impulseScale;
 			}
 
 			// sign flipped on Cdot
@@ -463,9 +463,9 @@ void b2SolveWheelJoint( b2JointSim* base, b2StepContext* context, bool useBias )
 		if ( useBias )
 		{
 			float C = b2Dot( perpA, d );
-			bias = context->jointSoftness.biasRate * C;
-			massScale = context->jointSoftness.massScale;
-			impulseScale = context->jointSoftness.impulseScale;
+			bias = base->constraintSoftness.biasRate * C;
+			massScale = base->constraintSoftness.massScale;
+			impulseScale = base->constraintSoftness.impulseScale;
 		}
 
 		float s1 = b2Cross( b2Add( d, rA ), perpA );

--- a/src/world.c
+++ b/src/world.c
@@ -763,7 +763,9 @@ void b2World_Step( b2WorldId worldId, float timeStep, int subStepCount )
 
 	// Hertz values get reduced for large time steps
 	float contactHertz = b2MinFloat( world->contactHertz, 0.25f * context.inv_h );
-	float jointHertz = b2MinFloat( world->jointHertz, 0.125f * context.inv_h );
+
+	// There is no increase in stiffness beyond this value
+	float jointHertz = b2MinFloat( world->jointHertz, 0.5f * context.inv_h );
 
 	context.contactSoftness = b2MakeSoft( contactHertz, world->contactDampingRatio, context.h );
 	context.staticSoftness = b2MakeSoft( 2.0f * contactHertz, world->contactDampingRatio, context.h );

--- a/src/world.c
+++ b/src/world.c
@@ -762,12 +762,14 @@ void b2World_Step( b2WorldId worldId, float timeStep, int subStepCount )
 	world->inv_h = context.inv_h;
 
 	// Hertz values get reduced for large time steps
-	float contactHertz = b2MinFloat( world->contactHertz, 0.25f * context.inv_h );
-	float jointHertz = b2MinFloat( world->jointHertz, 0.25f * context.inv_h );
+	float contactHertz = b2MinFloat( world->contactHertz, 0.125f * context.inv_h );
+	float jointHertz = b2MinFloat( world->jointHertz, 0.125f * context.inv_h );
 
 	context.contactSoftness = b2MakeSoft( contactHertz, world->contactDampingRatio, context.h );
 	context.staticSoftness = b2MakeSoft( 2.0f * contactHertz, world->contactDampingRatio, context.h );
 	context.jointSoftness = b2MakeSoft( jointHertz, world->jointDampingRatio, context.h );
+
+	world->contactSpeed = world->maxContactPushSpeed / context.staticSoftness.massScale;
 
 	context.restitutionThreshold = world->restitutionThreshold;
 	context.maxLinearVelocity = world->maxLinearSpeed;
@@ -1419,9 +1421,9 @@ void b2World_Draw( b2WorldId worldId, b2DebugDraw* draw )
 					else if ( draw->drawContactImpulses )
 					{
 						b2Vec2 p1 = point->point;
-						b2Vec2 p2 = b2MulAdd( p1, k_impulseScale * point->normalImpulse, normal );
+						b2Vec2 p2 = b2MulAdd( p1, k_impulseScale * point->totalNormalImpulse, normal );
 						draw->DrawSegmentFcn( p1, p2, impulseColor, draw->context );
-						snprintf( buffer, B2_ARRAY_COUNT( buffer ), "%.2f", 1000.0f * point->normalImpulse );
+						snprintf( buffer, B2_ARRAY_COUNT( buffer ), "%.2f", 1000.0f * point->totalNormalImpulse );
 						draw->DrawStringFcn( p1, buffer, b2_colorWhite, draw->context );
 					}
 

--- a/src/world.c
+++ b/src/world.c
@@ -763,9 +763,7 @@ void b2World_Step( b2WorldId worldId, float timeStep, int subStepCount )
 
 	// Hertz values get reduced for large time steps
 	float contactHertz = b2MinFloat( world->contactHertz, 0.25f * context.inv_h );
-
-	// There is no increase in stiffness beyond this value
-	float jointHertz = b2MinFloat( world->jointHertz, 0.5f * context.inv_h );
+	float jointHertz = b2MinFloat( world->jointHertz, 0.25f * context.inv_h );
 
 	context.contactSoftness = b2MakeSoft( contactHertz, world->contactDampingRatio, context.h );
 	context.staticSoftness = b2MakeSoft( 2.0f * contactHertz, world->contactDampingRatio, context.h );
@@ -2516,7 +2514,8 @@ static bool TreeCollideCallback( int proxyId, uint64_t userData, void* context )
 
 	b2PlaneResult result = b2CollideMover( shape, transform, &worldContext->mover );
 
-	if ( result.hit )
+	// todo handle deep overlap
+	if ( result.hit && b2IsNormalized(result.plane.normal) )
 	{
 		b2ShapeId id = { shape->id + 1, world->worldId, shape->generation };
 		return worldContext->fcn( id, &result, worldContext->userContext );

--- a/src/world.c
+++ b/src/world.c
@@ -194,8 +194,6 @@ b2WorldId b2CreateWorld( const b2WorldDef* def )
 	world->maxContactPushSpeed = def->maxContactPushSpeed;
 	world->contactHertz = def->contactHertz;
 	world->contactDampingRatio = def->contactDampingRatio;
-	world->jointHertz = def->jointHertz;
-	world->jointDampingRatio = def->jointDampingRatio;
 
 	if ( def->frictionCallback == NULL )
 	{
@@ -763,11 +761,8 @@ void b2World_Step( b2WorldId worldId, float timeStep, int subStepCount )
 
 	// Hertz values get reduced for large time steps
 	float contactHertz = b2MinFloat( world->contactHertz, 0.125f * context.inv_h );
-	float jointHertz = b2MinFloat( world->jointHertz, 0.125f * context.inv_h );
-
 	context.contactSoftness = b2MakeSoft( contactHertz, world->contactDampingRatio, context.h );
 	context.staticSoftness = b2MakeSoft( 2.0f * contactHertz, world->contactDampingRatio, context.h );
-	context.jointSoftness = b2MakeSoft( jointHertz, world->jointDampingRatio, context.h );
 
 	world->contactSpeed = world->maxContactPushSpeed / context.staticSoftness.massScale;
 
@@ -1839,19 +1834,6 @@ void b2World_SetContactTuning( b2WorldId worldId, float hertz, float dampingRati
 	world->contactHertz = b2ClampFloat( hertz, 0.0f, FLT_MAX );
 	world->contactDampingRatio = b2ClampFloat( dampingRatio, 0.0f, FLT_MAX );
 	world->maxContactPushSpeed = b2ClampFloat( pushSpeed, 0.0f, FLT_MAX );
-}
-
-void b2World_SetJointTuning( b2WorldId worldId, float hertz, float dampingRatio )
-{
-	b2World* world = b2GetWorldFromId( worldId );
-	B2_ASSERT( world->locked == false );
-	if ( world->locked )
-	{
-		return;
-	}
-
-	world->jointHertz = b2ClampFloat( hertz, 0.0f, FLT_MAX );
-	world->jointDampingRatio = b2ClampFloat( dampingRatio, 0.0f, FLT_MAX );
 }
 
 void b2World_SetMaximumLinearSpeed( b2WorldId worldId, float maximumLinearSpeed )

--- a/src/world.h
+++ b/src/world.h
@@ -133,6 +133,7 @@ typedef struct b2World
 	float restitutionThreshold;
 	float maxLinearSpeed;
 	float maxContactPushSpeed;
+	float contactSpeed;
 	float contactHertz;
 	float contactDampingRatio;
 	float jointHertz;

--- a/src/world.h
+++ b/src/world.h
@@ -136,8 +136,6 @@ typedef struct b2World
 	float contactSpeed;
 	float contactHertz;
 	float contactDampingRatio;
-	float jointHertz;
-	float jointDampingRatio;
 
 	b2FrictionCallback* frictionCallback;
 	b2RestitutionCallback* restitutionCallback;

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -17,8 +17,8 @@
 #define TracyCFrameMark
 #endif
 
-#define EXPECTED_SLEEP_STEP 323
-#define EXPECTED_HASH 0xdf9ee1fb
+#define EXPECTED_SLEEP_STEP 296
+#define EXPECTED_HASH 0x87b550a7
 
 enum
 {

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -17,8 +17,8 @@
 #define TracyCFrameMark
 #endif
 
-#define EXPECTED_SLEEP_STEP 296
-#define EXPECTED_HASH 0x87b550a7
+#define EXPECTED_SLEEP_STEP 288
+#define EXPECTED_HASH 0x35467e1e
 
 enum
 {

--- a/test/test_id.c
+++ b/test/test_id.c
@@ -7,6 +7,14 @@
 
 int IdTest( void )
 {
+	uint32_t a = 0x01234567;
+
+	{
+		b2WorldId id = b2LoadWorldId( a );
+		uint32_t b = b2StoreWorldId( id );
+		ENSURE( b == a );
+	}
+
 	uint64_t x = 0x0123456789ABCDEFull;
 
 	{

--- a/test/test_world.c
+++ b/test/test_world.c
@@ -302,7 +302,6 @@ int TestWorldCoverage( void )
 	b2World_Explode( worldId, &explosionDef );
 
 	b2World_SetContactTuning( worldId, 10.0f, 2.0f, 4.0f );
-	b2World_SetJointTuning( worldId, 10.0f, 2.0f );
 
 	b2World_SetMaximumLinearSpeed( worldId, 10.0f );
 	value = b2World_GetMaximumLinearSpeed( worldId );


### PR DESCRIPTION
Joint stiffness is now tunable per joint. This allows specific joints to have increased stiffness, which may be important for some games.
Removed `b2World_SetJointTuning`
Added `b2Joint_SetConstraintTuning` and `b2Joint_GetConstraintTuning`.
Added `b2StoreWorldId` and `b2LoadWorldId`.
Added `b2Joint_GetReferenceAngle`, `b2Joint_SetReferenceAngle`, `b2Joint_SetLocalAxisA`, and `b2Joint_GetLocalAxisA`.
Removed `b2WeldJoint_GetReferenceAngle` and `b2WeldJoint_SetReferenceAngle`.
Added `b2SpringDamper` math utility function used by the character sample.
Fixed bug in `b2SolvePlanes`.