### PR TITLE
Add Swift SPM package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,4 +161,23 @@ jobs:
       
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config Release
+
+  swift-package-manager:
+    name: swift-spm
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Select Xcode version
+      run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+    
+    - name: Swift Package - Build
+      run: swift build -c release
+    
+    - name: Swift Package - Test Build
+      run: swift build -c debug
+      
+    - name: Swift Package - Validate Package
+      run: swift package dump-package > /dev/null
       

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version:5.10
+import PackageDescription
+
+let package = Package(
+    name: "box2d",
+    products: [
+        .library(
+            name: "box2d",
+            targets: ["box2d"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "box2d",
+            path: ".",
+            exclude: [
+                "src/box2d.natvis",
+                "src/CMakeLists.txt"
+            ],
+            sources: [
+                "src"
+            ],
+            publicHeadersPath: "include",
+            cSettings: [
+                .define("B2_API", to: ""),
+                .headerSearchPath("include"),
+                .headerSearchPath("src")
+            ]
+        ),
+    ],
+    cLanguageStandard: .c17
+)


### PR DESCRIPTION
This PR introduces a `Package.swift` manifest to enable Swift Package Manager (SPM) support for the Box2D library. With this change, Swift developers can now easily integrate Box2D into their projects by declaring it as a dependency in their own Package.swift files.

Changes:
- Added a Package.swift file to the root of the repository.
- Defined targets and sources for Box2D's C/C++ code to allow compilation in Swift projects.
- Exposed the Box2D module under the name `box2d`

Usage Example (in Swift project's Package.swift):
```
.package(url: "https://github.com/erincatto/box2d.git", from: "your-version-tag")
```

---

I understand that pull requests might not be your preferred way of contributing - if that’s the case, please let me know and I’ll be happy to open an issue and attach the file there instead.