### PR TITLE
Sensor hits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ include(FetchContent)
 include(CMakeDependentOption)
 
 project(box2d
-	VERSION 3.1.1
+	VERSION 3.2.0
 	DESCRIPTION "A 2D physics engine for games"
 	HOMEPAGE_URL "https://box2d.org"
 	LANGUAGES C CXX

--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -229,7 +229,7 @@ B2_API void b2Body_SetType( b2BodyId bodyId, b2BodyType type );
 /// Set the body name. Up to 31 characters excluding 0 termination.
 B2_API void b2Body_SetName( b2BodyId bodyId, const char* name );
 
-/// Get the body name. May be null.
+/// Get the body name.
 B2_API const char* b2Body_GetName( b2BodyId bodyId );
 
 /// Set the user data for a body
@@ -249,7 +249,7 @@ B2_API b2Transform b2Body_GetTransform( b2BodyId bodyId );
 
 /// Set the world transform of a body. This acts as a teleport and is fairly expensive.
 /// @note Generally you should create a body with then intended transform.
-/// @see b2BodyDef::position and b2BodyDef::angle
+/// @see b2BodyDef::position and b2BodyDef::rotation
 B2_API void b2Body_SetTransform( b2BodyId bodyId, b2Vec2 position, b2Rot rotation );
 
 /// Get a local point on a body given a world point
@@ -672,8 +672,8 @@ B2_API int b2Shape_GetSensorOverlaps( b2ShapeId shapeId, b2ShapeId* overlaps, in
 /// Get the current world AABB
 B2_API b2AABB b2Shape_GetAABB( b2ShapeId shapeId );
 
-/// Get the mass data for a shape
-B2_API b2MassData b2Shape_GetMassData( b2ShapeId shapeId );
+/// Compute the mass data for a shape
+B2_API b2MassData b2Shape_ComputeMassData( b2ShapeId shapeId );
 
 /// Get the closest point on a shape to a target point. Target and result are in world space.
 /// todo need sample
@@ -1240,10 +1240,7 @@ B2_API float b2WheelJoint_GetMotorTorque( b2JointId jointId );
 /// Contact identifier validation. Provides validation for up to 2^32 allocations.
 B2_API bool b2Contact_IsValid( b2ContactId id );
 
-/// Get manifold for a contact. The manifold may have no points if the contact is not touching.
-B2_API b2Manifold b2Contact_GetManifold( b2ContactId contactId );
-
-/// Get the shapes associated with a contact.
-B2_API void b2Contact_GetShapeIds( b2ContactId contactId, b2ShapeId* shapeIdA, b2ShapeId* shapeIdB );
+/// Get the data for a contact. The manifold may have no points if the contact is not touching.
+B2_API b2ContactData b2Contact_GetData( b2ContactId contactId );
 
 /**@}*/

--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -660,14 +660,14 @@ B2_API int b2Shape_GetContactData( b2ShapeId shapeId, b2ContactData* contactData
 /// @returns the required capacity to get all the overlaps in b2Shape_GetSensorOverlaps
 B2_API int b2Shape_GetSensorCapacity( b2ShapeId shapeId );
 
-/// Get the overlapped shapes for a sensor shape.
+/// Get the overlap data for a sensor shape.
 /// @param shapeId the id of a sensor shape
-/// @param sensorData a user allocated array that is filled with the overlapping shapes
+/// @param sensorData a user allocated array that is filled with the overlapping shapes (visitors)
 /// @param capacity the capacity of overlappedShapes
 /// @returns the number of elements filled in the provided array
 /// @warning do not ignore the return value, it specifies the valid number of elements
 /// @warning overlaps may contain destroyed shapes so use b2Shape_IsValid to confirm each overlap
-B2_API int b2Shape_GetSensorOverlaps( b2ShapeId shapeId, b2SensorData* sensorData, int capacity );
+B2_API int b2Shape_GetSensorData( b2ShapeId shapeId, b2SensorData* sensorData, int capacity );
 
 /// Get the current world AABB
 B2_API b2AABB b2Shape_GetAABB( b2ShapeId shapeId );

--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -662,12 +662,12 @@ B2_API int b2Shape_GetSensorCapacity( b2ShapeId shapeId );
 
 /// Get the overlapped shapes for a sensor shape.
 /// @param shapeId the id of a sensor shape
-/// @param overlaps a user allocated array that is filled with the overlapping shapes
+/// @param sensorData a user allocated array that is filled with the overlapping shapes
 /// @param capacity the capacity of overlappedShapes
 /// @returns the number of elements filled in the provided array
 /// @warning do not ignore the return value, it specifies the valid number of elements
 /// @warning overlaps may contain destroyed shapes so use b2Shape_IsValid to confirm each overlap
-B2_API int b2Shape_GetSensorOverlaps( b2ShapeId shapeId, b2ShapeId* overlaps, int capacity );
+B2_API int b2Shape_GetSensorOverlaps( b2ShapeId shapeId, b2SensorData* sensorData, int capacity );
 
 /// Get the current world AABB
 B2_API b2AABB b2Shape_GetAABB( b2ShapeId shapeId );

--- a/include/box2d/collision.h
+++ b/include/box2d/collision.h
@@ -473,8 +473,17 @@ typedef enum b2TOIState
 /// Output parameters for b2TimeOfImpact.
 typedef struct b2TOIOutput
 {
-	b2TOIState state; ///< The type of result
-	float fraction;	  ///< The sweep time of the collision
+	/// The type of result
+	b2TOIState state;
+
+	/// The hit point
+	b2Vec2 point;
+
+	/// The hit normal
+	b2Vec2 normal;
+
+	/// The sweep time of the collision 
+	float fraction;
 } b2TOIOutput;
 
 /// Compute the upper bound on time before two shapes penetrate. Time is represented as

--- a/include/box2d/collision.h
+++ b/include/box2d/collision.h
@@ -16,6 +16,7 @@ typedef struct b2Hull b2Hull;
  * @brief Geometry types and algorithms
  *
  * Definitions of circles, capsules, segments, and polygons. Various algorithms to compute hulls, mass properties, and so on.
+ * Functions should take the shape as the first argument to assist editor auto-complete.
  * @{
  */
 
@@ -246,38 +247,38 @@ B2_API b2AABB b2ComputePolygonAABB( const b2Polygon* shape, b2Transform transfor
 B2_API b2AABB b2ComputeSegmentAABB( const b2Segment* shape, b2Transform transform );
 
 /// Test a point for overlap with a circle in local space
-B2_API bool b2PointInCircle( b2Vec2 point, const b2Circle* shape );
+B2_API bool b2PointInCircle( const b2Circle* shape, b2Vec2 point );
 
 /// Test a point for overlap with a capsule in local space
-B2_API bool b2PointInCapsule( b2Vec2 point, const b2Capsule* shape );
+B2_API bool b2PointInCapsule( const b2Capsule* shape, b2Vec2 point );
 
 /// Test a point for overlap with a convex polygon in local space
-B2_API bool b2PointInPolygon( b2Vec2 point, const b2Polygon* shape );
+B2_API bool b2PointInPolygon( const b2Polygon* shape, b2Vec2 point );
 
-/// Ray cast versus circle shape in local space. Initial overlap is treated as a miss.
-B2_API b2CastOutput b2RayCastCircle( const b2RayCastInput* input, const b2Circle* shape );
+/// Ray cast versus circle shape in local space.
+B2_API b2CastOutput b2RayCastCircle( const b2Circle* shape, const b2RayCastInput* input );
 
-/// Ray cast versus capsule shape in local space. Initial overlap is treated as a miss.
-B2_API b2CastOutput b2RayCastCapsule( const b2RayCastInput* input, const b2Capsule* shape );
+/// Ray cast versus capsule shape in local space.
+B2_API b2CastOutput b2RayCastCapsule( const b2Capsule* shape, const b2RayCastInput* input );
 
 /// Ray cast versus segment shape in local space. Optionally treat the segment as one-sided with hits from
 /// the left side being treated as a miss.
-B2_API b2CastOutput b2RayCastSegment( const b2RayCastInput* input, const b2Segment* shape, bool oneSided );
+B2_API b2CastOutput b2RayCastSegment( const b2Segment* shape, const b2RayCastInput* input, bool oneSided );
 
-/// Ray cast versus polygon shape in local space. Initial overlap is treated as a miss.
-B2_API b2CastOutput b2RayCastPolygon( const b2RayCastInput* input, const b2Polygon* shape );
+/// Ray cast versus polygon shape in local space.
+B2_API b2CastOutput b2RayCastPolygon( const b2Polygon* shape, const b2RayCastInput* input );
 
-/// Shape cast versus a circle. Initial overlap is treated as a miss.
-B2_API b2CastOutput b2ShapeCastCircle( const b2ShapeCastInput* input, const b2Circle* shape );
+/// Shape cast versus a circle.
+B2_API b2CastOutput b2ShapeCastCircle(const b2Circle* shape,  const b2ShapeCastInput* input );
 
-/// Shape cast versus a capsule. Initial overlap is treated as a miss.
-B2_API b2CastOutput b2ShapeCastCapsule( const b2ShapeCastInput* input, const b2Capsule* shape );
+/// Shape cast versus a capsule.
+B2_API b2CastOutput b2ShapeCastCapsule( const b2Capsule* shape, const b2ShapeCastInput* input);
 
-/// Shape cast versus a line segment. Initial overlap is treated as a miss.
-B2_API b2CastOutput b2ShapeCastSegment( const b2ShapeCastInput* input, const b2Segment* shape );
+/// Shape cast versus a line segment.
+B2_API b2CastOutput b2ShapeCastSegment( const b2Segment* shape, const b2ShapeCastInput* input );
 
-/// Shape cast versus a convex polygon. Initial overlap is treated as a miss.
-B2_API b2CastOutput b2ShapeCastPolygon( const b2ShapeCastInput* input, const b2Polygon* shape );
+/// Shape cast versus a convex polygon.
+B2_API b2CastOutput b2ShapeCastPolygon( const b2Polygon* shape, const b2ShapeCastInput* input );
 
 /// A convex hull. Used to create convex polygons.
 /// @warning Do not modify these values directly, instead use b2ComputeHull()

--- a/include/box2d/collision.h
+++ b/include/box2d/collision.h
@@ -450,7 +450,7 @@ typedef struct b2Sweep
 /// Evaluate the transform sweep at a specific time.
 B2_API b2Transform b2GetSweepTransform( const b2Sweep* sweep, float time );
 
-/// Input parameters for b2TimeOfImpact
+/// Time of impact input
 typedef struct b2TOIInput
 {
 	b2ShapeProxy proxyA; ///< The proxy for shape A
@@ -470,7 +470,7 @@ typedef enum b2TOIState
 	b2_toiStateSeparated
 } b2TOIState;
 
-/// Output parameters for b2TimeOfImpact.
+/// Time of impact output
 typedef struct b2TOIOutput
 {
 	/// The type of result

--- a/include/box2d/id.h
+++ b/include/box2d/id.h
@@ -5,6 +5,8 @@
 
 #include <stdint.h>
 
+// Note: this file should be stand-alone
+
 /**
  * @defgroup id Ids
  * These ids serve as handles to internal Box2D objects.

--- a/include/box2d/id.h
+++ b/include/box2d/id.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include "base.h"
-
 #include <stdint.h>
 
 /**
@@ -81,14 +79,22 @@ typedef struct b2ContactId
 	uint32_t generation;
 } b2ContactId;
 
+#ifdef __cplusplus
+	#define B2_NULL_ID {}
+	#define B2_ID_INLINE inline
+#else
+	#define B2_NULL_ID { 0 }
+	#define B2_ID_INLINE static inline
+#endif
+
 /// Use these to make your identifiers null.
 /// You may also use zero initialization to get null.
-static const b2WorldId b2_nullWorldId = B2_ZERO_INIT;
-static const b2BodyId b2_nullBodyId = B2_ZERO_INIT;
-static const b2ShapeId b2_nullShapeId = B2_ZERO_INIT;
-static const b2ChainId b2_nullChainId = B2_ZERO_INIT;
-static const b2JointId b2_nullJointId = B2_ZERO_INIT;
-static const b2ContactId b2_nullContactId = B2_ZERO_INIT;
+static const b2WorldId b2_nullWorldId = B2_NULL_ID;
+static const b2BodyId b2_nullBodyId = B2_NULL_ID;
+static const b2ShapeId b2_nullShapeId = B2_NULL_ID;
+static const b2ChainId b2_nullChainId = B2_NULL_ID;
+static const b2JointId b2_nullJointId = B2_NULL_ID;
+static const b2ContactId b2_nullContactId = B2_NULL_ID;
 
 /// Macro to determine if any id is null.
 #define B2_IS_NULL( id ) ( id.index1 == 0 )
@@ -100,72 +106,72 @@ static const b2ContactId b2_nullContactId = B2_ZERO_INIT;
 #define B2_ID_EQUALS( id1, id2 ) ( id1.index1 == id2.index1 && id1.world0 == id2.world0 && id1.generation == id2.generation )
 
 /// Store a world id into a uint32_t.
-B2_INLINE uint32_t b2StoreWorldId( b2WorldId id )
+B2_ID_INLINE uint32_t b2StoreWorldId( b2WorldId id )
 {
 	return ( (uint32_t)id.index1 << 16 ) | (uint32_t)id.generation;
 }
 
 /// Load a uint32_t into a world id.
-B2_INLINE b2WorldId b2LoadWorldId( uint32_t x )
+B2_ID_INLINE b2WorldId b2LoadWorldId( uint32_t x )
 {
 	b2WorldId id = { (uint16_t)( x >> 16 ), (uint16_t)( x ) };
 	return id;
 }
 
 /// Store a body id into a uint64_t.
-B2_INLINE uint64_t b2StoreBodyId( b2BodyId id )
+B2_ID_INLINE uint64_t b2StoreBodyId( b2BodyId id )
 {
 	return ( (uint64_t)id.index1 << 32 ) | ( (uint64_t)id.world0 ) << 16 | (uint64_t)id.generation;
 }
 
 /// Load a uint64_t into a body id.
-B2_INLINE b2BodyId b2LoadBodyId( uint64_t x )
+B2_ID_INLINE b2BodyId b2LoadBodyId( uint64_t x )
 {
 	b2BodyId id = { (int32_t)( x >> 32 ), (uint16_t)( x >> 16 ), (uint16_t)( x ) };
 	return id;
 }
 
 /// Store a shape id into a uint64_t.
-B2_INLINE uint64_t b2StoreShapeId( b2ShapeId id )
+B2_ID_INLINE uint64_t b2StoreShapeId( b2ShapeId id )
 {
 	return ( (uint64_t)id.index1 << 32 ) | ( (uint64_t)id.world0 ) << 16 | (uint64_t)id.generation;
 }
 
 /// Load a uint64_t into a shape id.
-B2_INLINE b2ShapeId b2LoadShapeId( uint64_t x )
+B2_ID_INLINE b2ShapeId b2LoadShapeId( uint64_t x )
 {
 	b2ShapeId id = { (int32_t)( x >> 32 ), (uint16_t)( x >> 16 ), (uint16_t)( x ) };
 	return id;
 }
 
 /// Store a chain id into a uint64_t.
-B2_INLINE uint64_t b2StoreChainId( b2ChainId id )
+B2_ID_INLINE uint64_t b2StoreChainId( b2ChainId id )
 {
 	return ( (uint64_t)id.index1 << 32 ) | ( (uint64_t)id.world0 ) << 16 | (uint64_t)id.generation;
 }
 
 /// Load a uint64_t into a chain id.
-B2_INLINE b2ChainId b2LoadChainId( uint64_t x )
+B2_ID_INLINE b2ChainId b2LoadChainId( uint64_t x )
 {
 	b2ChainId id = { (int32_t)( x >> 32 ), (uint16_t)( x >> 16 ), (uint16_t)( x ) };
 	return id;
 }
 
 /// Store a joint id into a uint64_t.
-B2_INLINE uint64_t b2StoreJointId( b2JointId id )
+B2_ID_INLINE uint64_t b2StoreJointId( b2JointId id )
 {
 	return ( (uint64_t)id.index1 << 32 ) | ( (uint64_t)id.world0 ) << 16 | (uint64_t)id.generation;
 }
 
 /// Load a uint64_t into a joint id.
-B2_INLINE b2JointId b2LoadJointId( uint64_t x )
+B2_ID_INLINE b2JointId b2LoadJointId( uint64_t x )
 {
 	b2JointId id = { (int32_t)( x >> 32 ), (uint16_t)( x >> 16 ), (uint16_t)( x ) };
 	return id;
 }
 
 /// Store a contact id into 16 bytes
-B2_INLINE void b2StoreContactId( b2ContactId id, uint32_t values[3] )
+B2_ID_INLINE void b2StoreContactId( b2ContactId id, uint32_t values[3] )
 {
 	values[0] = (uint32_t)id.index1;
 	values[1] = (uint32_t)id.world0;
@@ -173,7 +179,7 @@ B2_INLINE void b2StoreContactId( b2ContactId id, uint32_t values[3] )
 }
 
 /// Load a two uint64_t into a contact id.
-B2_INLINE b2ContactId b2LoadContactId( uint32_t values[3] )
+B2_ID_INLINE b2ContactId b2LoadContactId( uint32_t values[3] )
 {
 	b2ContactId id;
 	id.index1 = (int32_t)values[0];

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -902,14 +902,6 @@ B2_API b2ExplosionDef b2DefaultExplosionDef( void );
  * @{
  */
 
-// todo remove this?
-///// The reason a visitor was detected to touch a sensor
-//typedef enum b2SensorBeginTouchReason
-//{
-//	b2_sensorContinuousHit = 0,
-//	b2_sensorBeginOverlap = 1,
-//} b2SensorBeginTouchReason;
-
 /// A begin touch event is generated when a shape starts to overlap a sensor shape.
 typedef struct b2SensorBeginTouchEvent
 {
@@ -918,9 +910,6 @@ typedef struct b2SensorBeginTouchEvent
 
 	/// The id of the shape that began touching the sensor shape
 	b2ShapeId visitorShapeId;
-
-	///// The reason these shapes begin touching
-	//b2SensorBeginTouchReason reason;
 } b2SensorBeginTouchEvent;
 
 /// An end touch event is generated when a shape stops overlapping a sensor shape.
@@ -1028,7 +1017,7 @@ typedef struct b2ContactEvents
 	/// Array of end touch events
 	b2ContactEndTouchEvent* endEvents;
 
-	/// Array of end touch events
+	/// Array of hit events
 	b2ContactHitEvent* hitEvents;
 
 	/// Number of begin touch events
@@ -1148,7 +1137,7 @@ typedef bool b2CustomFilterFcn( b2ShapeId shapeIdA, b2ShapeId shapeIdB, void* co
 /// Return false if you want to disable the contact this step
 /// @warning Do not attempt to modify the world inside this callback
 /// @ingroup world
-typedef bool b2PreSolveFcn( b2ShapeId shapeIdA, b2ShapeId shapeIdB, b2Manifold* manifold, void* context );
+typedef bool b2PreSolveFcn( b2ShapeId shapeIdA, b2ShapeId shapeIdB, b2Vec2 point, b2Vec2 normal, void* context );
 
 /// Prototype callback for overlap queries.
 /// Called for each shape found in the query.

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -228,12 +228,11 @@ typedef struct b2BodyDef
 	/// continuous collision.
 	bool isBullet;
 
-	/// Allows the sensors to detect the shapes on this body under fast movement. This only applies to dynamic bodies.
+	/// Option to perform continuous collision checks with sensors. This only applies to dynamic bodies.
 	/// This is expensive and should be used sparingly. You still need to enable sensor events on the child shapes
 	/// for this to work. This only works if the body is awake. This will use a time of impact calculation to
 	/// generate sensor begin touch events, but not end events. End events are handled using regular overlap checks.
-	/// It is possible to get a begin and end touch event in the same time step.
-	bool enableSensorSweeps;
+	bool enableSensorHits;
 
 	/// Used to disable a body. A disabled body does not move or collide.
 	bool isEnabled;
@@ -903,6 +902,7 @@ B2_API b2ExplosionDef b2DefaultExplosionDef( void );
  * @{
  */
 
+// todo remove this?
 ///// The reason a visitor was detected to touch a sensor
 //typedef enum b2SensorBeginTouchReason
 //{
@@ -971,11 +971,6 @@ typedef struct b2ContactBeginTouchEvent
 	/// The transient contact id. This contact maybe destroyed automatically when the world is modified or simulated.
 	/// Used b2Contact_IsValid before using this id.
 	b2ContactId contactId;
-
-	/// The initial contact manifold. This is recorded before the solver is called,
-	/// so all the impulses will be zero. You can use the contact id to access the manifold impulses
-	/// using b2Contact_GetManifold.
-	b2Manifold manifold;
 } b2ContactBeginTouchEvent;
 
 /// An end touch event is generated when two shapes stop touching.
@@ -1098,6 +1093,20 @@ typedef struct b2JointEvents
 	/// Number of events
 	int count;
 } b2JointEvents;
+
+/// The contact data for two shapes. By convention the manifold normal points
+/// from shape A to shape B.
+/// @see b2Shape_GetContactData() and b2Body_GetContactData()
+typedef struct b2SensorData
+{
+	/// The visiting shape
+	b2ShapeId visitorId;
+
+	/// The transform of the body of the visiting shape. This is normally
+	/// the current transform of the body. However, for a sensor hit, this is
+	/// the transform of the visiting body when it hit.
+	b2Transform visitTransform;
+} b2SensorData;
 
 /// The contact data for two shapes. By convention the manifold normal points
 /// from shape A to shape B.

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -489,6 +489,7 @@ typedef struct b2Profile
 	float storeImpulses;
 	float splitIslands;
 	float transforms;
+	float sensorHits;
 	float jointEvents;
 	float hitEvents;
 	float refit;

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -100,7 +100,7 @@ typedef struct b2WorldDef
 	/// This parameter controls how fast overlap is resolved and usually has units of meters per second. This only
 	/// puts a cap on the resolution speed. The resolution speed is increased by increasing the hertz and/or
 	/// decreasing the damping ratio.
-	float maxContactPushSpeed;
+	float contactSpeed;
 
 	/// Maximum linear speed. Usually meters per second.
 	float maximumLinearSpeed;
@@ -225,8 +225,15 @@ typedef struct b2BodyDef
 	/// Treat this body as high speed object that performs continuous collision detection
 	/// against dynamic and kinematic bodies, but not other bullet bodies.
 	/// @warning Bullets should be used sparingly. They are not a solution for general dynamic-versus-dynamic
-	/// continuous collision. They may interfere with joint constraints.
+	/// continuous collision.
 	bool isBullet;
+
+	/// Allows the sensors to detect the shapes on this body under fast movement. This only applies to dynamic bodies.
+	/// This is expensive and should be used sparingly. You still need to enable sensor events on the child shapes
+	/// for this to work. This only works if the body is awake. This will use a time of impact calculation to
+	/// generate sensor begin touch events, but not end events. End events are handled using regular overlap checks.
+	/// It is possible to get a begin and end touch event in the same time step.
+	bool enableSensorSweeps;
 
 	/// Used to disable a body. A disabled body does not move or collide.
 	bool isEnabled;
@@ -392,7 +399,7 @@ typedef struct b2ShapeDef
 	bool enableHitEvents;
 
 	/// Enable pre-solve contact events for this shape. Only applies to dynamic bodies. These are expensive
-	/// and must be carefully handled due to threading. Ignored for sensors.
+	/// and must be carefully handled due to multithreading. Ignored for sensors.
 	bool enablePreSolveEvents;
 
 	/// When shapes are created they will scan the environment for collision the next time step. This can significantly slow down
@@ -524,6 +531,10 @@ typedef enum b2JointType
 	b2_wheelJoint,
 } b2JointType;
 
+/// Base joint definition used by all joint types.
+/// The local frames are measured from the body's origin rather than the center of mass because:
+/// 1. you might not know where the center of mass will be
+/// 2. if you add/remove shapes from a body and recompute the mass, the joints will be broken
 typedef struct b2JointDef
 {
 	/// User data pointer
@@ -547,8 +558,14 @@ typedef struct b2JointDef
 	/// Torque threshold for joint events
 	float torqueThreshold;
 
-	/// Debug draw size
-	float drawSize;
+	/// Constraint hertz (advanced feature)
+	float constraintHertz;
+
+	/// Constraint damping ratio (advanced feature)
+	float constraintDampingRatio;
+
+	/// Debug draw scale
+	float drawScale;
 
 	/// Set this flag to true if the attached bodies should collide
 	bool collideConnected;
@@ -556,11 +573,8 @@ typedef struct b2JointDef
 } b2JointDef;
 
 /// Distance joint definition
-///
-/// This requires defining an anchor point on both
-/// bodies and the non-zero distance of the distance joint. The definition uses
-/// local anchor points so that the initial configuration can violate the
-/// constraint slightly. This helps when saving and loading a game.
+/// Connects a point on body A with a point on body B by a segment.
+/// Useful for ropes and springs.
 /// @ingroup distance_joint
 typedef struct b2DistanceJointDef
 {
@@ -632,7 +646,7 @@ typedef struct b2MotorJointDef
 /// @ingroup motor_joint
 B2_API b2MotorJointDef b2DefaultMotorJointDef( void );
 
-/// A mouse joint is used to make a point on a body track a specified world point.
+/// A mouse joint is used to make a point on body B track a point on body A.
 /// You may move local frame A to change the target point.
 /// This a soft constraint and allows the constraint to stretch without
 /// applying huge forces. This also applies rotation constraint heuristic to improve control.
@@ -676,7 +690,6 @@ typedef struct b2FilterJointDef
 B2_API b2FilterJointDef b2DefaultFilterJointDef( void );
 
 /// Prismatic joint definition
-///
 /// Body B may slide along the x-axis in local frame A. Body B cannot rotate relative to body A.
 /// The joint translation is zero when the local frame origins coincide in world space.
 /// @ingroup prismatic_joint
@@ -684,10 +697,6 @@ typedef struct b2PrismaticJointDef
 {
 	/// Base joint definition
 	b2JointDef base;
-
-	/// The target translation for the joint in meters. The spring-damper will drive
-	/// to this translation.
-	float targetTranslation;
 
 	/// Enable a linear spring along the prismatic joint axis
 	bool enableSpring;
@@ -697,6 +706,10 @@ typedef struct b2PrismaticJointDef
 
 	/// The spring damping ratio, non-dimensional
 	float dampingRatio;
+
+	/// The target translation for the joint in meters. The spring-damper will drive
+	/// to this translation.
+	float targetTranslation;
 
 	/// Enable/disable the joint limit
 	bool enableLimit;
@@ -725,15 +738,7 @@ typedef struct b2PrismaticJointDef
 B2_API b2PrismaticJointDef b2DefaultPrismaticJointDef( void );
 
 /// Revolute joint definition
-///
-/// This requires defining an anchor point where the bodies are joined.
-/// The definition uses local anchor points so that the
-/// initial configuration can violate the constraint slightly. You also need to
-/// specify the initial relative angle for joint limits. This helps when saving
-/// and loading a game.
-/// The local anchor points are measured from the body's origin rather than the center of mass because:
-/// 1. you might not know where the center of mass will be
-/// 2. if you add/remove shapes from a body and recompute the mass, the joints will be broken
+/// A point on body B is fixed to a point on body A. Allows relative rotation.
 /// @ingroup revolute_joint
 typedef struct b2RevoluteJointDef
 {
@@ -780,8 +785,7 @@ typedef struct b2RevoluteJointDef
 B2_API b2RevoluteJointDef b2DefaultRevoluteJointDef( void );
 
 /// Weld joint definition
-///
-/// A weld joint connect to bodies together rigidly. This constraint provides springs to mimic
+/// Connects two bodies together rigidly. This constraint provides springs to mimic
 /// soft-body simulation.
 /// @note The approximate solver in Box2D cannot hold many bodies together rigidly
 /// @ingroup weld_joint
@@ -811,7 +815,6 @@ typedef struct b2WeldJointDef
 B2_API b2WeldJointDef b2DefaultWeldJointDef( void );
 
 /// Wheel joint definition
-///
 /// Body B is a wheel that may rotate freely and slide along the local x-axis in frame A.
 /// The joint translation is zero when the local frame origins coincide in world space.
 /// @ingroup wheel_joint
@@ -899,14 +902,24 @@ B2_API b2ExplosionDef b2DefaultExplosionDef( void );
  * @{
  */
 
+///// The reason a visitor was detected to touch a sensor
+//typedef enum b2SensorBeginTouchReason
+//{
+//	b2_sensorContinuousHit = 0,
+//	b2_sensorBeginOverlap = 1,
+//} b2SensorBeginTouchReason;
+
 /// A begin touch event is generated when a shape starts to overlap a sensor shape.
 typedef struct b2SensorBeginTouchEvent
 {
 	/// The id of the sensor shape
 	b2ShapeId sensorShapeId;
 
-	/// The id of the dynamic shape that began touching the sensor shape
+	/// The id of the shape that began touching the sensor shape
 	b2ShapeId visitorShapeId;
+
+	///// The reason these shapes begin touching
+	//b2SensorBeginTouchReason reason;
 } b2SensorBeginTouchEvent;
 
 /// An end touch event is generated when a shape stops overlapping a sensor shape.
@@ -920,14 +933,14 @@ typedef struct b2SensorEndTouchEvent
 	///	@see b2Shape_IsValid
 	b2ShapeId sensorShapeId;
 
-	/// The id of the dynamic shape that stopped touching the sensor shape
+	/// The id of the shape that stopped touching the sensor shape
 	///	@warning this shape may have been destroyed
 	///	@see b2Shape_IsValid
 	b2ShapeId visitorShapeId;
 
 } b2SensorEndTouchEvent;
 
-/// Sensor events are buffered in the Box2D world and are available
+/// Sensor events are buffered in the world and are available
 /// as begin/end overlap event arrays after the time step is complete.
 /// Note: these may become invalid if bodies and/or shapes are destroyed
 typedef struct b2SensorEvents
@@ -954,7 +967,7 @@ typedef struct b2ContactBeginTouchEvent
 	/// Id of the second shape
 	b2ShapeId shapeIdB;
 
-	/// The transient contact id. This contact maybe destroyed automatically by Box2D when the world is modified or simulated.
+	/// The transient contact id. This contact maybe destroyed automatically when the world is modified or simulated.
 	/// Used b2Contact_IsValid before using this id.
 	b2ContactId contactId;
 
@@ -980,7 +993,9 @@ typedef struct b2ContactEndTouchEvent
 	///	@see b2Shape_IsValid
 	b2ShapeId shapeIdB;
 
-	/// Id of the contact
+	/// Id of the contact.
+	///	@warning this contact may have been destroyed
+	///	@see b2Contact_IsValid
 	b2ContactId contactId;
 } b2ContactEndTouchEvent;
 
@@ -1017,7 +1032,7 @@ typedef struct b2ContactEvents
 	/// Array of end touch events
 	b2ContactEndTouchEvent* endEvents;
 
-	/// Array of hit events
+	/// Array of end touch events
 	b2ContactHitEvent* hitEvents;
 
 	/// Number of begin touch events
@@ -1042,9 +1057,9 @@ typedef struct b2ContactEvents
 /// @note If sleeping is disabled all dynamic and kinematic bodies will trigger move events.
 typedef struct b2BodyMoveEvent
 {
+	void* userData;
 	b2Transform transform;
 	b2BodyId bodyId;
-	void* userData;
 	bool fellAsleep;
 } b2BodyMoveEvent;
 
@@ -1064,11 +1079,14 @@ typedef struct b2BodyEvents
 /// The observed forces and torques are not returned for efficiency reasons.
 typedef struct b2JointEvent
 {
+	/// The joint id
 	b2JointId jointId;
+
+	/// The user data from the joint for convenience
 	void* userData;
 } b2JointEvent;
 
-/// Joint events are buffered in the Box2D world and are available
+/// Joint events are buffered in the world and are available
 /// as event arrays after the time step is complete.
 /// Note: this data becomes invalid if joints are destroyed
 typedef struct b2JointEvents
@@ -1085,6 +1103,7 @@ typedef struct b2JointEvents
 /// @see b2Shape_GetContactData() and b2Body_GetContactData()
 typedef struct b2ContactData
 {
+	b2ContactId contactId;
 	b2ShapeId shapeIdA;
 	b2ShapeId shapeIdB;
 	b2Manifold manifold;

--- a/samples/donut.cpp
+++ b/samples/donut.cpp
@@ -65,7 +65,7 @@ void Donut::Create( b2WorldId worldId, b2Vec2 position, float scale, int groupIn
 	weldDef.angularDampingRatio = 0.0f;
 	weldDef.base.localFrameA.p = { 0.0f, 0.5f * length };
 	weldDef.base.localFrameB.p = { 0.0f, -0.5f * length };
-	weldDef.base.drawSize = 0.5f * scale;
+	weldDef.base.drawScale = 0.5f * scale;
 
 	b2BodyId prevBodyId = m_bodyIds[m_sides - 1];
 	for ( int i = 0; i < m_sides; ++i )

--- a/samples/draw.cpp
+++ b/samples/draw.cpp
@@ -1166,7 +1166,7 @@ void DrawSolidCapsuleFcn( b2Vec2 p1, b2Vec2 p2, float radius, b2HexColor color, 
 
 void DrawSegmentFcn( b2Vec2 p1, b2Vec2 p2, b2HexColor color, void* context )
 {
-	static_cast<Draw*>( context )->DrawSegment( p1, p2, color );
+	static_cast<Draw*>( context )->DrawLine( p1, p2, color );
 }
 
 void DrawTransformFcn( b2Transform transform, void* context )
@@ -1326,7 +1326,7 @@ void Draw::DrawSolidCapsule( b2Vec2 p1, b2Vec2 p2, float radius, b2HexColor colo
 	m_solidCapsules->AddCapsule( p1, p2, radius, color );
 }
 
-void Draw::DrawSegment( b2Vec2 p1, b2Vec2 p2, b2HexColor color )
+void Draw::DrawLine( b2Vec2 p1, b2Vec2 p2, b2HexColor color )
 {
 	m_lines->AddLine( p1, p2, color );
 }
@@ -1386,7 +1386,7 @@ void Draw::DrawString( b2Vec2 p, const char* string, ... )
 	va_end( arg );
 }
 
-void Draw::DrawAABB( b2AABB aabb, b2HexColor c )
+void Draw::DrawBounds( b2AABB aabb, b2HexColor c )
 {
 	b2Vec2 p1 = aabb.lowerBound;
 	b2Vec2 p2 = { aabb.upperBound.x, aabb.lowerBound.y };

--- a/samples/draw.h
+++ b/samples/draw.h
@@ -41,7 +41,7 @@ public:
 
 	void DrawSolidCapsule( b2Vec2 p1, b2Vec2 p2, float radius, b2HexColor color );
 
-	void DrawSegment( b2Vec2 p1, b2Vec2 p2, b2HexColor color );
+	void DrawLine( b2Vec2 p1, b2Vec2 p2, b2HexColor color );
 
 	void DrawTransform( b2Transform transform );
 
@@ -51,7 +51,7 @@ public:
 
 	void DrawString( b2Vec2 p, const char* string, ... );
 
-	void DrawAABB( b2AABB aabb, b2HexColor color );
+	void DrawBounds( b2AABB aabb, b2HexColor color );
 
 	void Flush();
 	void DrawBackground();

--- a/samples/draw.h
+++ b/samples/draw.h
@@ -19,8 +19,8 @@ struct Camera
 
 	b2Vec2 m_center;
 	float m_zoom;
-	int m_width;
-	int m_height;
+	float m_width;
+	float m_height;
 };
 
 // This class implements Box2D debug drawing callbacks

--- a/samples/sample.cpp
+++ b/samples/sample.cpp
@@ -427,13 +427,6 @@ void Sample::Step(  )
 
 	m_context->draw.m_debugDraw.drawingBounds = m_context->camera.GetViewBounds();
 	m_context->draw.m_debugDraw.useDrawingBounds = m_context->useCameraBounds;
-
-	// todo testing
-	// b2Transform t1 = {m_context->draw.m_debugDraw.drawingBounds.lowerBound, b2Rot_identity};
-	// b2Transform t2 = {m_context->draw.m_debugDraw.drawingBounds.upperBound, b2Rot_identity};
-	// m_context->draw.DrawSolidCircle(t1, b2Vec2_zero, 1.0f, {1.0f, 0.0f, 0.0f, 1.0f});
-	// m_context->draw.DrawSolidCircle(t2, b2Vec2_zero, 1.0f, {1.0f, 0.0f, 0.0f, 1.0f});
-
 	m_context->draw.m_debugDraw.drawShapes = m_context->drawShapes;
 	m_context->draw.m_debugDraw.drawJoints = m_context->drawJoints;
 	m_context->draw.m_debugDraw.drawJointExtras = m_context->drawJointExtras;

--- a/samples/sample_bodies.cpp
+++ b/samples/sample_bodies.cpp
@@ -387,8 +387,8 @@ public:
 		b2Vec2 v2 = b2Body_GetWorldPointVelocity( m_weebleId, worldPoint );
 
 		b2Vec2 offset = { 0.05f, 0.0f };
-		m_context->draw.DrawSegment( worldPoint, worldPoint + v1, b2_colorRed );
-		m_context->draw.DrawSegment( worldPoint + offset, worldPoint + v2 + offset, b2_colorGreen );
+		m_context->draw.DrawLine( worldPoint, worldPoint + v1, b2_colorRed );
+		m_context->draw.DrawLine( worldPoint + offset, worldPoint + v2 + offset, b2_colorGreen );
 	}
 
 	static Sample* Create( SampleContext* context )
@@ -849,7 +849,7 @@ public:
 			b2Rot rotation = b2MakeRot( 2.0f * m_time );
 
 			b2Vec2 axis = b2RotateVector( rotation, { 0.0f, 1.0f } );
-			m_context->draw.DrawSegment( point - 0.5f * axis, point + 0.5f * axis, b2_colorPlum );
+			m_context->draw.DrawLine( point - 0.5f * axis, point + 0.5f * axis, b2_colorPlum );
 			m_context->draw.DrawPoint( point, 10.0f, b2_colorPlum );
 
 			b2Body_SetTargetTransform( m_bodyId, { point, rotation }, timeStep );

--- a/samples/sample_character.cpp
+++ b/samples/sample_character.cpp
@@ -327,7 +327,7 @@ public:
 			m_pogoVelocity = 0.0f;
 
 			b2Vec2 delta = translation;
-			m_draw->DrawSegment( origin, origin + delta, b2_colorGray );
+			m_draw->DrawLine( origin, origin + delta, b2_colorGray );
 
 			if ( m_pogoShape == PogoPoint )
 			{
@@ -339,7 +339,7 @@ public:
 			}
 			else
 			{
-				m_draw->DrawSegment( segment.point1 + delta, segment.point2 + delta, b2_colorGray );
+				m_draw->DrawLine( segment.point1 + delta, segment.point2 + delta, b2_colorGray );
 			}
 		}
 		else
@@ -350,7 +350,7 @@ public:
 			m_pogoVelocity = b2SpringDamper( m_pogoHertz, m_pogoDampingRatio, offset, m_pogoVelocity, timeStep );
 
 			b2Vec2 delta = castResult.fraction * translation;
-			m_draw->DrawSegment( origin, origin + delta, b2_colorGray );
+			m_draw->DrawLine( origin, origin + delta, b2_colorGray );
 
 			if ( m_pogoShape == PogoPoint )
 			{
@@ -362,7 +362,7 @@ public:
 			}
 			else
 			{
-				m_draw->DrawSegment( segment.point1 + delta, segment.point2 + delta, b2_colorPlum );
+				m_draw->DrawLine( segment.point1 + delta, segment.point2 + delta, b2_colorPlum );
 			}
 
 			b2Body_ApplyForce( castResult.bodyId, { 0.0f, -50.0f }, castResult.point, true );
@@ -568,7 +568,7 @@ public:
 			b2Vec2 p1 = m_transform.p + ( plane.offset - m_capsule.radius ) * plane.normal;
 			b2Vec2 p2 = p1 + 0.1f * plane.normal;
 			m_draw->DrawPoint( p1, 5.0f, b2_colorYellow );
-			m_draw->DrawSegment( p1, p2, b2_colorYellow );
+			m_draw->DrawLine( p1, p2, b2_colorYellow );
 		}
 
 		b2Vec2 p1 = b2TransformPoint( m_transform, m_capsule.center1 );
@@ -576,7 +576,7 @@ public:
 
 		b2HexColor color = m_onGround ? b2_colorOrange : b2_colorAquamarine;
 		m_draw->DrawSolidCapsule( p1, p2, m_capsule.radius, color );
-		m_draw->DrawSegment( m_transform.p, m_transform.p + m_velocity, b2_colorPurple );
+		m_draw->DrawLine( m_transform.p, m_transform.p + m_velocity, b2_colorPurple );
 
 		b2Vec2 p = m_transform.p;
 		DrawTextLine( "position %.2f %.2f", p.x, p.y );

--- a/samples/sample_collision.cpp
+++ b/samples/sample_collision.cpp
@@ -141,7 +141,7 @@ public:
 				}
 				else
 				{
-					m_context->draw.DrawSegment( p1, p2, color );
+					m_context->draw.DrawLine( p1, p2, color );
 				}
 			}
 			break;
@@ -336,7 +336,7 @@ public:
 				b2Vec2 pointA, pointB;
 				ComputeSimplexWitnessPoints( &pointA, &pointB, simplex );
 
-				m_context->draw.DrawSegment( pointA, pointB, b2_colorWhite );
+				m_context->draw.DrawLine( pointA, pointB, b2_colorWhite );
 				m_context->draw.DrawPoint( pointA, 10.0f, b2_colorWhite );
 				m_context->draw.DrawPoint( pointB, 10.0f, b2_colorWhite );
 			}
@@ -352,11 +352,11 @@ public:
 		}
 		else
 		{
-			m_context->draw.DrawSegment( output.pointA, output.pointB, b2_colorDimGray );
+			m_context->draw.DrawLine( output.pointA, output.pointB, b2_colorDimGray );
 			m_context->draw.DrawPoint( output.pointA, 10.0f, b2_colorWhite );
 			m_context->draw.DrawPoint( output.pointB, 10.0f, b2_colorWhite );
 
-			m_context->draw.DrawSegment( output.pointA, output.pointA + 0.5f * output.normal, b2_colorYellow );
+			m_context->draw.DrawLine( output.pointA, output.pointA + 0.5f * output.normal, b2_colorYellow );
 		}
 
 		if ( m_showIndices )
@@ -683,7 +683,7 @@ public:
 			b2AABB box = { b2Min( m_startPoint, m_endPoint ), b2Max( m_startPoint, m_endPoint ) };
 			b2DynamicTree_Query( &m_tree, box, B2_DEFAULT_MASK_BITS, QueryCallback, this );
 
-			m_context->draw.DrawAABB( box, b2_colorWhite );
+			m_context->draw.DrawBounds( box, b2_colorWhite );
 		}
 
 		// m_startPoint = {-1.0f, 0.5f};
@@ -694,7 +694,7 @@ public:
 			b2RayCastInput input = { m_startPoint, b2Sub( m_endPoint, m_startPoint ), 1.0f };
 			b2TreeStats result = b2DynamicTree_RayCast( &m_tree, &input, B2_DEFAULT_MASK_BITS, RayCallback, this );
 
-			m_context->draw.DrawSegment( m_startPoint, m_endPoint, b2_colorWhite );
+			m_context->draw.DrawLine( m_startPoint, m_endPoint, b2_colorWhite );
 			m_context->draw.DrawPoint( m_startPoint, 5.0f, b2_colorGreen );
 			m_context->draw.DrawPoint( m_endPoint, 5.0f, b2_colorRed );
 
@@ -712,11 +712,11 @@ public:
 
 			if ( p->queryStamp == m_timeStamp || p->rayStamp == m_timeStamp )
 			{
-				m_context->draw.DrawAABB( p->box, qc );
+				m_context->draw.DrawBounds( p->box, qc );
 			}
 			else
 			{
-				m_context->draw.DrawAABB( p->box, c );
+				m_context->draw.DrawBounds( p->box, c );
 			}
 
 			float moveTest = RandomFloatRange( 0.0f, 1.0f );
@@ -1010,21 +1010,21 @@ public:
 		{
 			b2Vec2 p;
 
-			if (output->fraction == 0.0f)
+			if ( output->fraction == 0.0f )
 			{
-				assert(output->normal.x == 0.0f && output->normal.y == 0.0f);
+				assert( output->normal.x == 0.0f && output->normal.y == 0.0f );
 				p = output->point;
-				m_draw->DrawPoint(output->point, 5.0, b2_colorPeru);
+				m_draw->DrawPoint( output->point, 5.0, b2_colorPeru );
 			}
 			else
 			{
 				p = b2MulAdd( p1, output->fraction, d );
-				m_draw->DrawSegment( p1, p, b2_colorWhite );
+				m_draw->DrawLine( p1, p, b2_colorWhite );
 				m_draw->DrawPoint( p1, 5.0f, b2_colorGreen );
 				m_draw->DrawPoint( output->point, 5.0f, b2_colorWhite );
 
 				b2Vec2 n = b2MulAdd( p, 1.0f, output->normal );
-				m_draw->DrawSegment( p, n, b2_colorViolet );
+				m_draw->DrawLine( p, n, b2_colorViolet );
 			}
 
 			if ( m_showFraction )
@@ -1035,7 +1035,7 @@ public:
 		}
 		else
 		{
-			m_draw->DrawSegment( p1, p2, b2_colorWhite );
+			m_draw->DrawLine( p1, p2, b2_colorWhite );
 			m_draw->DrawPoint( p1, 5.0f, b2_colorGreen );
 			m_draw->DrawPoint( p2, 5.0f, b2_colorRed );
 		}
@@ -1060,7 +1060,7 @@ public:
 			b2Vec2 translation = b2InvRotateVector( transform.q, b2Sub( m_rayEnd, m_rayStart ) );
 			b2RayCastInput input = { start, translation, maxFraction };
 
-			b2CastOutput localOutput = b2RayCastCircle( &input, &m_circle );
+			b2CastOutput localOutput = b2RayCastCircle( &m_circle, &input );
 			if ( localOutput.hit )
 			{
 				output = localOutput;
@@ -1083,7 +1083,7 @@ public:
 			b2Vec2 translation = b2InvRotateVector( transform.q, b2Sub( m_rayEnd, m_rayStart ) );
 			b2RayCastInput input = { start, translation, maxFraction };
 
-			b2CastOutput localOutput = b2RayCastCapsule( &input, &m_capsule );
+			b2CastOutput localOutput = b2RayCastCapsule( &m_capsule, &input );
 			if ( localOutput.hit )
 			{
 				output = localOutput;
@@ -1104,7 +1104,7 @@ public:
 			b2Vec2 translation = b2InvRotateVector( transform.q, b2Sub( m_rayEnd, m_rayStart ) );
 			b2RayCastInput input = { start, translation, maxFraction };
 
-			b2CastOutput localOutput = b2RayCastPolygon( &input, &m_box );
+			b2CastOutput localOutput = b2RayCastPolygon( &m_box, &input );
 			if ( localOutput.hit )
 			{
 				output = localOutput;
@@ -1125,7 +1125,7 @@ public:
 			b2Vec2 translation = b2InvRotateVector( transform.q, b2Sub( m_rayEnd, m_rayStart ) );
 			b2RayCastInput input = { start, translation, maxFraction };
 
-			b2CastOutput localOutput = b2RayCastPolygon( &input, &m_triangle );
+			b2CastOutput localOutput = b2RayCastPolygon( &m_triangle, &input );
 			if ( localOutput.hit )
 			{
 				output = localOutput;
@@ -1143,13 +1143,13 @@ public:
 
 			b2Vec2 p1 = b2TransformPoint( transform, m_segment.point1 );
 			b2Vec2 p2 = b2TransformPoint( transform, m_segment.point2 );
-			m_context->draw.DrawSegment( p1, p2, color1 );
+			m_context->draw.DrawLine( p1, p2, color1 );
 
 			b2Vec2 start = b2InvTransformPoint( transform, m_rayStart );
 			b2Vec2 translation = b2InvRotateVector( transform.q, b2Sub( m_rayEnd, m_rayStart ) );
 			b2RayCastInput input = { start, translation, maxFraction };
 
-			b2CastOutput localOutput = b2RayCastSegment( &input, &m_segment, false );
+			b2CastOutput localOutput = b2RayCastSegment( &m_segment, &input, false );
 			if ( localOutput.hit )
 			{
 				output = localOutput;
@@ -1218,7 +1218,7 @@ static float RayCastClosestCallback( b2ShapeId shapeId, b2Vec2 point, b2Vec2 nor
 	ShapeUserData* userData = (ShapeUserData*)b2Shape_GetUserData( shapeId );
 
 	// Ignore a specific shape. Also ignore initial overlap.
-	if ( (userData != nullptr && userData->ignore) || fraction == 0.0f )
+	if ( ( userData != nullptr && userData->ignore ) || fraction == 0.0f )
 	{
 		// By returning -1, we instruct the calling code to ignore this shape and
 		// continue the ray-cast to the next shape.
@@ -1246,7 +1246,7 @@ static float RayCastAnyCallback( b2ShapeId shapeId, b2Vec2 point, b2Vec2 normal,
 	ShapeUserData* userData = (ShapeUserData*)b2Shape_GetUserData( shapeId );
 
 	// Ignore a specific shape. Also ignore initial overlap.
-	if ( (userData != nullptr && userData->ignore) || fraction == 0.0f )
+	if ( ( userData != nullptr && userData->ignore ) || fraction == 0.0f )
 	{
 		// By returning -1, we instruct the calling code to ignore this shape and
 		// continue the ray-cast to the next shape.
@@ -1276,7 +1276,7 @@ static float RayCastMultipleCallback( b2ShapeId shapeId, b2Vec2 point, b2Vec2 no
 	ShapeUserData* userData = (ShapeUserData*)b2Shape_GetUserData( shapeId );
 
 	// Ignore a specific shape. Also ignore initial overlap.
-	if ( (userData != nullptr && userData->ignore) || fraction == 0.0f )
+	if ( ( userData != nullptr && userData->ignore ) || fraction == 0.0f )
 	{
 		// By returning -1, we instruct the calling code to ignore this shape and
 		// continue the ray-cast to the next shape.
@@ -1308,9 +1308,9 @@ static float RayCastSortedCallback( b2ShapeId shapeId, b2Vec2 point, b2Vec2 norm
 	CastContext* rayContext = (CastContext*)context;
 
 	ShapeUserData* userData = (ShapeUserData*)b2Shape_GetUserData( shapeId );
-	
+
 	// Ignore a specific shape. Also ignore initial overlap.
-	if ( (userData != nullptr && userData->ignore) || fraction == 0.0f )
+	if ( ( userData != nullptr && userData->ignore ) || fraction == 0.0f )
 	{
 		// By returning -1, we instruct the calling code to ignore this shape and
 		// continue the ray-cast to the next shape.
@@ -1689,13 +1689,13 @@ public:
 			{
 				b2Vec2 c = b2MulAdd( m_rayStart, result.fraction, rayTranslation );
 				m_context->draw.DrawPoint( result.point, 5.0f, color1 );
-				m_context->draw.DrawSegment( m_rayStart, c, color2 );
+				m_context->draw.DrawLine( m_rayStart, c, color2 );
 				b2Vec2 head = b2MulAdd( result.point, 0.5f, result.normal );
-				m_context->draw.DrawSegment( result.point, head, color3 );
+				m_context->draw.DrawLine( result.point, head, color3 );
 			}
 			else
 			{
-				m_context->draw.DrawSegment( m_rayStart, m_rayEnd, color2 );
+				m_context->draw.DrawLine( m_rayStart, m_rayEnd, color2 );
 			}
 		}
 		else
@@ -1777,9 +1777,9 @@ public:
 					b2Vec2 p = context.points[i];
 					b2Vec2 n = context.normals[i];
 					m_context->draw.DrawPoint( p, 5.0f, colors[i] );
-					m_context->draw.DrawSegment( m_rayStart, c, color2 );
+					m_context->draw.DrawLine( m_rayStart, c, color2 );
 					b2Vec2 head = b2MulAdd( p, 1.0f, n );
-					m_context->draw.DrawSegment( p, head, color3 );
+					m_context->draw.DrawLine( p, head, color3 );
 
 					b2Vec2 t = b2MulSV( context.fractions[i], rayTranslation );
 					b2Transform shiftedTransform = { t, b2Rot_identity };
@@ -1803,7 +1803,7 @@ public:
 			else
 			{
 				b2Transform shiftedTransform = { b2Add( transform.p, rayTranslation ), transform.q };
-				m_context->draw.DrawSegment( m_rayStart, m_rayEnd, color2 );
+				m_context->draw.DrawLine( m_rayStart, m_rayEnd, color2 );
 
 				if ( m_castType == e_circleCast )
 				{
@@ -2374,7 +2374,7 @@ public:
 
 			b2Vec2 p1 = mp->point;
 			b2Vec2 p2 = b2MulAdd( p1, 0.5f, manifold->normal );
-			m_context->draw.DrawSegment( p1, p2, b2_colorViolet );
+			m_context->draw.DrawLine( p1, p2, b2_colorViolet );
 
 			if ( m_showAnchors )
 			{
@@ -2470,7 +2470,7 @@ public:
 
 			b2Vec2 p1 = b2TransformPoint( transform1, segment.point1 );
 			b2Vec2 p2 = b2TransformPoint( transform1, segment.point2 );
-			m_context->draw.DrawSegment( p1, p2, color1 );
+			m_context->draw.DrawLine( p1, p2, color1 );
 
 			m_context->draw.DrawSolidCircle( transform2, circle.center, circle.radius, color2 );
 
@@ -2554,7 +2554,7 @@ public:
 
 			b2Vec2 p1 = b2TransformPoint( transform1, segment.point1 );
 			b2Vec2 p2 = b2TransformPoint( transform1, segment.point2 );
-			m_context->draw.DrawSegment( p1, p2, color1 );
+			m_context->draw.DrawLine( p1, p2, color1 );
 
 			p1 = b2TransformPoint( transform2, capsule.center1 );
 			p2 = b2TransformPoint( transform2, capsule.center2 );
@@ -2660,7 +2660,7 @@ public:
 
 			b2Vec2 p1 = b2TransformPoint( transform1, segment.point1 );
 			b2Vec2 p2 = b2TransformPoint( transform1, segment.point2 );
-			m_context->draw.DrawSegment( p1, p2, color1 );
+			m_context->draw.DrawLine( p1, p2, color1 );
 			m_context->draw.DrawSolidPolygon( transform2, rox.vertices, rox.count, rox.radius, color2 );
 
 			DrawManifold( &m, transform1.p, transform2.p );
@@ -2753,9 +2753,9 @@ public:
 			b2Vec2 g2 = b2TransformPoint( transform1, segment.ghost2 );
 			b2Vec2 p1 = b2TransformPoint( transform1, segment.segment.point1 );
 			b2Vec2 p2 = b2TransformPoint( transform1, segment.segment.point2 );
-			m_context->draw.DrawSegment( g1, p1, b2_colorLightGray );
-			m_context->draw.DrawSegment( p1, p2, color1 );
-			m_context->draw.DrawSegment( p2, g2, b2_colorLightGray );
+			m_context->draw.DrawLine( g1, p1, b2_colorLightGray );
+			m_context->draw.DrawLine( p1, p2, color1 );
+			m_context->draw.DrawLine( p2, g2, b2_colorLightGray );
 			m_context->draw.DrawSolidCircle( transform2, circle.center, circle.radius, color2 );
 
 			DrawManifold( &m, transform1.p, transform2.p );
@@ -2784,18 +2784,18 @@ public:
 				b2Vec2 g2 = b2TransformPoint( transform1, segment1.ghost2 );
 				b2Vec2 p1 = b2TransformPoint( transform1, segment1.segment.point1 );
 				b2Vec2 p2 = b2TransformPoint( transform1, segment1.segment.point2 );
-				m_context->draw.DrawSegment( p1, p2, color1 );
+				m_context->draw.DrawLine( p1, p2, color1 );
 				m_context->draw.DrawPoint( p1, 4.0f, color1 );
 				m_context->draw.DrawPoint( p2, 4.0f, color1 );
-				m_context->draw.DrawSegment( p2, g2, b2_colorLightGray );
+				m_context->draw.DrawLine( p2, g2, b2_colorLightGray );
 			}
 
 			{
 				b2Vec2 g1 = b2TransformPoint( transform1, segment2.ghost1 );
 				b2Vec2 p1 = b2TransformPoint( transform1, segment2.segment.point1 );
 				b2Vec2 p2 = b2TransformPoint( transform1, segment2.segment.point2 );
-				m_context->draw.DrawSegment( g1, p1, b2_colorLightGray );
-				m_context->draw.DrawSegment( p1, p2, color1 );
+				m_context->draw.DrawLine( g1, p1, b2_colorLightGray );
+				m_context->draw.DrawLine( p1, p2, color1 );
 				m_context->draw.DrawPoint( p1, 4.0f, color1 );
 				m_context->draw.DrawPoint( p2, 4.0f, color1 );
 			}
@@ -2826,18 +2826,18 @@ public:
 				b2Vec2 p1 = b2TransformPoint( transform1, segment1.segment.point1 );
 				b2Vec2 p2 = b2TransformPoint( transform1, segment1.segment.point2 );
 				// m_context->draw.DrawSegment(g1, p1, b2_colorLightGray);
-				m_context->draw.DrawSegment( p1, p2, color1 );
+				m_context->draw.DrawLine( p1, p2, color1 );
 				m_context->draw.DrawPoint( p1, 4.0f, color1 );
 				m_context->draw.DrawPoint( p2, 4.0f, color1 );
-				m_context->draw.DrawSegment( p2, g2, b2_colorLightGray );
+				m_context->draw.DrawLine( p2, g2, b2_colorLightGray );
 			}
 
 			{
 				b2Vec2 g1 = b2TransformPoint( transform1, segment2.ghost1 );
 				b2Vec2 p1 = b2TransformPoint( transform1, segment2.segment.point1 );
 				b2Vec2 p2 = b2TransformPoint( transform1, segment2.segment.point2 );
-				m_context->draw.DrawSegment( g1, p1, b2_colorLightGray );
-				m_context->draw.DrawSegment( p1, p2, color1 );
+				m_context->draw.DrawLine( g1, p1, b2_colorLightGray );
+				m_context->draw.DrawLine( p1, p2, color1 );
 				m_context->draw.DrawPoint( p1, 4.0f, color1 );
 				m_context->draw.DrawPoint( p2, 4.0f, color1 );
 				// m_context->draw.DrawSegment(p2, g2, b2_colorLightGray);
@@ -3080,7 +3080,7 @@ public:
 
 			b2Vec2 p1 = mp->point;
 			b2Vec2 p2 = b2MulAdd( p1, 0.5f, manifold->normal );
-			m_context->draw.DrawSegment( p1, p2, b2_colorWhite );
+			m_context->draw.DrawLine( p1, p2, b2_colorWhite );
 
 			if ( m_showAnchors )
 			{
@@ -3120,7 +3120,7 @@ public:
 			const b2ChainSegment* segment = m_segments + i;
 			b2Vec2 p1 = b2TransformPoint( transform1, segment->segment.point1 );
 			b2Vec2 p2 = b2TransformPoint( transform1, segment->segment.point2 );
-			m_context->draw.DrawSegment( p1, p2, color1 );
+			m_context->draw.DrawLine( p1, p2, color1 );
 			m_context->draw.DrawPoint( p1, 4.0f, color1 );
 		}
 
@@ -3336,7 +3336,7 @@ public:
 				}
 				else
 				{
-					m_context->draw.DrawSegment( p1, p2, color );
+					m_context->draw.DrawLine( p1, p2, color );
 				}
 			}
 			break;
@@ -3504,11 +3504,11 @@ public:
 		if ( output.hit )
 		{
 			DrawShape( m_typeB, transform, m_radiusB, b2_colorPlum );
-			
-			if (output.fraction > 0.0f)
+
+			if ( output.fraction > 0.0f )
 			{
 				m_context->draw.DrawPoint( output.point, 5.0f, b2_colorWhite );
-				m_context->draw.DrawSegment( output.point, output.point + 0.5f * output.normal, b2_colorYellow );
+				m_context->draw.DrawLine( output.point, output.point + 0.5f * output.normal, b2_colorYellow );
 			}
 			else
 			{

--- a/samples/sample_continuous.cpp
+++ b/samples/sample_continuous.cpp
@@ -254,7 +254,7 @@ public:
 		b2CosSin cs2 = b2ComputeCosSin( m_time );
 		float gravity = 10.0f;
 		b2Vec2 gravityVec = { gravity * cs1.sine, gravity * cs2.cosine };
-		m_context->draw.DrawSegment( b2Vec2_zero, b2Vec2{ 3.0f * cs1.sine, 3.0f * cs2.cosine }, b2_colorWhite );
+		m_context->draw.DrawLine( b2Vec2_zero, b2Vec2{ 3.0f * cs1.sine, 3.0f * cs2.cosine }, b2_colorWhite );
 		m_time += timeStep;
 		m_countDown -= timeStep;
 		b2World_SetGravity( m_worldId, gravityVec );

--- a/samples/sample_events.cpp
+++ b/samples/sample_events.cpp
@@ -1013,7 +1013,7 @@ public:
 						for ( int k = 0; k < manifold.pointCount; ++k )
 						{
 							b2ManifoldPoint point = manifold.points[k];
-							m_context->draw.DrawSegment( point.point, point.point + point.totalNormalImpulse * normal,
+							m_context->draw.DrawLine( point.point, point.point + point.totalNormalImpulse * normal,
 														 b2_colorBlueViolet );
 							m_context->draw.DrawPoint( point.point, 10.0f, b2_colorWhite );
 						}
@@ -1044,7 +1044,7 @@ public:
 						for ( int k = 0; k < manifold.pointCount; ++k )
 						{
 							b2ManifoldPoint point = manifold.points[k];
-							m_context->draw.DrawSegment( point.point, point.point + point.totalNormalImpulse * normal,
+							m_context->draw.DrawLine( point.point, point.point + point.totalNormalImpulse * normal,
 														 b2_colorYellowGreen );
 							m_context->draw.DrawPoint( point.point, 10.0f, b2_colorWhite );
 						}
@@ -1827,7 +1827,7 @@ public:
 		b2Vec2 origin = { 5.0f, 1.0f };
 		b2Vec2 translation = { -10.0f, 0.0f };
 		b2RayResult result = b2World_CastRayClosest( m_worldId, origin, translation, b2DefaultQueryFilter() );
-		m_context->draw.DrawSegment( origin, origin + translation, b2_colorDimGray );
+		m_context->draw.DrawLine( origin, origin + translation, b2_colorDimGray );
 
 		if ( result.hit )
 		{
@@ -2007,8 +2007,6 @@ public:
 			jointDef.base.localFrameB.p = b2Body_GetLocalPoint( jointDef.base.bodyIdB, pivot );
 			jointDef.angularHertz = 2.0f;
 			jointDef.angularDampingRatio = 0.5f;
-			jointDef.linearHertz = 2.0f;
-			jointDef.linearDampingRatio = 0.5f;
 			jointDef.base.forceThreshold = forceThreshold;
 			jointDef.base.torqueThreshold = torqueThreshold;
 			jointDef.base.collideConnected = true;
@@ -2081,7 +2079,7 @@ public:
 	b2JointId m_jointIds[e_count];
 };
 
-static int sampleBreakableJoint = RegisterSample( "Events", "Joint", JointEvent::Create );
+static int sampleJointEvent = RegisterSample( "Events", "Joint", JointEvent::Create );
 
 class PersistentContact : public Sample
 {
@@ -2157,14 +2155,14 @@ public:
 
 		if (B2_IS_NON_NULL(m_contactId) && b2Contact_IsValid(m_contactId))
 		{
-			b2Manifold manifold = b2Contact_GetManifold( m_contactId );
+			b2ContactData data = b2Contact_GetData( m_contactId );
 
-			for (int i = 0; i < manifold.pointCount; ++i)
+			for ( int i = 0; i < data.manifold.pointCount; ++i )
 			{
-				const b2ManifoldPoint* manifoldPoint = manifold.points + i;
+				const b2ManifoldPoint* manifoldPoint = data.manifold.points + i;
 				b2Vec2 p1 = manifoldPoint->point;
-				b2Vec2 p2 = p1 + manifoldPoint->totalNormalImpulse * manifold.normal;
-				m_draw->DrawSegment( p1, p2, b2_colorCrimson );
+				b2Vec2 p2 = p1 + manifoldPoint->totalNormalImpulse * data.manifold.normal;
+				m_draw->DrawLine( p1, p2, b2_colorCrimson );
 				m_draw->DrawPoint( p1, 6.0f, b2_colorCrimson );
 				m_draw->DrawString( p1, "%.2f", manifoldPoint->totalNormalImpulse );
 			}

--- a/samples/sample_joints.cpp
+++ b/samples/sample_joints.cpp
@@ -663,7 +663,7 @@ public:
 			jointDef.base.localFrameA.q = b2MakeRotFromUnitVector( axis );
 			jointDef.base.localFrameB.p = b2Body_GetLocalPoint( jointDef.base.bodyIdB, pivot );
 			jointDef.base.localFrameB.q = b2MakeRotFromUnitVector( axis );
-			jointDef.base.drawSize = 2.0f;
+			jointDef.base.drawScale = 2.0f;
 			jointDef.motorSpeed = m_motorSpeed;
 			jointDef.maxMotorForce = m_motorForce;
 			jointDef.enableMotor = m_enableMotor;
@@ -2134,12 +2134,12 @@ public:
 			float C = length - slackLength;
 			if ( C < 0.0f || length < 0.001f )
 			{
-				m_context->draw.DrawSegment( anchorA, anchorB, b2_colorLightCyan );
+				m_context->draw.DrawLine( anchorA, anchorB, b2_colorLightCyan );
 				m_impulses[i] = 0.0f;
 				continue;
 			}
 
-			m_context->draw.DrawSegment( anchorA, anchorB, b2_colorViolet );
+			m_context->draw.DrawLine( anchorA, anchorB, b2_colorViolet );
 			b2Vec2 axis = b2Normalize( deltaAnchor );
 
 			b2Vec2 rB = b2Sub( anchorB, pB );
@@ -2985,7 +2985,7 @@ public:
 				jointDef.base.bodyIdB = bodyId;
 				jointDef.base.localFrameA.p = b2Body_GetLocalPoint( jointDef.base.bodyIdA, pivot );
 				jointDef.base.localFrameB.p = b2Body_GetLocalPoint( jointDef.base.bodyIdB, pivot );
-				jointDef.base.drawSize = 0.2f;
+				jointDef.base.drawScale = 0.2f;
 				b2CreateRevoluteJoint( m_worldId, &jointDef );
 
 				position.y -= 2.0f * linkHalfLength;

--- a/samples/sample_robustness.cpp
+++ b/samples/sample_robustness.cpp
@@ -6,7 +6,6 @@
 
 #include "box2d/box2d.h"
 
-#include <GLFW/glfw3.h>
 #include <imgui.h>
 #include <stdlib.h>
 
@@ -71,7 +70,7 @@ public:
 	}
 };
 
-static int sampleIndex1 = RegisterSample( "Robustness", "HighMassRatio1", HighMassRatio1::Create );
+static int sampleHighMassRatio1 = RegisterSample( "Robustness", "HighMassRatio1", HighMassRatio1::Create );
 
 // Big box on small boxes
 class HighMassRatio2 : public Sample
@@ -129,7 +128,7 @@ public:
 	}
 };
 
-static int sampleIndex2 = RegisterSample( "Robustness", "HighMassRatio2", HighMassRatio2::Create );
+static int sampleHighMassRatio2 = RegisterSample( "Robustness", "HighMassRatio2", HighMassRatio2::Create );
 
 // Big box on small triangles
 class HighMassRatio3 : public Sample
@@ -189,7 +188,7 @@ public:
 	}
 };
 
-static int sampleIndex3 = RegisterSample( "Robustness", "HighMassRatio3", HighMassRatio3::Create );
+static int sampleHighMassRatio3 = RegisterSample( "Robustness", "HighMassRatio3", HighMassRatio3::Create );
 
 class OverlapRecovery : public Sample
 {
@@ -208,18 +207,14 @@ public:
 		m_baseCount = 4;
 		m_overlap = 0.25f;
 		m_extent = 0.5f;
-		m_pushOut = 3.0f;
+		m_speed = 3.0f;
 		m_hertz = 30.0f;
 		m_dampingRatio = 10.0f;
 
 		b2BodyDef bodyDef = b2DefaultBodyDef();
 		b2BodyId groundId = b2CreateBody( m_worldId, &bodyDef );
-
-		float groundWidth = 40.0f;
 		b2ShapeDef shapeDef = b2DefaultShapeDef();
-		shapeDef.density = 1.0f;
-
-		b2Segment segment = { { -groundWidth, 0.0f }, { groundWidth, 0.0f } };
+		b2Segment segment = { { -40.0f, 0.0f }, { 40.0f, 0.0f } };
 		b2CreateSegmentShape( groundId, &shapeDef, &segment );
 
 		CreateScene();
@@ -232,12 +227,12 @@ public:
 
 	void CreateScene()
 	{
-		for ( int32_t i = 0; i < m_bodyCount; ++i )
+		for ( int i = 0; i < m_bodyCount; ++i )
 		{
 			b2DestroyBody( m_bodyIds[i] );
 		}
 
-		b2World_SetContactTuning( m_worldId, m_hertz, m_dampingRatio, m_pushOut );
+		b2World_SetContactTuning( m_worldId, m_hertz, m_dampingRatio, m_speed );
 
 		b2BodyDef bodyDef = b2DefaultBodyDef();
 		bodyDef.type = b2_dynamicBody;
@@ -249,13 +244,13 @@ public:
 		m_bodyCount = m_baseCount * ( m_baseCount + 1 ) / 2;
 		m_bodyIds = (b2BodyId*)realloc( m_bodyIds, m_bodyCount * sizeof( b2BodyId ) );
 
-		int32_t bodyIndex = 0;
+		int bodyIndex = 0;
 		float fraction = 1.0f - m_overlap;
 		float y = m_extent;
-		for ( int32_t i = 0; i < m_baseCount; ++i )
+		for ( int i = 0; i < m_baseCount; ++i )
 		{
 			float x = fraction * m_extent * ( i - m_baseCount );
-			for ( int32_t j = i; j < m_baseCount; ++j )
+			for ( int j = i; j < m_baseCount; ++j )
 			{
 				bodyDef.position = { x, y };
 				b2BodyId bodyId = b2CreateBody( m_worldId, &bodyDef );
@@ -286,7 +281,7 @@ public:
 		changed = changed || ImGui::SliderFloat( "Extent", &m_extent, 0.1f, 1.0f, "%.1f" );
 		changed = changed || ImGui::SliderInt( "Base Count", &m_baseCount, 1, 10 );
 		changed = changed || ImGui::SliderFloat( "Overlap", &m_overlap, 0.0f, 1.0f, "%.2f" );
-		changed = changed || ImGui::SliderFloat( "Speed", &m_pushOut, 0.0f, 10.0f, "%.1f" );
+		changed = changed || ImGui::SliderFloat( "Speed", &m_speed, 0.0f, 10.0f, "%.1f" );
 		changed = changed || ImGui::SliderFloat( "Hertz", &m_hertz, 0.0f, 240.0f, "%.f" );
 		changed = changed || ImGui::SliderFloat( "Damping Ratio", &m_dampingRatio, 0.0f, 20.0f, "%.1f" );
 		changed = changed || ImGui::Button( "Reset Scene" );
@@ -306,16 +301,16 @@ public:
 	}
 
 	b2BodyId* m_bodyIds;
-	int32_t m_bodyCount;
-	int32_t m_baseCount;
+	int m_bodyCount;
+	int m_baseCount;
 	float m_overlap;
 	float m_extent;
-	float m_pushOut;
+	float m_speed;
 	float m_hertz;
 	float m_dampingRatio;
 };
 
-static int sampleIndex4 = RegisterSample( "Robustness", "Overlap Recovery", OverlapRecovery::Create );
+static int sampleOverlapRecovery = RegisterSample( "Robustness", "Overlap Recovery", OverlapRecovery::Create );
 
 class TinyPyramid : public Sample
 {
@@ -380,7 +375,9 @@ public:
 
 static int sampleTinyPyramid = RegisterSample( "Robustness", "Tiny Pyramid", TinyPyramid::Create );
 
-// High gravity and high mass ratio
+// High gravity and high mass ratio. This shows how to tune contact and joint stiffness values to
+// achieve an improved result at a high sub-step count.
+// There is still a fair bit of bounce with some settings.
 class Cart : public Sample
 {
 public:
@@ -391,32 +388,34 @@ public:
 		{
 			m_context->camera.m_center = { 0.0f, 1.0f };
 			m_context->camera.m_zoom = 1.5f;
+			m_context->subStepCount = 12;
 		}
 
-		b2BodyId groundId;
 		{
 			b2BodyDef bodyDef = b2DefaultBodyDef();
 			bodyDef.position = { 0.0f, -1.0f };
-			groundId = b2CreateBody( m_worldId, &bodyDef );
+			b2BodyId groundId = b2CreateBody( m_worldId, &bodyDef );
 
 			b2ShapeDef shapeDef = b2DefaultShapeDef();
 			b2Polygon groundBox = b2MakeBox( 20.0f, 1.0f );
 			b2CreatePolygonShape( groundId, &shapeDef, &groundBox );
 		}
 
-		b2World_SetGravity( m_worldId, { 0, -22 } );
+		b2World_SetGravity( m_worldId, { 0, -22.0f } );
 
-		m_contactHertz = 30.0f;
+		m_contactHertz = 240.0f;
 		m_contactDampingRatio = 10.0f;
-		m_contactSpeed = 3.0f;
+		m_contactSpeed = 0.5f;
 		b2World_SetContactTuning( m_worldId, m_contactHertz, m_contactDampingRatio, m_contactSpeed );
 
-		m_jointHertz = 60.0f;
-		m_jointDampingRatio = 1.0f;
+		m_constraintHertz = 240.0f;
+		m_constraintDampingRatio = 0.0f;
 
 		m_chassisId = {};
 		m_wheelId1 = {};
 		m_wheelId2 = {};
+		m_jointId1 = {};
+		m_jointId2 = {};
 
 		CreateScene();
 	}
@@ -446,40 +445,43 @@ public:
 		m_chassisId = b2CreateBody( m_worldId, &bodyDef );
 
 		b2ShapeDef shapeDef = b2DefaultShapeDef();
-		shapeDef.density = 100.0f;
+		shapeDef.density = 1000.0f;
 
-		b2Polygon box = b2MakeOffsetBox( 0.5f, 0.25f, { 0.0f, 0.25f }, b2Rot_identity );
+		b2Polygon box = b2MakeOffsetBox( 1.0f, 0.25f, { 0.0f, 0.25f }, b2Rot_identity );
 		b2CreatePolygonShape( m_chassisId, &shapeDef, &box );
 
 		shapeDef = b2DefaultShapeDef();
 		shapeDef.material.rollingResistance = 0.02f;
-		shapeDef.density = 10.0f;
+		shapeDef.density = 50.0f;
 
 		b2Circle circle = { b2Vec2_zero, 0.1f };
-		bodyDef.position = { -0.4f, yBase - 0.15f };
+		bodyDef.position = { -0.9f, yBase - 0.15f };
 		m_wheelId1 = b2CreateBody( m_worldId, &bodyDef );
 		b2CreateCircleShape( m_wheelId1, &shapeDef, &circle );
 
-		bodyDef.position = { 0.4f, yBase - 0.15f };
+		bodyDef.position = { 0.9f, yBase - 0.15f };
 		m_wheelId2 = b2CreateBody( m_worldId, &bodyDef );
 		b2CreateCircleShape( m_wheelId2, &shapeDef, &circle );
 
 		b2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
+		jointDef.base.constraintHertz = 120.0f;
+		jointDef.base.constraintDampingRatio = 0.0f;
+
 		jointDef.base.bodyIdA = m_chassisId;
 		jointDef.base.bodyIdB = m_wheelId1;
-		jointDef.base.localFrameA.p = { -0.4f, -0.15f };
+		jointDef.base.localFrameA.p = { -0.9f, -0.15f };
 		jointDef.base.localFrameB.p = { 0.0f, 0.0f };
 
 		m_jointId1 = b2CreateRevoluteJoint( m_worldId, &jointDef );
-		b2Joint_SetConstraintTuning( m_jointId1, m_jointHertz, m_jointDampingRatio );
+		b2Joint_SetConstraintTuning( m_jointId1, m_constraintHertz, m_constraintDampingRatio );
 
 		jointDef.base.bodyIdA = m_chassisId;
 		jointDef.base.bodyIdB = m_wheelId2;
-		jointDef.base.localFrameA.p = { 0.4f, -0.15f };
+		jointDef.base.localFrameA.p = { 0.9f, -0.15f };
 		jointDef.base.localFrameB.p = { 0.0f, 0.0f };
 
 		m_jointId2 = b2CreateRevoluteJoint( m_worldId, &jointDef );
-		b2Joint_SetConstraintTuning( m_jointId2, m_jointHertz, m_jointDampingRatio );
+		b2Joint_SetConstraintTuning( m_jointId2, m_constraintHertz, m_constraintDampingRatio );
 	}
 
 	void UpdateGui() override
@@ -494,7 +496,7 @@ public:
 		bool changed = false;
 		ImGui::Text( "Contact" );
 		changed = changed || ImGui::SliderFloat( "Hertz##contact", &m_contactHertz, 0.0f, 240.0f, "%.f" );
-		changed = changed || ImGui::SliderFloat( "Damping Ratio##contact", &m_contactDampingRatio, 0.0f, 1000.0f, "%.f" );
+		changed = changed || ImGui::SliderFloat( "Damping Ratio##contact", &m_contactDampingRatio, 0.0f, 100.0f, "%.f" );
 		changed = changed || ImGui::SliderFloat( "Speed", &m_contactSpeed, 0.0f, 5.0f, "%.1f" );
 
 		if ( changed )
@@ -507,8 +509,8 @@ public:
 
 		changed = false;
 		ImGui::Text( "Joint" );
-		changed = changed || ImGui::SliderFloat( "Hertz##joint", &m_jointHertz, 0.0f, 240.0f, "%.f" );
-		changed = changed || ImGui::SliderFloat( "Damping Ratio##joint", &m_jointDampingRatio, 0.0f, 1000.0f, "%.f" );
+		changed = changed || ImGui::SliderFloat( "Hertz##joint", &m_constraintHertz, 0.0f, 240.0f, "%.f" );
+		changed = changed || ImGui::SliderFloat( "Damping Ratio##joint", &m_constraintDampingRatio, 0.0f, 20.0f, "%.f" );
 
 		ImGui::Separator();
 
@@ -516,8 +518,8 @@ public:
 
 		if ( changed )
 		{
-			b2Joint_SetConstraintTuning( m_jointId1, m_jointHertz, m_jointDampingRatio );
-			b2Joint_SetConstraintTuning( m_jointId2, m_jointHertz, m_jointDampingRatio );
+			b2Joint_SetConstraintTuning( m_jointId1, m_constraintHertz, m_constraintDampingRatio );
+			b2Joint_SetConstraintTuning( m_jointId2, m_constraintHertz, m_constraintDampingRatio );
 			CreateScene();
 		}
 
@@ -539,8 +541,8 @@ public:
 	float m_contactHertz;
 	float m_contactDampingRatio;
 	float m_contactSpeed;
-	float m_jointHertz;
-	float m_jointDampingRatio;
+	float m_constraintHertz;
+	float m_constraintDampingRatio;
 };
 
 static int sampleCart = RegisterSample( "Robustness", "Cart", Cart::Create );

--- a/samples/sample_shapes.cpp
+++ b/samples/sample_shapes.cpp
@@ -206,8 +206,8 @@ public:
 	{
 		Sample::Step();
 
-		m_context->draw.DrawSegment( b2Vec2_zero, { 0.5f, 0.0f }, b2_colorRed );
-		m_context->draw.DrawSegment( b2Vec2_zero, { 0.0f, 0.5f }, b2_colorGreen );
+		m_context->draw.DrawLine( b2Vec2_zero, { 0.5f, 0.0f }, b2_colorRed );
+		m_context->draw.DrawLine( b2Vec2_zero, { 0.0f, 0.5f }, b2_colorGreen );
 
 		// DrawTextLine( "toi calls, hits = %d, %d", b2_toiCalls, b2_toiHitCount );
 	}
@@ -422,16 +422,16 @@ public:
 		if ( m_drawBodyAABBs )
 		{
 			b2AABB aabb = b2Body_ComputeAABB( m_table1Id );
-			m_context->draw.DrawAABB( aabb, b2_colorYellow );
+			m_context->draw.DrawBounds( aabb, b2_colorYellow );
 
 			aabb = b2Body_ComputeAABB( m_table2Id );
-			m_context->draw.DrawAABB( aabb, b2_colorYellow );
+			m_context->draw.DrawBounds( aabb, b2_colorYellow );
 
 			aabb = b2Body_ComputeAABB( m_ship1Id );
-			m_context->draw.DrawAABB( aabb, b2_colorYellow );
+			m_context->draw.DrawBounds( aabb, b2_colorYellow );
 
 			aabb = b2Body_ComputeAABB( m_ship2Id );
-			m_context->draw.DrawAABB( aabb, b2_colorYellow );
+			m_context->draw.DrawBounds( aabb, b2_colorYellow );
 		}
 	}
 
@@ -727,7 +727,7 @@ public:
 		void* userDataA = b2Shape_GetUserData( shapeIdA );
 		void* userDataB = b2Shape_GetUserData( shapeIdB );
 
-		if ( userDataA == NULL || userDataB == NULL )
+		if ( userDataA == nullptr || userDataB == nullptr )
 		{
 			return true;
 		}

--- a/shared/determinism.c
+++ b/shared/determinism.c
@@ -46,7 +46,7 @@ FallingHingeData CreateFallingHinges( b2WorldId worldId )
 	jointDef.dampingRatio = 0.5f;
 	jointDef.base.localFrameA.p = (b2Vec2){ h, h };
 	jointDef.base.localFrameB.p = (b2Vec2){ offset, -h };
-	jointDef.base.drawSize = 0.1f;
+	jointDef.base.drawScale = 0.1f;
 
 	int bodyIndex = 0;
 

--- a/shared/human.c
+++ b/shared/human.c
@@ -118,7 +118,7 @@ void CreateHuman( Human* human, b2WorldId worldId, b2Vec2 position, float scale,
 		jointDef.enableSpring = hertz > 0.0f;
 		jointDef.hertz = hertz;
 		jointDef.dampingRatio = dampingRatio;
-		jointDef.base.drawSize = drawSize;
+		jointDef.base.drawScale = drawSize;
 
 		bone->jointId = b2CreateRevoluteJoint( worldId, &jointDef );
 	}
@@ -161,7 +161,7 @@ void CreateHuman( Human* human, b2WorldId worldId, b2Vec2 position, float scale,
 		jointDef.enableSpring = hertz > 0.0f;
 		jointDef.hertz = hertz;
 		jointDef.dampingRatio = dampingRatio;
-		jointDef.base.drawSize = drawSize;
+		jointDef.base.drawScale = drawSize;
 
 		bone->jointId = b2CreateRevoluteJoint( worldId, &jointDef );
 	}
@@ -200,7 +200,7 @@ void CreateHuman( Human* human, b2WorldId worldId, b2Vec2 position, float scale,
 		jointDef.enableSpring = hertz > 0.0f;
 		jointDef.hertz = hertz;
 		jointDef.dampingRatio = dampingRatio;
-		jointDef.base.drawSize = drawSize;
+		jointDef.base.drawScale = drawSize;
 
 		bone->jointId = b2CreateRevoluteJoint( worldId, &jointDef );
 	}
@@ -257,7 +257,7 @@ void CreateHuman( Human* human, b2WorldId worldId, b2Vec2 position, float scale,
 		jointDef.enableSpring = hertz > 0.0f;
 		jointDef.hertz = hertz;
 		jointDef.dampingRatio = dampingRatio;
-		jointDef.base.drawSize = drawSize;
+		jointDef.base.drawScale = drawSize;
 
 		bone->jointId = b2CreateRevoluteJoint( worldId, &jointDef );
 	}
@@ -296,7 +296,7 @@ void CreateHuman( Human* human, b2WorldId worldId, b2Vec2 position, float scale,
 		jointDef.enableSpring = hertz > 0.0f;
 		jointDef.hertz = hertz;
 		jointDef.dampingRatio = dampingRatio;
-		jointDef.base.drawSize = drawSize;
+		jointDef.base.drawScale = drawSize;
 
 		bone->jointId = b2CreateRevoluteJoint( worldId, &jointDef );
 	}
@@ -343,7 +343,7 @@ void CreateHuman( Human* human, b2WorldId worldId, b2Vec2 position, float scale,
 		jointDef.enableSpring = hertz > 0.0f;
 		jointDef.hertz = hertz;
 		jointDef.dampingRatio = dampingRatio;
-		jointDef.base.drawSize = drawSize;
+		jointDef.base.drawScale = drawSize;
 
 		bone->jointId = b2CreateRevoluteJoint( worldId, &jointDef );
 	}
@@ -382,7 +382,7 @@ void CreateHuman( Human* human, b2WorldId worldId, b2Vec2 position, float scale,
 		jointDef.enableSpring = hertz > 0.0f;
 		jointDef.hertz = hertz;
 		jointDef.dampingRatio = dampingRatio;
-		jointDef.base.drawSize = drawSize;
+		jointDef.base.drawScale = drawSize;
 
 		bone->jointId = b2CreateRevoluteJoint( worldId, &jointDef );
 	}
@@ -422,7 +422,7 @@ void CreateHuman( Human* human, b2WorldId worldId, b2Vec2 position, float scale,
 		jointDef.enableSpring = hertz > 0.0f;
 		jointDef.hertz = hertz;
 		jointDef.dampingRatio = dampingRatio;
-		jointDef.base.drawSize = drawSize;
+		jointDef.base.drawScale = drawSize;
 
 		bone->jointId = b2CreateRevoluteJoint( worldId, &jointDef );
 	}
@@ -461,7 +461,7 @@ void CreateHuman( Human* human, b2WorldId worldId, b2Vec2 position, float scale,
 		jointDef.enableSpring = hertz > 0.0f;
 		jointDef.hertz = hertz;
 		jointDef.dampingRatio = dampingRatio;
-		jointDef.base.drawSize = drawSize;
+		jointDef.base.drawScale = drawSize;
 
 		bone->jointId = b2CreateRevoluteJoint( worldId, &jointDef );
 	}
@@ -501,7 +501,7 @@ void CreateHuman( Human* human, b2WorldId worldId, b2Vec2 position, float scale,
 		jointDef.enableSpring = hertz > 0.0f;
 		jointDef.hertz = hertz;
 		jointDef.dampingRatio = dampingRatio;
-		jointDef.base.drawSize = drawSize;
+		jointDef.base.drawScale = drawSize;
 
 		bone->jointId = b2CreateRevoluteJoint( worldId, &jointDef );
 	}

--- a/src/array.h
+++ b/src/array.h
@@ -178,4 +178,4 @@ B2_ARRAY_DECLARE( b2Shape, b2Shape );
 B2_ARRAY_DECLARE( b2ShapeRef, b2ShapeRef );
 B2_ARRAY_DECLARE( b2SolverSet, b2SolverSet );
 B2_ARRAY_DECLARE( b2TaskContext, b2TaskContext );
-B2_ARRAY_DECLARE( b2SensorContinuousHit, b2SensorContinuousHit );
+B2_ARRAY_DECLARE( b2SensorHit, b2SensorHit );

--- a/src/array.h
+++ b/src/array.h
@@ -178,3 +178,4 @@ B2_ARRAY_DECLARE( b2Shape, b2Shape );
 B2_ARRAY_DECLARE( b2ShapeRef, b2ShapeRef );
 B2_ARRAY_DECLARE( b2SolverSet, b2SolverSet );
 B2_ARRAY_DECLARE( b2TaskContext, b2TaskContext );
+B2_ARRAY_DECLARE( b2SensorContinuousHit, b2SensorContinuousHit );

--- a/src/body.c
+++ b/src/body.c
@@ -247,6 +247,7 @@ b2BodyId b2CreateBody( b2WorldId worldId, const b2BodyDef* def )
 	bodySim->gravityScale = def->gravityScale;
 	bodySim->bodyId = bodyId;
 	bodySim->isBullet = def->isBullet;
+	bodySim->enableSensorSweeps = def->enableSensorSweeps;
 	bodySim->allowFastRotation = def->allowFastRotation;
 
 	if ( setId == b2_awakeSet )
@@ -482,6 +483,7 @@ int b2Body_GetContactData( b2BodyId bodyId, b2ContactData* contactData, int capa
 			b2Shape* shapeA = b2ShapeArray_Get( &world->shapes, contact->shapeIdA );
 			b2Shape* shapeB = b2ShapeArray_Get( &world->shapes, contact->shapeIdB );
 
+			contactData[index].contactId = (b2ContactId){ contact->contactId + 1, bodyId.world0, 0, contact->generation };
 			contactData[index].shapeIdA = (b2ShapeId){ shapeA->id + 1, bodyId.world0, shapeA->generation };
 			contactData[index].shapeIdB = (b2ShapeId){ shapeB->id + 1, bodyId.world0, shapeB->generation };
 

--- a/src/body.c
+++ b/src/body.c
@@ -247,7 +247,7 @@ b2BodyId b2CreateBody( b2WorldId worldId, const b2BodyDef* def )
 	bodySim->gravityScale = def->gravityScale;
 	bodySim->bodyId = bodyId;
 	bodySim->isBullet = def->isBullet;
-	bodySim->enableSensorSweeps = def->enableSensorSweeps;
+	bodySim->enableSensorHits = def->enableSensorHits;
 	bodySim->allowFastRotation = def->allowFastRotation;
 
 	if ( setId == b2_awakeSet )

--- a/src/body.h
+++ b/src/body.h
@@ -153,6 +153,7 @@ typedef struct b2BodySim
 	bool isFast;
 
 	bool isBullet;
+	bool enableSensorSweeps;
 	bool isSpeedCapped;
 	bool allowFastRotation;
 	bool enlargeAABB;

--- a/src/body.h
+++ b/src/body.h
@@ -153,7 +153,7 @@ typedef struct b2BodySim
 	bool isFast;
 
 	bool isBullet;
-	bool enableSensorSweeps;
+	bool enableSensorHits;
 	bool isSpeedCapped;
 	bool allowFastRotation;
 	bool enlargeAABB;

--- a/src/constants.h
+++ b/src/constants.h
@@ -46,12 +46,6 @@ extern float b2_lengthUnitsPerMeter;
 // The time that a body must be still before it will go to sleep. In seconds.
 #define B2_TIME_TO_SLEEP 0.5f
 
-// The default joint constraint hertz
-#define B2_JOINT_CONSTRAINT_HERTZ 60.0f
-
-// The default joint constraint damping ratio
-#define B2_JOINT_CONSTRAINT_DAMPING_RATIO 0.0f
-
 enum b2TreeNodeFlags
 {
 	b2_allocatedNode = 0x0001,

--- a/src/contact.c
+++ b/src/contact.c
@@ -562,8 +562,20 @@ bool b2UpdateContact( b2World* world, b2ContactSim* contactSim, b2Shape* shapeA,
 		b2ShapeId shapeIdA = { shapeA->id + 1, world->worldId, shapeA->generation };
 		b2ShapeId shapeIdB = { shapeB->id + 1, world->worldId, shapeB->generation };
 
+		float bestSeparation = contactSim->manifold.points[0].separation;
+		b2Vec2 bestPoint = contactSim->manifold.points[0].point;
+		for ( int i = 1; i < contactSim->manifold.pointCount; ++i )
+		{
+			float separation = contactSim->manifold.points[i].separation;
+			if ( separation < bestSeparation )
+			{
+				bestSeparation = separation;
+				bestPoint = contactSim->manifold.points[i].point;
+			}
+		}
+
 		// this call assumes thread safety
-		touching = world->preSolveFcn( shapeIdA, shapeIdB, &contactSim->manifold, world->preSolveContext );
+		touching = world->preSolveFcn( shapeIdA, shapeIdB, bestPoint, contactSim->manifold.normal, world->preSolveContext );
 		if ( touching == false )
 		{
 			// disable contact

--- a/src/contact.c
+++ b/src/contact.c
@@ -562,25 +562,28 @@ bool b2UpdateContact( b2World* world, b2ContactSim* contactSim, b2Shape* shapeA,
 		b2ShapeId shapeIdA = { shapeA->id + 1, world->worldId, shapeA->generation };
 		b2ShapeId shapeIdB = { shapeB->id + 1, world->worldId, shapeB->generation };
 
-		float bestSeparation = contactSim->manifold.points[0].separation;
-		b2Vec2 bestPoint = contactSim->manifold.points[0].point;
-		for ( int i = 1; i < contactSim->manifold.pointCount; ++i )
+		b2Manifold* manifold = &contactSim->manifold;
+		float bestSeparation = manifold->points[0].separation;
+		b2Vec2 bestPoint = manifold->points[0].point;
+
+		// Get deepest point
+		for ( int i = 1; i < manifold->pointCount; ++i )
 		{
-			float separation = contactSim->manifold.points[i].separation;
+			float separation = manifold->points[i].separation;
 			if ( separation < bestSeparation )
 			{
 				bestSeparation = separation;
-				bestPoint = contactSim->manifold.points[i].point;
+				bestPoint = manifold->points[i].point;
 			}
 		}
 
 		// this call assumes thread safety
-		touching = world->preSolveFcn( shapeIdA, shapeIdB, bestPoint, contactSim->manifold.normal, world->preSolveContext );
+		touching = world->preSolveFcn( shapeIdA, shapeIdB, bestPoint, manifold->normal, world->preSolveContext );
 		if ( touching == false )
 		{
 			// disable contact
 			pointCount = 0;
-			contactSim->manifold.pointCount = 0;
+			manifold->pointCount = 0;
 		}
 	}
 

--- a/src/contact.c
+++ b/src/contact.c
@@ -65,30 +65,32 @@ static b2Contact* b2GetContactFullId( b2World* world, b2ContactId contactId )
 	return contact;
 }
 
-b2Manifold b2Contact_GetManifold( b2ContactId contactId )
+b2ContactData b2Contact_GetData( b2ContactId contactId )
 {
 	b2World* world = b2GetWorld( contactId.world0 );
 	b2Contact* contact = b2GetContactFullId( world, contactId );
 	b2ContactSim* contactSim = b2GetContactSim( world, contact );
-	return contactSim->manifold;
-}
-
-void b2Contact_GetShapeIds( b2ContactId contactId, b2ShapeId* shapeIdA, b2ShapeId* shapeIdB )
-{
-	b2World* world = b2GetWorld( contactId.world0 );
-	b2Contact* contact = b2GetContactFullId( world, contactId );
 	const b2Shape* shapeA = b2ShapeArray_Get( &world->shapes, contact->shapeIdA );
 	const b2Shape* shapeB = b2ShapeArray_Get( &world->shapes, contact->shapeIdB );
-	*shapeIdA = (b2ShapeId){
-		.index1 = shapeA->id + 1,
-		.world0 = (uint16_t)contactId.world0,
-		.generation = shapeA->generation,
+
+	b2ContactData data = {
+		.contactId = contactId,
+		.shapeIdA =
+			{
+				.index1 = shapeA->id + 1,
+				.world0 = (uint16_t)contactId.world0,
+				.generation = shapeA->generation,
+			},
+		.shapeIdB =
+			{
+				.index1 = shapeB->id + 1,
+				.world0 = (uint16_t)contactId.world0,
+				.generation = shapeB->generation,
+			},
+		.manifold = contactSim->manifold,
 	};
-	*shapeIdB = (b2ShapeId){
-		.index1 = shapeB->id + 1,
-		.world0 = (uint16_t)contactId.world0,
-		.generation = shapeB->generation,
-	};
+
+	return data;
 }
 
 typedef b2Manifold b2ManifoldFcn( const b2Shape* shapeA, b2Transform xfA, const b2Shape* shapeB, b2Transform xfB,

--- a/src/core.c
+++ b/src/core.c
@@ -70,8 +70,8 @@ b2Version b2GetVersion( void )
 {
 	return (b2Version){
 		.major = 3,
-		.minor = 1,
-		.revision = 1,
+		.minor = 2,
+		.revision = 0,
 	};
 }
 

--- a/src/distance.c
+++ b/src/distance.c
@@ -631,7 +631,8 @@ b2CastOutput b2ShapeCast( const b2ShapeCastPairInput* input )
 	b2CastOutput output = { 0 };
 
 	int iteration = 0;
-	int maxIterations = 20;
+	const int maxIterations = 20;
+
 	for ( ; iteration < maxIterations; ++iteration )
 	{
 		output.iterations += 1;

--- a/src/distance.c
+++ b/src/distance.c
@@ -1161,8 +1161,6 @@ b2TOIOutput b2TimeOfImpact( const b2TOIInput* input )
 	float tMax = input->maxFraction;
 
 	float totalRadius = proxyA->radius + proxyB->radius;
-	// todo_erin consider different target
-	// float target = b2MaxFloat( B2_LINEAR_SLOP, totalRadius );
 	float target = b2MaxFloat( B2_LINEAR_SLOP, totalRadius - B2_LINEAR_SLOP );
 	float tolerance = 0.25f * B2_LINEAR_SLOP;
 	B2_ASSERT( target > tolerance );
@@ -1230,6 +1228,13 @@ b2TOIOutput b2TimeOfImpact( const b2TOIInput* input )
 #if B2_SNOOP_TOI_COUNTERS
 			b2_toiHitCount += 1;
 #endif
+			output.normal = distanceOutput.normal;
+
+			// Averaged hit point
+			b2Vec2 pA = b2MulAdd( distanceOutput.pointA, proxyA->radius, distanceOutput.normal );
+			b2Vec2 pB = b2MulAdd( distanceOutput.pointB, -proxyB->radius, distanceOutput.normal );
+			output.point = b2Lerp( pA, pB, 0.5f );
+
 			output.fraction = t1;
 			break;
 		}
@@ -1318,6 +1323,12 @@ b2TOIOutput b2TimeOfImpact( const b2TOIInput* input )
 #if B2_SNOOP_TOI_COUNTERS
 				b2_toiHitCount += 1;
 #endif
+				output.normal = distanceOutput.normal;
+
+				// Averaged hit point
+				b2Vec2 pA = b2MulAdd( distanceOutput.pointA, proxyA->radius, distanceOutput.normal );
+				b2Vec2 pB = b2MulAdd( distanceOutput.pointB, -proxyB->radius, distanceOutput.normal );
+				output.point = b2Lerp( pA, pB, 0.5f );
 				output.fraction = t1;
 				done = true;
 				break;
@@ -1398,6 +1409,12 @@ b2TOIOutput b2TimeOfImpact( const b2TOIInput* input )
 #if B2_SNOOP_TOI_COUNTERS
 			b2_toiFailedCount += 1;
 #endif
+			output.normal = distanceOutput.normal;
+
+			// Averaged hit point
+			b2Vec2 pA = b2MulAdd( distanceOutput.pointA, proxyA->radius, distanceOutput.normal );
+			b2Vec2 pB = b2MulAdd( distanceOutput.pointB, -proxyB->radius, distanceOutput.normal );
+			output.point = b2Lerp( pA, pB, 0.5f );
 			output.fraction = t1;
 			break;
 		}

--- a/src/distance.c
+++ b/src/distance.c
@@ -1228,13 +1228,11 @@ b2TOIOutput b2TimeOfImpact( const b2TOIInput* input )
 #if B2_SNOOP_TOI_COUNTERS
 			b2_toiHitCount += 1;
 #endif
-			output.normal = distanceOutput.normal;
-
 			// Averaged hit point
 			b2Vec2 pA = b2MulAdd( distanceOutput.pointA, proxyA->radius, distanceOutput.normal );
 			b2Vec2 pB = b2MulAdd( distanceOutput.pointB, -proxyB->radius, distanceOutput.normal );
 			output.point = b2Lerp( pA, pB, 0.5f );
-
+			output.normal = distanceOutput.normal;
 			output.fraction = t1;
 			break;
 		}
@@ -1323,12 +1321,11 @@ b2TOIOutput b2TimeOfImpact( const b2TOIInput* input )
 #if B2_SNOOP_TOI_COUNTERS
 				b2_toiHitCount += 1;
 #endif
-				output.normal = distanceOutput.normal;
-
 				// Averaged hit point
 				b2Vec2 pA = b2MulAdd( distanceOutput.pointA, proxyA->radius, distanceOutput.normal );
 				b2Vec2 pB = b2MulAdd( distanceOutput.pointB, -proxyB->radius, distanceOutput.normal );
 				output.point = b2Lerp( pA, pB, 0.5f );
+				output.normal = distanceOutput.normal;
 				output.fraction = t1;
 				done = true;
 				break;
@@ -1409,12 +1406,11 @@ b2TOIOutput b2TimeOfImpact( const b2TOIInput* input )
 #if B2_SNOOP_TOI_COUNTERS
 			b2_toiFailedCount += 1;
 #endif
-			output.normal = distanceOutput.normal;
-
 			// Averaged hit point
 			b2Vec2 pA = b2MulAdd( distanceOutput.pointA, proxyA->radius, distanceOutput.normal );
 			b2Vec2 pB = b2MulAdd( distanceOutput.pointB, -proxyB->radius, distanceOutput.normal );
 			output.point = b2Lerp( pA, pB, 0.5f );
+			output.normal = distanceOutput.normal;
 			output.fraction = t1;
 			break;
 		}

--- a/src/joint.c
+++ b/src/joint.c
@@ -30,7 +30,9 @@ static b2JointDef b2DefaultJointDef( void )
 	def.localFrameB.q = b2Rot_identity;
 	def.forceThreshold = FLT_MAX;
 	def.torqueThreshold = FLT_MAX;
-	def.drawSize = 1.0f;
+	def.constraintHertz = 60.0f;
+	def.constraintDampingRatio = 0.0f;
+	def.drawScale = 1.0f;
 	return def;
 }
 
@@ -230,7 +232,7 @@ static b2JointPair b2CreateJoint( b2World* world, const b2JointDef* def, b2Joint
 	joint->islandId = B2_NULL_INDEX;
 	joint->islandPrev = B2_NULL_INDEX;
 	joint->islandNext = B2_NULL_INDEX;
-	joint->drawSize = def->drawSize;
+	joint->drawSize = def->drawScale;
 	joint->type = type;
 	joint->collideConnected = def->collideConnected;
 	joint->isMarked = false;
@@ -353,8 +355,8 @@ static b2JointPair b2CreateJoint( b2World* world, const b2JointDef* def, b2Joint
 	jointSim->localFrameA = def->localFrameA;
 	jointSim->localFrameB = def->localFrameB;
 	jointSim->type = type;
-	jointSim->constraintHertz = B2_JOINT_CONSTRAINT_HERTZ;
-	jointSim->constraintDampingRatio = B2_JOINT_CONSTRAINT_DAMPING_RATIO;
+	jointSim->constraintHertz = def->constraintHertz;
+	jointSim->constraintDampingRatio = def->constraintDampingRatio;
 	jointSim->constraintSoftness = (b2Softness){
 		.biasRate = 0.0f,
 		.massScale = 1.0f,
@@ -498,6 +500,40 @@ b2JointId b2CreateFilterJoint( b2WorldId worldId, const b2FilterJointDef* def )
 	return jointId;
 }
 
+b2JointId b2CreatePrismaticJoint( b2WorldId worldId, const b2PrismaticJointDef* def )
+{
+	B2_CHECK_DEF( def );
+	B2_ASSERT( def->lowerTranslation <= def->upperTranslation );
+
+	b2World* world = b2GetWorldFromId( worldId );
+
+	B2_ASSERT( world->locked == false );
+
+	if ( world->locked )
+	{
+		return (b2JointId){ 0 };
+	}
+
+	b2JointPair pair = b2CreateJoint( world, &def->base, b2_prismaticJoint );
+
+	b2JointSim* joint = pair.jointSim;
+
+	joint->prismaticJoint = (b2PrismaticJoint){ 0 };
+	joint->prismaticJoint.hertz = def->hertz;
+	joint->prismaticJoint.dampingRatio = def->dampingRatio;
+	joint->prismaticJoint.targetTranslation = def->targetTranslation;
+	joint->prismaticJoint.lowerTranslation = def->lowerTranslation;
+	joint->prismaticJoint.upperTranslation = def->upperTranslation;
+	joint->prismaticJoint.maxMotorForce = def->maxMotorForce;
+	joint->prismaticJoint.motorSpeed = def->motorSpeed;
+	joint->prismaticJoint.enableSpring = def->enableSpring;
+	joint->prismaticJoint.enableLimit = def->enableLimit;
+	joint->prismaticJoint.enableMotor = def->enableMotor;
+
+	b2JointId jointId = { joint->jointId + 1, world->worldId, pair.joint->generation };
+	return jointId;
+}
+
 b2JointId b2CreateRevoluteJoint( b2WorldId worldId, const b2RevoluteJointDef* def )
 {
 	B2_CHECK_DEF( def );
@@ -531,42 +567,6 @@ b2JointId b2CreateRevoluteJoint( b2WorldId worldId, const b2RevoluteJointDef* de
 	joint->revoluteJoint.enableSpring = def->enableSpring;
 	joint->revoluteJoint.enableLimit = def->enableLimit;
 	joint->revoluteJoint.enableMotor = def->enableMotor;
-
-	b2JointId jointId = { joint->jointId + 1, world->worldId, pair.joint->generation };
-	return jointId;
-}
-
-b2JointId b2CreatePrismaticJoint( b2WorldId worldId, const b2PrismaticJointDef* def )
-{
-	B2_CHECK_DEF( def );
-	B2_ASSERT( def->lowerTranslation <= def->upperTranslation );
-
-	b2World* world = b2GetWorldFromId( worldId );
-
-	B2_ASSERT( world->locked == false );
-
-	if ( world->locked )
-	{
-		return (b2JointId){ 0 };
-	}
-
-	b2JointPair pair = b2CreateJoint( world, &def->base, b2_prismaticJoint );
-
-	b2JointSim* joint = pair.jointSim;
-
-	b2PrismaticJoint empty = { 0 };
-	joint->prismaticJoint = empty;
-
-	joint->prismaticJoint.targetTranslation = def->targetTranslation;
-	joint->prismaticJoint.hertz = def->hertz;
-	joint->prismaticJoint.dampingRatio = def->dampingRatio;
-	joint->prismaticJoint.lowerTranslation = def->lowerTranslation;
-	joint->prismaticJoint.upperTranslation = def->upperTranslation;
-	joint->prismaticJoint.maxMotorForce = def->maxMotorForce;
-	joint->prismaticJoint.motorSpeed = def->motorSpeed;
-	joint->prismaticJoint.enableSpring = def->enableSpring;
-	joint->prismaticJoint.enableLimit = def->enableLimit;
-	joint->prismaticJoint.enableMotor = def->enableMotor;
 
 	b2JointId jointId = { joint->jointId + 1, world->worldId, pair.joint->generation };
 	return jointId;
@@ -983,7 +983,7 @@ void b2GetJointReaction( b2JointSim* sim, float invTimeStep, float* force, float
 
 float b2GetJointConstraintTorqueMagnitude( b2JointSim* jointSim, float invTimeStep );
 
-b2Vec2 b2GetJointConstraintForce( b2World* world, b2Joint* joint )
+static b2Vec2 b2GetJointConstraintForce( b2World* world, b2Joint* joint )
 {
 	b2JointSim* base = b2GetJointSim( world, joint );
 
@@ -1019,7 +1019,7 @@ b2Vec2 b2GetJointConstraintForce( b2World* world, b2Joint* joint )
 	}
 }
 
-float b2GetJointConstraintTorque( b2World* world, b2Joint* joint )
+static float b2GetJointConstraintTorque( b2World* world, b2Joint* joint )
 {
 	b2JointSim* base = b2GetJointSim( world, joint );
 
@@ -1096,7 +1096,8 @@ float b2Joint_GetLinearSeparation( b2JointId jointId )
 					{
 						return distanceJoint->minLength - length;
 					}
-					else if ( length > distanceJoint->maxLength )
+
+					if ( length > distanceJoint->maxLength )
 					{
 						return length - distanceJoint->maxLength;
 					}
@@ -1508,6 +1509,7 @@ void b2DrawJoint( b2DebugDraw* draw, b2World* world, b2Joint* joint )
 			draw->DrawSegmentFcn( transformA.p, pA, color, draw->context );
 			draw->DrawSegmentFcn( pA, pB, color, draw->context );
 			draw->DrawSegmentFcn( transformB.p, pB, color, draw->context );
+			break;
 	}
 
 	if ( draw->drawGraphColors )

--- a/src/joint.c
+++ b/src/joint.c
@@ -232,7 +232,7 @@ static b2JointPair b2CreateJoint( b2World* world, const b2JointDef* def, b2Joint
 	joint->islandId = B2_NULL_INDEX;
 	joint->islandPrev = B2_NULL_INDEX;
 	joint->islandNext = B2_NULL_INDEX;
-	joint->drawSize = def->drawScale;
+	joint->drawScale = def->drawScale;
 	joint->type = type;
 	joint->collideConnected = def->collideConnected;
 	joint->isMarked = false;
@@ -1490,15 +1490,15 @@ void b2DrawJoint( b2DebugDraw* draw, b2World* world, b2Joint* joint )
 			break;
 
 		case b2_prismaticJoint:
-			b2DrawPrismaticJoint( draw, jointSim, transformA, transformB, joint->drawSize );
+			b2DrawPrismaticJoint( draw, jointSim, transformA, transformB, joint->drawScale );
 			break;
 
 		case b2_revoluteJoint:
-			b2DrawRevoluteJoint( draw, jointSim, transformA, transformB, joint->drawSize );
+			b2DrawRevoluteJoint( draw, jointSim, transformA, transformB, joint->drawScale );
 			break;
 
 		case b2_weldJoint:
-			b2DrawWeldJoint( draw, jointSim, transformA, transformB, joint->drawSize );
+			b2DrawWeldJoint( draw, jointSim, transformA, transformB, joint->drawScale );
 			break;
 
 		case b2_wheelJoint:

--- a/src/joint.h
+++ b/src/joint.h
@@ -47,7 +47,7 @@ typedef struct b2Joint
 	int islandPrev;
 	int islandNext;
 
-	float drawSize;
+	float drawScale;
 
 	b2JointType type;
 

--- a/src/joint.h
+++ b/src/joint.h
@@ -125,7 +125,7 @@ typedef struct b2MouseJoint
 	b2Transform frameB;
 	b2Vec2 deltaCenter;
 	b2Mat22 linearMass;
-	float axialMass;
+	float angularMass;
 } b2MouseJoint;
 
 typedef struct b2PrismaticJoint
@@ -288,8 +288,6 @@ float b2GetJointConstraintForceMagnitude( b2JointSim* jointSim, float invTimeSte
 float b2GetJointConstraintTorqueMagnitude( b2JointSim* jointSim, float invTimeStep );
 
 void b2GetJointReaction( b2JointSim* sim, float invTimeStep, float* force, float* torque );
-b2Vec2 b2GetJointConstraintForce( b2World* world, b2Joint* joint );
-float b2GetJointConstraintTorque( b2World* world, b2Joint* joint );
 
 void b2DrawJoint( b2DebugDraw* draw, b2World* world, b2Joint* joint );
 

--- a/src/mouse_joint.c
+++ b/src/mouse_joint.c
@@ -65,7 +65,6 @@ void b2PrepareMouseJoint( b2JointSim* base, b2StepContext* context )
 {
 	B2_ASSERT( base->type == b2_mouseJoint );
 
-	// chase body id to the solver set where the body lives
 	int idA = base->bodyIdA;
 	int idB = base->bodyIdB;
 
@@ -128,7 +127,7 @@ void b2PrepareMouseJoint( b2JointSim* base, b2StepContext* context )
 	joint->linearMass = b2GetInverse22( K );
 
 	float ka = iA + iB;
-	joint->axialMass = ka > 0.0f ? 1.0f / ka : 0.0f;
+	joint->angularMass = ka > 0.0f ? 1.0f / ka : 0.0f;
 
 	if ( context->enableWarmStarting == false )
 	{
@@ -190,7 +189,7 @@ void b2SolveMouseJoint( b2JointSim* base, b2StepContext* context )
 		float impulseScale = joint->angularSoftness.impulseScale;
 
 		float Cdot = wB - wA;
-		float impulse = -massScale * joint->axialMass * Cdot - impulseScale * joint->angularImpulse;
+		float impulse = -massScale * joint->angularMass * Cdot - impulseScale * joint->angularImpulse;
 		joint->angularImpulse += impulse;
 
 		wA -= iA * impulse;

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -314,6 +314,7 @@ void b2DestroyWorld( b2WorldId worldId )
 	int sensorCount = world->sensors.count;
 	for ( int i = 0; i < sensorCount; ++i )
 	{
+		b2ShapeRefArray_Destroy( &world->sensors.data[i].hits );
 		b2ShapeRefArray_Destroy( &world->sensors.data[i].overlaps1 );
 		b2ShapeRefArray_Destroy( &world->sensors.data[i].overlaps2 );
 	}
@@ -643,7 +644,7 @@ static void b2Collide( b2StepContext* context )
 
 				if ( flags & b2_contactEnableContactEvents )
 				{
-					b2ContactBeginTouchEvent event = { shapeIdA, shapeIdB, contactFullId, contactSim->manifold };
+					b2ContactBeginTouchEvent event = { shapeIdA, shapeIdB, contactFullId };
 					b2ContactBeginTouchEventArray_Push( &world->contactBeginEvents, event );
 				}
 

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -245,7 +245,7 @@ b2WorldId b2CreateWorld( const b2WorldDef* def )
 
 	for ( int i = 0; i < world->workerCount; ++i )
 	{
-		world->taskContexts.data[i].sensorContinuousHits = b2SensorContinuousHitArray_Create( 8 );
+		world->taskContexts.data[i].sensorHits = b2SensorHitArray_Create( 8 );
 		world->taskContexts.data[i].contactStateBitSet = b2CreateBitSet( 1024 );
 		world->taskContexts.data[i].jointStateBitSet = b2CreateBitSet( 1024 );
 		world->taskContexts.data[i].enlargedSimBitSet = b2CreateBitSet( 256 );
@@ -274,7 +274,7 @@ void b2DestroyWorld( b2WorldId worldId )
 
 	for ( int i = 0; i < world->workerCount; ++i )
 	{
-		b2SensorContinuousHitArray_Destroy( &world->taskContexts.data[i].sensorContinuousHits );
+		b2SensorHitArray_Destroy( &world->taskContexts.data[i].sensorHits );
 		b2DestroyBitSet( &world->taskContexts.data[i].contactStateBitSet );
 		b2DestroyBitSet( &world->taskContexts.data[i].jointStateBitSet );
 		b2DestroyBitSet( &world->taskContexts.data[i].enlargedSimBitSet );

--- a/src/physics_world.h
+++ b/src/physics_world.h
@@ -24,7 +24,7 @@ enum b2SetType
 typedef struct b2TaskContext
 {
 	// Collect per thread sensor continuous hit events.
-	b2SensorContinuousHitArray sensorContinuousHits;
+	b2SensorHitArray sensorHits;
 
 	// These bits align with the contact id capacity and signal a change in contact status
 	b2BitSet contactStateBitSet;

--- a/src/physics_world.h
+++ b/src/physics_world.h
@@ -23,6 +23,9 @@ enum b2SetType
 // Per thread task storage
 typedef struct b2TaskContext
 {
+	// Collect per thread sensor continuous hit events.
+	b2SensorContinuousHitArray sensorContinuousHits;
+
 	// These bits align with the contact id capacity and signal a change in contact status
 	b2BitSet contactStateBitSet;
 
@@ -105,7 +108,6 @@ typedef struct b2World
 	b2BodyMoveEventArray bodyMoveEvents;
 	b2SensorBeginTouchEventArray sensorBeginEvents;
 	b2ContactBeginTouchEventArray contactBeginEvents;
-	b2JointEventArray jointEvents;
 
 	// End events are double buffered so that the user doesn't need to flush events
 	b2SensorEndTouchEventArray sensorEndEvents[2];
@@ -113,6 +115,7 @@ typedef struct b2World
 	int endEventArrayIndex;
 
 	b2ContactHitEventArray contactHitEvents;
+	b2JointEventArray jointEvents;
 
 	// Used to track debug draw
 	b2BitSet debugBodySet;
@@ -136,7 +139,6 @@ typedef struct b2World
 	float hitEventThreshold;
 	float restitutionThreshold;
 	float maxLinearSpeed;
-	float maxContactPushSpeed;
 	float contactSpeed;
 	float contactHertz;
 	float contactDampingRatio;

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -114,6 +114,7 @@ static bool b2SensorQueryCallback( int proxyId, uint64_t userData, void* context
 	// Record the overlap
 	b2Sensor* sensor = queryContext->sensor;
 	b2ShapeRef* shapeRef = b2ShapeRefArray_Add( &sensor->overlaps2 );
+	shapeRef->transform = otherTransform;
 	shapeRef->shapeId = shapeId;
 	shapeRef->generation = otherShape->generation;
 
@@ -128,19 +129,6 @@ static int b2CompareShapeRefs( const void* a, const void* b )
 	if ( sa->shapeId < sb->shapeId )
 	{
 		return -1;
-	}
-
-	if ( sa->shapeId == sb->shapeId )
-	{
-		if ( sa->generation < sb->generation )
-		{
-			return -1;
-		}
-
-		if ( sa->generation == sb->generation )
-		{
-			return 0;
-		}
 	}
 
 	return 1;
@@ -216,8 +204,7 @@ static void b2SensorTask( int startIndex, int endIndex, uint32_t threadIndex, vo
 		b2ShapeRef* overlapData = sensor->overlaps2.data;
 		for ( int i = 0; i < overlapCount; ++i )
 		{
-			if ( uniqueCount == 0 || overlapData[i].shapeId != overlapData[uniqueCount - 1].shapeId ||
-				 overlapData[i].generation != overlapData[uniqueCount - 1].generation )
+			if ( uniqueCount == 0 || overlapData[i].shapeId != overlapData[uniqueCount - 1].shapeId )
 			{
 				overlapData[uniqueCount] = overlapData[i];
 				uniqueCount += 1;

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -10,11 +10,11 @@ typedef struct b2Shape b2Shape;
 typedef struct b2World b2World;
 
 // Used to track shapes that hit sensors using time of impact
-typedef struct b2SensorContinuousHit
+typedef struct b2SensorHit
 {
 	int sensorId;
 	int visitorId;
-} b2SensorContinuousHit;
+} b2SensorHit;
 
 typedef struct b2ShapeRef
 {
@@ -24,7 +24,7 @@ typedef struct b2ShapeRef
 
 typedef struct b2Sensor
 {
-	b2ShapeRefArray continuousHits;
+	b2ShapeRefArray hits;
 	b2ShapeRefArray overlaps1;
 	b2ShapeRefArray overlaps2;
 	int shapeId;
@@ -40,6 +40,6 @@ void b2OverlapSensors( b2World* world );
 void b2DestroySensor( b2World* world, b2Shape* sensorShape );
 
 B2_ARRAY_INLINE( b2Sensor, b2Sensor )
-B2_ARRAY_INLINE( b2SensorContinuousHit, b2SensorContinuousHit )
+B2_ARRAY_INLINE( b2SensorHit, b2SensorHit )
 B2_ARRAY_INLINE( b2SensorTaskContext, b2SensorTaskContext )
 B2_ARRAY_INLINE( b2ShapeRef, b2ShapeRef )

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -14,10 +14,12 @@ typedef struct b2SensorHit
 {
 	int sensorId;
 	int visitorId;
+	b2Transform visitorTransform;
 } b2SensorHit;
 
 typedef struct b2ShapeRef
 {
+	b2Transform transform;
 	int shapeId;
 	uint16_t generation;
 } b2ShapeRef;

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -9,6 +9,13 @@
 typedef struct b2Shape b2Shape;
 typedef struct b2World b2World;
 
+// Used to track shapes that hit sensors using time of impact
+typedef struct b2SensorContinuousHit
+{
+	int sensorId;
+	int visitorId;
+} b2SensorContinuousHit;
+
 typedef struct b2ShapeRef
 {
 	int shapeId;
@@ -17,6 +24,7 @@ typedef struct b2ShapeRef
 
 typedef struct b2Sensor
 {
+	b2ShapeRefArray continuousHits;
 	b2ShapeRefArray overlaps1;
 	b2ShapeRefArray overlaps2;
 	int shapeId;
@@ -31,6 +39,7 @@ void b2OverlapSensors( b2World* world );
 
 void b2DestroySensor( b2World* world, b2Shape* sensorShape );
 
-B2_ARRAY_INLINE( b2ShapeRef, b2ShapeRef )
 B2_ARRAY_INLINE( b2Sensor, b2Sensor )
+B2_ARRAY_INLINE( b2SensorContinuousHit, b2SensorContinuousHit )
 B2_ARRAY_INLINE( b2SensorTaskContext, b2SensorTaskContext )
+B2_ARRAY_INLINE( b2ShapeRef, b2ShapeRef )

--- a/src/shape.c
+++ b/src/shape.c
@@ -1662,7 +1662,7 @@ int b2Shape_GetSensorCapacity( b2ShapeId shapeId )
 	return sensor->overlaps2.count;
 }
 
-int b2Shape_GetSensorOverlaps( b2ShapeId shapeId, b2ShapeId* overlaps, int capacity )
+int b2Shape_GetSensorOverlaps( b2ShapeId shapeId, b2SensorData* sensorData, int capacity )
 {
 	b2World* world = b2GetWorldLocked( shapeId.world0 );
 	if ( world == NULL )
@@ -1682,10 +1682,15 @@ int b2Shape_GetSensorOverlaps( b2ShapeId shapeId, b2ShapeId* overlaps, int capac
 	b2ShapeRef* refs = sensor->overlaps2.data;
 	for ( int i = 0; i < count; ++i )
 	{
-		overlaps[i] = (b2ShapeId){
+		b2ShapeId visitorId = {
 			.index1 = refs[i].shapeId + 1,
 			.world0 = shapeId.world0,
 			.generation = refs[i].generation,
+		};
+
+		sensorData[i] = (b2SensorData){
+			.visitorId = visitorId,
+			.visitTransform = refs[i].transform,
 		};
 	}
 

--- a/src/shape.c
+++ b/src/shape.c
@@ -144,6 +144,7 @@ static b2Shape* b2CreateShapeInternal( b2World* world, b2Body* body, b2Transform
 	{
 		shape->sensorIndex = world->sensors.count;
 		b2Sensor sensor = {
+			.continuousHits = b2ShapeRefArray_Create( 4 ),
 			.overlaps1 = b2ShapeRefArray_Create( 16 ),
 			.overlaps2 = b2ShapeRefArray_Create( 16 ),
 			.shapeId = shapeId,
@@ -799,19 +800,19 @@ b2CastOutput b2RayCastShape( const b2RayCastInput* input, const b2Shape* shape, 
 	switch ( shape->type )
 	{
 		case b2_capsuleShape:
-			output = b2RayCastCapsule( &localInput, &shape->capsule );
+			output = b2RayCastCapsule( &shape->capsule, &localInput );
 			break;
 		case b2_circleShape:
-			output = b2RayCastCircle( &localInput, &shape->circle );
+			output = b2RayCastCircle( &shape->circle, &localInput );
 			break;
 		case b2_polygonShape:
-			output = b2RayCastPolygon( &localInput, &shape->polygon );
+			output = b2RayCastPolygon( &shape->polygon, &localInput );
 			break;
 		case b2_segmentShape:
-			output = b2RayCastSegment( &localInput, &shape->segment, false );
+			output = b2RayCastSegment( &shape->segment, &localInput, false );
 			break;
 		case b2_chainSegmentShape:
-			output = b2RayCastSegment( &localInput, &shape->chainSegment.segment, true );
+			output = b2RayCastSegment( &shape->chainSegment.segment, &localInput, true );
 			break;
 		default:
 			return output;
@@ -837,19 +838,19 @@ b2CastOutput b2ShapeCastShape( const b2ShapeCastInput* input, const b2Shape* sha
 	switch ( shape->type )
 	{
 		case b2_capsuleShape:
-			output = b2ShapeCastCapsule( &localInput, &shape->capsule );
+			output = b2ShapeCastCapsule( &shape->capsule, &localInput );
 			break;
 		case b2_circleShape:
-			output = b2ShapeCastCircle( &localInput, &shape->circle );
+			output = b2ShapeCastCircle( &shape->circle, &localInput );
 			break;
 		case b2_polygonShape:
-			output = b2ShapeCastPolygon( &localInput, &shape->polygon );
+			output = b2ShapeCastPolygon( &shape->polygon, &localInput );
 			break;
 		case b2_segmentShape:
-			output = b2ShapeCastSegment( &localInput, &shape->segment );
+			output = b2ShapeCastSegment( &shape->segment, &localInput );
 			break;
 		case b2_chainSegmentShape:
-			output = b2ShapeCastSegment( &localInput, &shape->chainSegment.segment );
+			output = b2ShapeCastSegment( &shape->chainSegment.segment, &localInput );
 			break;
 		default:
 			return output;
@@ -860,7 +861,7 @@ b2CastOutput b2ShapeCastShape( const b2ShapeCastInput* input, const b2Shape* sha
 	return output;
 }
 
-b2PlaneResult b2CollideMover( const b2Shape* shape, b2Transform transform, const b2Capsule* mover )
+b2PlaneResult b2CollideMover( const b2Capsule* mover, const b2Shape* shape, b2Transform transform )
 {
 	b2Capsule localMover;
 	localMover.center1 = b2InvTransformPoint( transform, mover->center1 );
@@ -871,19 +872,19 @@ b2PlaneResult b2CollideMover( const b2Shape* shape, b2Transform transform, const
 	switch ( shape->type )
 	{
 		case b2_capsuleShape:
-			result = b2CollideMoverAndCapsule( &shape->capsule, &localMover );
+			result = b2CollideMoverAndCapsule( &localMover, &shape->capsule );
 			break;
 		case b2_circleShape:
-			result = b2CollideMoverAndCircle( &shape->circle, &localMover );
+			result = b2CollideMoverAndCircle( &localMover, &shape->circle );
 			break;
 		case b2_polygonShape:
-			result = b2CollideMoverAndPolygon( &shape->polygon, &localMover );
+			result = b2CollideMoverAndPolygon( &localMover, &shape->polygon );
 			break;
 		case b2_segmentShape:
-			result = b2CollideMoverAndSegment( &shape->segment, &localMover );
+			result = b2CollideMoverAndSegment( &localMover, &shape->segment );
 			break;
 		case b2_chainSegmentShape:
-			result = b2CollideMoverAndSegment( &shape->chainSegment.segment, &localMover );
+			result = b2CollideMoverAndSegment( &localMover, &shape->chainSegment.segment );
 			break;
 		default:
 			return result;
@@ -987,13 +988,13 @@ bool b2Shape_TestPoint( b2ShapeId shapeId, b2Vec2 point )
 	switch ( shape->type )
 	{
 		case b2_capsuleShape:
-			return b2PointInCapsule( localPoint, &shape->capsule );
+			return b2PointInCapsule( &shape->capsule, localPoint );
 
 		case b2_circleShape:
-			return b2PointInCircle( localPoint, &shape->circle );
+			return b2PointInCircle( &shape->circle, localPoint );
 
 		case b2_polygonShape:
-			return b2PointInPolygon( localPoint, &shape->polygon );
+			return b2PointInPolygon( &shape->polygon, localPoint );
 
 		default:
 			return false;
@@ -1018,23 +1019,23 @@ b2CastOutput b2Shape_RayCast( b2ShapeId shapeId, const b2RayCastInput* input )
 	switch ( shape->type )
 	{
 		case b2_capsuleShape:
-			output = b2RayCastCapsule( &localInput, &shape->capsule );
+			output = b2RayCastCapsule( &shape->capsule, &localInput );
 			break;
 
 		case b2_circleShape:
-			output = b2RayCastCircle( &localInput, &shape->circle );
+			output = b2RayCastCircle( &shape->circle, &localInput );
 			break;
 
 		case b2_segmentShape:
-			output = b2RayCastSegment( &localInput, &shape->segment, false );
+			output = b2RayCastSegment( &shape->segment, &localInput, false );
 			break;
 
 		case b2_polygonShape:
-			output = b2RayCastPolygon( &localInput, &shape->polygon );
+			output = b2RayCastPolygon( &shape->polygon, &localInput );
 			break;
 
 		case b2_chainSegmentShape:
-			output = b2RayCastSegment( &localInput, &shape->chainSegment.segment, true );
+			output = b2RayCastSegment( &shape->chainSegment.segment, &localInput, true );
 			break;
 
 		default:
@@ -1626,6 +1627,7 @@ int b2Shape_GetContactData( b2ShapeId shapeId, b2ContactData* contactData, int c
 			b2Shape* shapeA = world->shapes.data + contact->shapeIdA;
 			b2Shape* shapeB = world->shapes.data + contact->shapeIdB;
 
+			contactData[index].contactId = (b2ContactId){ contact->contactId + 1, shapeId.world0, 0, contact->generation };
 			contactData[index].shapeIdA = (b2ShapeId){ shapeA->id + 1, shapeId.world0, shapeA->generation };
 			contactData[index].shapeIdB = (b2ShapeId){ shapeB->id + 1, shapeId.world0, shapeB->generation };
 
@@ -1702,7 +1704,7 @@ b2AABB b2Shape_GetAABB( b2ShapeId shapeId )
 	return shape->aabb;
 }
 
-b2MassData b2Shape_GetMassData( b2ShapeId shapeId )
+b2MassData b2Shape_ComputeMassData( b2ShapeId shapeId )
 {
 	b2World* world = b2GetWorld( shapeId.world0 );
 	if ( world == NULL )

--- a/src/shape.c
+++ b/src/shape.c
@@ -296,6 +296,7 @@ static void b2DestroyShapeInternal( b2World* world, b2Shape* shape, b2Body* body
 		}
 
 		// Destroy sensor
+		b2ShapeRefArray_Destroy( &sensor->hits );
 		b2ShapeRefArray_Destroy( &sensor->overlaps1 );
 		b2ShapeRefArray_Destroy( &sensor->overlaps2 );
 
@@ -1662,7 +1663,7 @@ int b2Shape_GetSensorCapacity( b2ShapeId shapeId )
 	return sensor->overlaps2.count;
 }
 
-int b2Shape_GetSensorOverlaps( b2ShapeId shapeId, b2SensorData* sensorData, int capacity )
+int b2Shape_GetSensorData( b2ShapeId shapeId, b2SensorData* sensorData, int capacity )
 {
 	b2World* world = b2GetWorldLocked( shapeId.world0 );
 	if ( world == NULL )

--- a/src/shape.c
+++ b/src/shape.c
@@ -144,7 +144,7 @@ static b2Shape* b2CreateShapeInternal( b2World* world, b2Body* body, b2Transform
 	{
 		shape->sensorIndex = world->sensors.count;
 		b2Sensor sensor = {
-			.continuousHits = b2ShapeRefArray_Create( 4 ),
+			.hits = b2ShapeRefArray_Create( 4 ),
 			.overlaps1 = b2ShapeRefArray_Create( 16 ),
 			.overlaps2 = b2ShapeRefArray_Create( 16 ),
 			.shapeId = shapeId,

--- a/src/shape.h
+++ b/src/shape.h
@@ -98,11 +98,11 @@ b2ShapeProxy b2MakeShapeDistanceProxy( const b2Shape* shape );
 b2CastOutput b2RayCastShape( const b2RayCastInput* input, const b2Shape* shape, b2Transform transform );
 b2CastOutput b2ShapeCastShape( const b2ShapeCastInput* input, const b2Shape* shape, b2Transform transform );
 
-b2PlaneResult b2CollideMoverAndCircle( const b2Circle* shape, const b2Capsule* mover );
-b2PlaneResult b2CollideMoverAndCapsule( const b2Capsule* shape, const b2Capsule* mover );
-b2PlaneResult b2CollideMoverAndPolygon( const b2Polygon* shape, const b2Capsule* mover );
-b2PlaneResult b2CollideMoverAndSegment( const b2Segment* shape, const b2Capsule* mover );
-b2PlaneResult b2CollideMover( const b2Shape* shape, b2Transform transform, const b2Capsule* mover );
+b2PlaneResult b2CollideMoverAndCircle( const b2Capsule* mover, const b2Circle* shape );
+b2PlaneResult b2CollideMoverAndCapsule( const b2Capsule* mover, const b2Capsule* shape );
+b2PlaneResult b2CollideMoverAndPolygon( const b2Capsule* mover, const b2Polygon* shape );
+b2PlaneResult b2CollideMoverAndSegment( const b2Capsule* mover, const b2Segment* shape );
+b2PlaneResult b2CollideMover( const b2Capsule* mover, const b2Shape* shape, b2Transform transform );
 
 static inline float b2GetShapeRadius( const b2Shape* shape )
 {

--- a/src/solver.c
+++ b/src/solver.c
@@ -410,17 +410,9 @@ static bool b2ContinuousQueryCallback( int proxyId, uint64_t userData, void* con
 
 	if ( didHit && ( shape->enablePreSolveEvents || fastShape->enablePreSolveEvents ) && world->preSolveFcn != NULL )
 	{
-		// Pre-solve is expensive because I need to compute a temporary manifold
-		b2Transform transformA = b2GetSweepTransform( &input.sweepA, hitFraction );
-		b2Transform transformB = b2GetSweepTransform( &input.sweepB, hitFraction );
-		b2Manifold manifold = b2ComputeManifold( shape, transformA, fastShape, transformB );
 		b2ShapeId shapeIdA = { shape->id + 1, world->worldId, shape->generation };
 		b2ShapeId shapeIdB = { fastShape->id + 1, world->worldId, fastShape->generation };
-
-		// The user may need the manifold geometry to judge whether this TOI should skip.
-		// The user may modify the temporary manifold here but it doesn't matter. They will be able to
-		// modify the real manifold in the discrete solver.
-		didHit = world->preSolveFcn( shapeIdA, shapeIdB, &manifold, world->preSolveContext );
+		didHit = world->preSolveFcn( shapeIdA, shapeIdB, output.point, output.normal, world->preSolveContext );
 	}
 
 	if ( didHit )

--- a/src/types.c
+++ b/src/types.c
@@ -13,7 +13,7 @@ b2WorldDef b2DefaultWorldDef( void )
 	def.gravity.y = -10.0f;
 	def.hitEventThreshold = 1.0f * b2_lengthUnitsPerMeter;
 	def.restitutionThreshold = 1.0f * b2_lengthUnitsPerMeter;
-	def.maxContactPushSpeed = 3.0f * b2_lengthUnitsPerMeter;
+	def.contactSpeed = 3.0f * b2_lengthUnitsPerMeter;
 	def.contactHertz = 30.0;
 	def.contactDampingRatio = 10.0f;
 

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -17,8 +17,8 @@
 #define TracyCFrameMark
 #endif
 
-#define EXPECTED_SLEEP_STEP 342
-#define EXPECTED_HASH 0xd8d6b53a
+#define EXPECTED_SLEEP_STEP 244
+#define EXPECTED_HASH 0xfcb96059
 
 enum
 {

--- a/test/test_shape.c
+++ b/test/test_shape.c
@@ -108,17 +108,17 @@ static int PointInShapeTest( void )
 
 	{
 		bool hit;
-		hit = b2PointInCircle( p1, &circle );
+		hit = b2PointInCircle(&circle,  p1 );
 		ENSURE( hit == true );
-		hit = b2PointInCircle( p2, &circle );
+		hit = b2PointInCircle( &circle, p2 );
 		ENSURE( hit == false );
 	}
 
 	{
 		bool hit;
-		hit = b2PointInPolygon( p1, &box );
+		hit = b2PointInPolygon( &box,  p1);
 		ENSURE( hit == true );
-		hit = b2PointInPolygon( p2, &box );
+		hit = b2PointInPolygon(&box,  p2);
 		ENSURE( hit == false );
 	}
 
@@ -130,7 +130,7 @@ static int RayCastShapeTest( void )
 	b2RayCastInput input = { { -4.0f, 0.0f }, { 8.0f, 0.0f }, 1.0f };
 
 	{
-		b2CastOutput output = b2RayCastCircle( &input, &circle );
+		b2CastOutput output = b2RayCastCircle( &circle, & input );
 		ENSURE( output.hit );
 		ENSURE_SMALL( output.normal.x + 1.0f, FLT_EPSILON );
 		ENSURE_SMALL( output.normal.y, FLT_EPSILON );
@@ -138,7 +138,7 @@ static int RayCastShapeTest( void )
 	}
 
 	{
-		b2CastOutput output = b2RayCastPolygon( &input, &box );
+		b2CastOutput output = b2RayCastPolygon( &box, & input);
 		ENSURE( output.hit );
 		ENSURE_SMALL( output.normal.x + 1.0f, FLT_EPSILON );
 		ENSURE_SMALL( output.normal.y, FLT_EPSILON );
@@ -146,7 +146,7 @@ static int RayCastShapeTest( void )
 	}
 
 	{
-		b2CastOutput output = b2RayCastSegment( &input, &segment, true );
+		b2CastOutput output = b2RayCastSegment( &segment, &input, true );
 		ENSURE( output.hit );
 		ENSURE_SMALL( output.normal.x + 1.0f, FLT_EPSILON );
 		ENSURE_SMALL( output.normal.y, FLT_EPSILON );

--- a/test/test_world.c
+++ b/test/test_world.c
@@ -252,11 +252,12 @@ static bool CustomFilter( b2ShapeId shapeIdA, b2ShapeId shapeIdB, void* context 
 	return true;
 }
 
-static bool PreSolveStatic( b2ShapeId shapeIdA, b2ShapeId shapeIdB, b2Manifold* manifold, void* context )
+static bool PreSolveStatic( b2ShapeId shapeIdA, b2ShapeId shapeIdB, b2Vec2 point, b2Vec2 normal, void* context )
 {
 	(void)shapeIdA;
 	(void)shapeIdB;
-	(void)manifold;
+	(void)point;
+	(void)normal;
 	ENSURE( context == NULL );
 	return false;
 }


### PR DESCRIPTION
Sensor hits for shapes that move fast over sensors.
`b2SensorData` that has the visitor shape id and the captured visitor body transform.
Bug fix: sensors were not using the custom filter.
Time of impact now returns the point and normal.
`b2PreSolveFcn` now returns a contact point and normal instead of the manifold. This change was made to support more efficient continuous collision and for consistency. Pre-solve is called in continuous and discrete collision, but continuous collision no longer uses manifolds.
Contact push speed is now independent of contact hertz and damping ratio.
Bumped version to 3.2.0 (work in progress).

Renamed: `b2Shape_GetMassData` to `b2Shape_ComputeMassData`
Removed: `b2Contact_GetManifold`  and `b2Contact_GetShapeIds`
Added: `b2Contact_GetData`
Changed function order on some collision functions to assist editor auto-complete
`id.h` is now stand-alone
Renamed: `b2WorldDef::maxContactPushSpeed` to `contactSpeed`
Added: `b2BodyDef::enableSensorHits`
Added: `b2JointDef::constraintHertz` and `b2JointDef::constraintDampingRatio`
Renamed: `b2JointDef::drawSize` to `b2JointDef::drawScale`
Removed: `b2ContactBeginTouchEvent::manifold`
Added: `b2ContactData::contactId`
Modified: `b2PreSolveFcn` receives a point and normal instead of a manifold
