### PR TITLE
Sensor clean up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ message(STATUS "CMake C++ compiler: ${CMAKE_CXX_COMPILER_ID}")
 message(STATUS "CMake system name: ${CMAKE_SYSTEM_NAME}")
 message(STATUS "CMake host system processor: ${CMAKE_HOST_SYSTEM_PROCESSOR}")
 
+# static link to make leak checking easier (_crtBreakAlloc)
+# set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
 if (MSVC OR APPLE)
 	option(BOX2D_SANITIZE "Enable sanitizers for some builds" OFF)
 	if(BOX2D_SANITIZE)

--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -787,14 +787,27 @@ B2_API float b2Joint_GetLinearSeparation( b2JointId jointId );
 /// Get the current angular separation error for this joint. Does not consider admissible movement. Usually in meters.
 B2_API float b2Joint_GetAngularSeparation( b2JointId jointId );
 
-/// Get the joint constraint tuning. Advanced feature.
-B2_API void b2Joint_GetConstraintTuning( b2JointId jointId, float* hertz, float* dampingRatio );
-
 /// Set the joint constraint tuning. Advanced feature.
 /// @param jointId the joint
 /// @param hertz the stiffness in Hertz (cycles per second)
 /// @param dampingRatio the non-dimensional damping ratio (one for critical damping)
 B2_API void b2Joint_SetConstraintTuning( b2JointId jointId, float hertz, float dampingRatio );
+
+/// Get the joint constraint tuning. Advanced feature.
+B2_API void b2Joint_GetConstraintTuning( b2JointId jointId, float* hertz, float* dampingRatio );
+
+/// Set the force threshold for joint events (Newtons)
+B2_API void b2Joint_SetForceThreshold( b2JointId jointId, float threshold );
+
+/// Get the force threshold for joint events (Newtons)
+B2_API float b2Joint_GetForceThreshold( b2JointId jointId );
+
+/// Set the torque threshold for joint events (N-m)
+B2_API void b2Joint_SetTorqueThreshold( b2JointId jointId, float threshold );
+
+/// Get the torque threshold for joint events (N-m)
+B2_API float b2Joint_GetTorqueThreshold( b2JointId jointId );
+
 
 /**
  * @defgroup distance_joint Distance Joint

--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -337,8 +337,8 @@ B2_API void b2Body_ApplyLinearImpulseToCenter( b2BodyId bodyId, b2Vec2 impulse, 
 /// @param bodyId The body id
 /// @param impulse the angular impulse, usually in units of kg*m*m/s
 /// @param wake also wake up the body
-/// @warning This should be used for one-shot impulses. If you need a steady force,
-/// use a force instead, which will work better with the sub-stepping solver.
+/// @warning This should be used for one-shot impulses. If you need a steady torque,
+/// use a torque instead, which will work better with the sub-stepping solver.
 B2_API void b2Body_ApplyAngularImpulse( b2BodyId bodyId, float impulse, bool wake );
 
 /// Get the mass of the body, usually in kilograms

--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -417,10 +417,10 @@ B2_API void b2Body_Disable( b2BodyId bodyId );
 /// Enable a body by adding it to the simulation. This is expensive.
 B2_API void b2Body_Enable( b2BodyId bodyId );
 
-/// Set this body to have fixed rotation. This causes the mass to be reset in all cases.
+/// Set the motion locks on this body.
 B2_API void b2Body_SetMotionLocks( b2BodyId bodyId, b2MotionLocks locks );
 
-/// Does this body have fixed rotation?
+/// Get the motion locks for this body.
 B2_API b2MotionLocks b2Body_GetMotionLocks( b2BodyId bodyId );
 
 /// Set this body to be a bullet. A bullet does continuous collision detection

--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -662,12 +662,12 @@ B2_API int b2Shape_GetSensorCapacity( b2ShapeId shapeId );
 
 /// Get the overlap data for a sensor shape.
 /// @param shapeId the id of a sensor shape
-/// @param sensorData a user allocated array that is filled with the overlapping shapes (visitors)
+/// @param visitorIds a user allocated array that is filled with the overlapping shapes (visitors)
 /// @param capacity the capacity of overlappedShapes
 /// @returns the number of elements filled in the provided array
 /// @warning do not ignore the return value, it specifies the valid number of elements
 /// @warning overlaps may contain destroyed shapes so use b2Shape_IsValid to confirm each overlap
-B2_API int b2Shape_GetSensorData( b2ShapeId shapeId, b2SensorData* sensorData, int capacity );
+B2_API int b2Shape_GetSensorData( b2ShapeId shapeId, b2ShapeId* visitorIds, int capacity );
 
 /// Get the current world AABB
 B2_API b2AABB b2Shape_GetAABB( b2ShapeId shapeId );

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -241,12 +241,6 @@ typedef struct b2BodyDef
 	/// continuous collision.
 	bool isBullet;
 
-	/// Option to perform continuous collision checks with sensors. This only applies to dynamic bodies.
-	/// This is expensive and should be used sparingly. You still need to enable sensor events on the child shapes
-	/// for this to work. This only works if the body is awake. This will use a time of impact calculation to
-	/// generate sensor begin touch events, but not end events. End events are handled using regular overlap checks.
-	bool enableSensorHits;
-
 	/// Used to disable a body. A disabled body does not move or collide.
 	bool isEnabled;
 
@@ -1095,20 +1089,6 @@ typedef struct b2JointEvents
 	/// Number of events
 	int count;
 } b2JointEvents;
-
-/// The contact data for two shapes. By convention the manifold normal points
-/// from shape A to shape B.
-/// @see b2Shape_GetContactData() and b2Body_GetContactData()
-typedef struct b2SensorData
-{
-	/// The visiting shape
-	b2ShapeId visitorId;
-
-	/// The transform of the body of the visiting shape. This is normally
-	/// the current transform of the body. However, for a sensor hit, this is
-	/// the transform of the visiting body when it hit.
-	b2Transform visitTransform;
-} b2SensorData;
 
 /// The contact data for two shapes. By convention the manifold normal points
 /// from shape A to shape B.

--- a/samples/sample_joints.cpp
+++ b/samples/sample_joints.cpp
@@ -1388,37 +1388,16 @@ public:
 		}
 
 		b2BodyDef bodyDef = b2DefaultBodyDef();
-		m_groundId = b2CreateBody( m_worldId, &bodyDef );
+		b2BodyId groundId = b2CreateBody( m_worldId, &bodyDef );
+
 		m_motionLocks = { false, false, true };
 
 		for ( int i = 0; i < e_count; ++i )
 		{
 			m_bodyIds[i] = b2_nullBodyId;
-			m_jointIds[i] = b2_nullJointId;
-		}
-
-		CreateScene();
-	}
-
-	void CreateScene()
-	{
-		for ( int i = 0; i < e_count; ++i )
-		{
-			if ( B2_IS_NON_NULL( m_jointIds[i] ) )
-			{
-				b2DestroyJoint( m_jointIds[i] );
-				m_jointIds[i] = b2_nullJointId;
-			}
-
-			if ( B2_IS_NON_NULL( m_bodyIds[i] ) )
-			{
-				b2DestroyBody( m_bodyIds[i] );
-				m_bodyIds[i] = b2_nullBodyId;
-			}
 		}
 
 		b2Vec2 position = { -12.5f, 10.0f };
-		b2BodyDef bodyDef = b2DefaultBodyDef();
 		bodyDef.type = b2_dynamicBody;
 		bodyDef.motionLocks = m_motionLocks;
 
@@ -1439,12 +1418,12 @@ public:
 			b2Vec2 pivot1 = { position.x, position.y + 1.0f + length };
 			b2Vec2 pivot2 = { position.x, position.y + 1.0f };
 			b2DistanceJointDef jointDef = b2DefaultDistanceJointDef();
-			jointDef.base.bodyIdA = m_groundId;
+			jointDef.base.bodyIdA = groundId;
 			jointDef.base.bodyIdB = m_bodyIds[index];
 			jointDef.base.localFrameA.p = b2Body_GetLocalPoint( jointDef.base.bodyIdA, pivot1 );
 			jointDef.base.localFrameB.p = b2Body_GetLocalPoint( jointDef.base.bodyIdB, pivot2 );
 			jointDef.length = length;
-			m_jointIds[index] = b2CreateDistanceJoint( m_worldId, &jointDef );
+			b2CreateDistanceJoint( m_worldId, &jointDef );
 		}
 
 		position.x += 5.0f;
@@ -1460,12 +1439,12 @@ public:
 			b2CreatePolygonShape( m_bodyIds[index], &shapeDef, &box );
 
 			b2MotorJointDef jointDef = b2DefaultMotorJointDef();
-			jointDef.base.bodyIdA = m_groundId;
+			jointDef.base.bodyIdA = groundId;
 			jointDef.base.bodyIdB = m_bodyIds[index];
 			jointDef.base.localFrameA.p = position;
 			jointDef.maxForce = 200.0f;
 			jointDef.maxTorque = 200.0f;
-			m_jointIds[index] = b2CreateMotorJoint( m_worldId, &jointDef );
+			b2CreateMotorJoint( m_worldId, &jointDef );
 		}
 
 		position.x += 5.0f;
@@ -1482,11 +1461,11 @@ public:
 
 			b2Vec2 pivot = { position.x - 1.0f, position.y };
 			b2PrismaticJointDef jointDef = b2DefaultPrismaticJointDef();
-			jointDef.base.bodyIdA = m_groundId;
+			jointDef.base.bodyIdA = groundId;
 			jointDef.base.bodyIdB = m_bodyIds[index];
 			jointDef.base.localFrameA.p = b2Body_GetLocalPoint( jointDef.base.bodyIdA, pivot );
 			jointDef.base.localFrameB.p = b2Body_GetLocalPoint( jointDef.base.bodyIdB, pivot );
-			m_jointIds[index] = b2CreatePrismaticJoint( m_worldId, &jointDef );
+			b2CreatePrismaticJoint( m_worldId, &jointDef );
 		}
 
 		position.x += 5.0f;
@@ -1503,11 +1482,11 @@ public:
 
 			b2Vec2 pivot = { position.x - 1.0f, position.y };
 			b2RevoluteJointDef jointDef = b2DefaultRevoluteJointDef();
-			jointDef.base.bodyIdA = m_groundId;
+			jointDef.base.bodyIdA = groundId;
 			jointDef.base.bodyIdB = m_bodyIds[index];
 			jointDef.base.localFrameA.p = b2Body_GetLocalPoint( jointDef.base.bodyIdA, pivot );
 			jointDef.base.localFrameB.p = b2Body_GetLocalPoint( jointDef.base.bodyIdB, pivot );
-			m_jointIds[index] = b2CreateRevoluteJoint( m_worldId, &jointDef );
+			b2CreateRevoluteJoint( m_worldId, &jointDef );
 		}
 
 		position.x += 5.0f;
@@ -1524,7 +1503,7 @@ public:
 
 			b2Vec2 pivot = { position.x - 1.0f, position.y };
 			b2WeldJointDef jointDef = b2DefaultWeldJointDef();
-			jointDef.base.bodyIdA = m_groundId;
+			jointDef.base.bodyIdA = groundId;
 			jointDef.base.bodyIdB = m_bodyIds[index];
 			jointDef.base.localFrameA.p = b2Body_GetLocalPoint( jointDef.base.bodyIdA, pivot );
 			jointDef.base.localFrameB.p = b2Body_GetLocalPoint( jointDef.base.bodyIdB, pivot );
@@ -1532,7 +1511,7 @@ public:
 			jointDef.angularDampingRatio = 0.5f;
 			jointDef.linearHertz = 1.0f;
 			jointDef.linearDampingRatio = 0.5f;
-			m_jointIds[index] = b2CreateWeldJoint( m_worldId, &jointDef );
+			b2CreateWeldJoint( m_worldId, &jointDef );
 		}
 
 		position.x += 5.0f;
@@ -1549,7 +1528,7 @@ public:
 
 			b2Vec2 pivot = { position.x - 1.0f, position.y };
 			b2WheelJointDef jointDef = b2DefaultWheelJointDef();
-			jointDef.base.bodyIdA = m_groundId;
+			jointDef.base.bodyIdA = groundId;
 			jointDef.base.bodyIdB = m_bodyIds[index];
 			jointDef.base.localFrameA.p = b2Body_GetLocalPoint( jointDef.base.bodyIdA, pivot );
 			jointDef.base.localFrameB.p = b2Body_GetLocalPoint( jointDef.base.bodyIdB, pivot );
@@ -1561,7 +1540,7 @@ public:
 			jointDef.enableMotor = true;
 			jointDef.maxMotorTorque = 10.0f;
 			jointDef.motorSpeed = 1.0f;
-			m_jointIds[index] = b2CreateWheelJoint( m_worldId, &jointDef );
+			b2CreateWheelJoint( m_worldId, &jointDef );
 		}
 
 		position.x += 5.0f;
@@ -1573,7 +1552,7 @@ public:
 		float fontSize = ImGui::GetFontSize();
 		float height = 8.0f * fontSize;
 		ImGui::SetNextWindowPos( ImVec2( 0.5f * fontSize, m_camera->m_height - height - 2.0f * fontSize ), ImGuiCond_Once );
-		ImGui::SetNextWindowSize( ImVec2( 180.0f, height ) );
+		ImGui::SetNextWindowSize( ImVec2( 14.0f * fontSize, height ) );
 
 		ImGui::Begin( "Motion Locks", nullptr, ImGuiWindowFlags_NoResize );
 
@@ -1617,9 +1596,7 @@ public:
 		return new MotionLocks( context );
 	}
 
-	b2BodyId m_groundId;
 	b2BodyId m_bodyIds[e_count];
-	b2JointId m_jointIds[e_count];
 	b2MotionLocks m_motionLocks;
 };
 

--- a/src/array.h
+++ b/src/array.h
@@ -185,7 +185,7 @@ B2_ARRAY_DECLARE( b2SensorBeginTouchEvent, b2SensorBeginTouchEvent );
 B2_ARRAY_DECLARE( b2SensorEndTouchEvent, b2SensorEndTouchEvent );
 B2_ARRAY_DECLARE( b2SensorTaskContext, b2SensorTaskContext );
 B2_ARRAY_DECLARE( b2Shape, b2Shape );
-B2_ARRAY_DECLARE( b2ShapeRef, b2ShapeRef );
+B2_ARRAY_DECLARE( b2Visitor, b2Visitor );
 B2_ARRAY_DECLARE( b2SolverSet, b2SolverSet );
 B2_ARRAY_DECLARE( b2TaskContext, b2TaskContext );
 B2_ARRAY_DECLARE( b2SensorHit, b2SensorHit );

--- a/src/body.c
+++ b/src/body.c
@@ -253,7 +253,6 @@ b2BodyId b2CreateBody( b2WorldId worldId, const b2BodyDef* def )
 	bodySim->bodyId = bodyId;
 	bodySim->flags = lockFlags;
 	bodySim->flags |= def->isBullet ? b2_isBullet : 0;
-	bodySim->flags |= def->enableSensorHits ? b2_enableSensorHits : 0;
 	bodySim->flags |= def->allowFastRotation ? b2_allowFastRotation : 0;
 
 	if ( setId == b2_awakeSet )

--- a/src/body.h
+++ b/src/body.h
@@ -12,14 +12,14 @@ typedef struct b2World b2World;
 
 enum b2BodyFlags
 {
-	// This body has fixed rotation
-	b2_lockAngularZ = 0x00000001,
-
 	// This body has fixed translation along the x-axis
-	b2_lockLinearX = 0x00000002,
+	b2_lockLinearX = 0x00000001,
 
 	// This body has fixed translation along the y-axis
-	b2_lockLinearY = 0x00000004,
+	b2_lockLinearY = 0x00000002,
+
+	// This body has fixed rotation
+	b2_lockAngularZ = 0x00000004,
 
 	// This flag is used for debug draw
 	b2_isFast = 0x00000008,
@@ -92,14 +92,16 @@ typedef struct b2Body
 
 	int id;
 
+	// b2BodyFlags
+	uint32_t flags;
+
 	b2BodyType type;
 
 	// This is monotonically advanced when a body is allocated in this slot
 	// Used to check for invalid b2BodyId
 	uint16_t generation;
 
-	uint32_t flags;
-
+	// todo move into flags
 	bool enableSleep;
 	bool isSpeedCapped;
 	bool isMarked;
@@ -136,7 +138,9 @@ typedef struct b2BodyState
 {
 	b2Vec2 linearVelocity; // 8
 	float angularVelocity; // 4
-	int flags;			   // 4
+
+	// b2BodyFlags
+	uint32_t flags; // 4
 
 	// Using delta position reduces round-off error far from the origin
 	b2Vec2 deltaPosition; // 8
@@ -179,9 +183,10 @@ typedef struct b2BodySim
 	float angularDamping;
 	float gravityScale;
 
-	// body data can be moved around, the id is stable (used in b2BodyId)
+	// Index of b2Body
 	int bodyId;
 
+	// b2BodyFlags
 	uint32_t flags;
 } b2BodySim;
 

--- a/src/body.h
+++ b/src/body.h
@@ -27,17 +27,14 @@ enum b2BodyFlags
 	// This dynamic body does a final CCD pass against all body types, but not other bullets
 	b2_isBullet = 0x00000010,
 
-	// This body does a CCD pass against sensors
-	b2_enableSensorHits = 0x00000020,
-
 	// This body has hit the maximum linear or angular velocity
-	b2_isSpeedCapped = 0x00000040,
+	b2_isSpeedCapped = 0x00000020,
 
 	// This body has no limit on angular velocity
-	b2_allowFastRotation = 0x00000080,
+	b2_allowFastRotation = 0x00000040,
 
 	// This body need's to have its AABB increased
-	b2_enlargeBounds = 0x00000100,
+	b2_enlargeBounds = 0x00000080,
 
 	// All lock flags
 	b2_allLocks = b2_lockAngularZ | b2_lockLinearX | b2_lockLinearY,

--- a/src/joint.c
+++ b/src/joint.c
@@ -1260,15 +1260,6 @@ float b2Joint_GetAngularSeparation( b2JointId jointId )
 	}
 }
 
-void b2Joint_GetConstraintTuning( b2JointId jointId, float* hertz, float* dampingRatio )
-{
-	b2World* world = b2GetWorld( jointId.world0 );
-	b2Joint* joint = b2GetJointFullId( world, jointId );
-	b2JointSim* base = b2GetJointSim( world, joint );
-	*hertz = base->constraintHertz;
-	*dampingRatio = base->constraintDampingRatio;
-}
-
 void b2Joint_SetConstraintTuning( b2JointId jointId, float hertz, float dampingRatio )
 {
 	B2_ASSERT( b2IsValidFloat( hertz ) && hertz >= 0.0f );
@@ -1279,6 +1270,51 @@ void b2Joint_SetConstraintTuning( b2JointId jointId, float hertz, float dampingR
 	b2JointSim* base = b2GetJointSim( world, joint );
 	base->constraintHertz = hertz;
 	base->constraintDampingRatio = dampingRatio;
+}
+
+void b2Joint_GetConstraintTuning( b2JointId jointId, float* hertz, float* dampingRatio )
+{
+	b2World* world = b2GetWorld( jointId.world0 );
+	b2Joint* joint = b2GetJointFullId( world, jointId );
+	b2JointSim* base = b2GetJointSim( world, joint );
+	*hertz = base->constraintHertz;
+	*dampingRatio = base->constraintDampingRatio;
+}
+
+void b2Joint_SetForceThreshold( b2JointId jointId, float threshold )
+{
+	B2_ASSERT( b2IsValidFloat( threshold ) && threshold >= 0.0f );
+
+	b2World* world = b2GetWorld( jointId.world0 );
+	b2Joint* joint = b2GetJointFullId( world, jointId );
+	b2JointSim* base = b2GetJointSim( world, joint );
+	base->forceThreshold = threshold;
+}
+
+float b2Joint_GetForceThreshold( b2JointId jointId )
+{
+	b2World* world = b2GetWorld( jointId.world0 );
+	b2Joint* joint = b2GetJointFullId( world, jointId );
+	b2JointSim* base = b2GetJointSim( world, joint );
+	return base->forceThreshold;
+}
+
+void b2Joint_SetTorqueThreshold( b2JointId jointId, float threshold )
+{
+	B2_ASSERT( b2IsValidFloat( threshold ) && threshold >= 0.0f );
+
+	b2World* world = b2GetWorld( jointId.world0 );
+	b2Joint* joint = b2GetJointFullId( world, jointId );
+	b2JointSim* base = b2GetJointSim( world, joint );
+	base->torqueThreshold = threshold;
+}
+
+float b2Joint_GetTorqueThreshold( b2JointId jointId )
+{
+	b2World* world = b2GetWorld( jointId.world0 );
+	b2Joint* joint = b2GetJointFullId( world, jointId );
+	b2JointSim* base = b2GetJointSim( world, joint );
+	return base->torqueThreshold;
 }
 
 void b2PrepareJoint( b2JointSim* joint, b2StepContext* context )

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -314,9 +314,9 @@ void b2DestroyWorld( b2WorldId worldId )
 	int sensorCount = world->sensors.count;
 	for ( int i = 0; i < sensorCount; ++i )
 	{
-		b2ShapeRefArray_Destroy( &world->sensors.data[i].hits );
-		b2ShapeRefArray_Destroy( &world->sensors.data[i].overlaps1 );
-		b2ShapeRefArray_Destroy( &world->sensors.data[i].overlaps2 );
+		b2VisitorArray_Destroy( &world->sensors.data[i].hits );
+		b2VisitorArray_Destroy( &world->sensors.data[i].overlaps1 );
+		b2VisitorArray_Destroy( &world->sensors.data[i].overlaps2 );
 	}
 
 	b2SensorArray_Destroy( &world->sensors );

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -120,7 +120,7 @@ static bool b2SensorQueryCallback( int proxyId, uint64_t userData, void* context
 	return true;
 }
 
-static int b2CompareShapeRefs( const void* a, const void* b )
+static int b2CompareVisitors( const void* a, const void* b )
 {
 	const b2Visitor* sa = a;
 	const b2Visitor* sb = b;
@@ -195,7 +195,7 @@ static void b2SensorTask( int startIndex, int endIndex, uint32_t threadIndex, vo
 		b2DynamicTree_Query( trees + 2, queryBounds, sensorShape->filter.maskBits, b2SensorQueryCallback, &queryContext );
 
 		// Sort the overlaps to enable finding begin and end events.
-		qsort( sensor->overlaps2.data, sensor->overlaps2.count, sizeof( b2Visitor ), b2CompareShapeRefs );
+		qsort( sensor->overlaps2.data, sensor->overlaps2.count, sizeof( b2Visitor ), b2CompareVisitors );
 
 		// Remove duplicates from overlaps2 (sorted). Duplicates are possible due to the hit events appended earlier.
 		int uniqueCount = 0;

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -402,6 +402,7 @@ void b2DestroySensor( b2World* world, b2Shape* sensorShape )
 	}
 
 	// Destroy sensor
+	b2ShapeRefArray_Destroy( &sensor->hits );
 	b2ShapeRefArray_Destroy( &sensor->overlaps1 );
 	b2ShapeRefArray_Destroy( &sensor->overlaps2 );
 

--- a/src/sensor.c
+++ b/src/sensor.c
@@ -15,7 +15,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 
-B2_ARRAY_SOURCE( b2ShapeRef, b2ShapeRef )
+B2_ARRAY_SOURCE( b2Visitor, b2Visitor )
 B2_ARRAY_SOURCE( b2Sensor, b2Sensor )
 B2_ARRAY_SOURCE( b2SensorTaskContext, b2SensorTaskContext )
 B2_ARRAY_SOURCE( b2SensorHit, b2SensorHit )
@@ -113,8 +113,7 @@ static bool b2SensorQueryCallback( int proxyId, uint64_t userData, void* context
 
 	// Record the overlap
 	b2Sensor* sensor = queryContext->sensor;
-	b2ShapeRef* shapeRef = b2ShapeRefArray_Add( &sensor->overlaps2 );
-	shapeRef->transform = otherTransform;
+	b2Visitor* shapeRef = b2VisitorArray_Add( &sensor->overlaps2 );
 	shapeRef->shapeId = shapeId;
 	shapeRef->generation = otherShape->generation;
 
@@ -123,8 +122,8 @@ static bool b2SensorQueryCallback( int proxyId, uint64_t userData, void* context
 
 static int b2CompareShapeRefs( const void* a, const void* b )
 {
-	const b2ShapeRef* sa = a;
-	const b2ShapeRef* sb = b;
+	const b2Visitor* sa = a;
+	const b2Visitor* sb = b;
 
 	if ( sa->shapeId < sb->shapeId )
 	{
@@ -151,20 +150,20 @@ static void b2SensorTask( int startIndex, int endIndex, uint32_t threadIndex, vo
 		b2Shape* sensorShape = b2ShapeArray_Get( &world->shapes, sensor->shapeId );
 
 		// Swap overlap arrays
-		b2ShapeRefArray temp = sensor->overlaps1;
+		b2VisitorArray temp = sensor->overlaps1;
 		sensor->overlaps1 = sensor->overlaps2;
 		sensor->overlaps2 = temp;
-		b2ShapeRefArray_Clear( &sensor->overlaps2 );
+		b2VisitorArray_Clear( &sensor->overlaps2 );
 
 		// Append sensor hits
 		int hitCount = sensor->hits.count;
 		for ( int i = 0; i < hitCount; ++i )
 		{
-			b2ShapeRefArray_Push( &sensor->overlaps2, sensor->hits.data[i] );
+			b2VisitorArray_Push( &sensor->overlaps2, sensor->hits.data[i] );
 		}
 
 		// Clear the hits
-		b2ShapeRefArray_Clear( &sensor->hits );
+		b2VisitorArray_Clear( &sensor->hits );
 
 		b2Body* body = b2BodyArray_Get( &world->bodies, sensorShape->bodyId );
 		if ( body->setIndex == b2_disabledSet || sensorShape->enableSensorEvents == false )
@@ -196,12 +195,12 @@ static void b2SensorTask( int startIndex, int endIndex, uint32_t threadIndex, vo
 		b2DynamicTree_Query( trees + 2, queryBounds, sensorShape->filter.maskBits, b2SensorQueryCallback, &queryContext );
 
 		// Sort the overlaps to enable finding begin and end events.
-		qsort( sensor->overlaps2.data, sensor->overlaps2.count, sizeof( b2ShapeRef ), b2CompareShapeRefs );
+		qsort( sensor->overlaps2.data, sensor->overlaps2.count, sizeof( b2Visitor ), b2CompareShapeRefs );
 
 		// Remove duplicates from overlaps2 (sorted). Duplicates are possible due to the hit events appended earlier.
 		int uniqueCount = 0;
 		int overlapCount = sensor->overlaps2.count;
-		b2ShapeRef* overlapData = sensor->overlaps2.data;
+		b2Visitor* overlapData = sensor->overlaps2.data;
 		for ( int i = 0; i < overlapCount; ++i )
 		{
 			if ( uniqueCount == 0 || overlapData[i].shapeId != overlapData[uniqueCount - 1].shapeId )
@@ -223,8 +222,8 @@ static void b2SensorTask( int startIndex, int endIndex, uint32_t threadIndex, vo
 		{
 			for ( int i = 0; i < count1; ++i )
 			{
-				b2ShapeRef* s1 = sensor->overlaps1.data + i;
-				b2ShapeRef* s2 = sensor->overlaps2.data + i;
+				b2Visitor* s1 = sensor->overlaps1.data + i;
+				b2Visitor* s2 = sensor->overlaps2.data + i;
 
 				if ( s1->shapeId != s2->shapeId || s1->generation != s2->generation )
 				{
@@ -292,16 +291,16 @@ void b2OverlapSensors( b2World* world )
 
 			int count1 = sensor->overlaps1.count;
 			int count2 = sensor->overlaps2.count;
-			const b2ShapeRef* refs1 = sensor->overlaps1.data;
-			const b2ShapeRef* refs2 = sensor->overlaps2.data;
+			const b2Visitor* refs1 = sensor->overlaps1.data;
+			const b2Visitor* refs2 = sensor->overlaps2.data;
 
 			// overlaps1 can have overlaps that end
 			// overlaps2 can have overlaps that begin
 			int index1 = 0, index2 = 0;
 			while ( index1 < count1 && index2 < count2 )
 			{
-				const b2ShapeRef* r1 = refs1 + index1;
-				const b2ShapeRef* r2 = refs2 + index2;
+				const b2Visitor* r1 = refs1 + index1;
+				const b2Visitor* r2 = refs2 + index2;
 				if ( r1->shapeId == r2->shapeId )
 				{
 					if ( r1->generation < r2->generation )
@@ -351,7 +350,7 @@ void b2OverlapSensors( b2World* world )
 			while ( index1 < count1 )
 			{
 				// end
-				const b2ShapeRef* r1 = refs1 + index1;
+				const b2Visitor* r1 = refs1 + index1;
 				b2ShapeId visitorId = { r1->shapeId + 1, world->worldId, r1->generation };
 				b2SensorEndTouchEvent event = { sensorId, visitorId };
 				b2SensorEndTouchEventArray_Push( &world->sensorEndEvents[world->endEventArrayIndex], event );
@@ -361,7 +360,7 @@ void b2OverlapSensors( b2World* world )
 			while ( index2 < count2 )
 			{
 				// begin
-				const b2ShapeRef* r2 = refs2 + index2;
+				const b2Visitor* r2 = refs2 + index2;
 				b2ShapeId visitorId = { r2->shapeId + 1, world->worldId, r2->generation };
 				b2SensorBeginTouchEvent event = { sensorId, visitorId };
 				b2SensorBeginTouchEventArray_Push( &world->sensorBeginEvents, event );
@@ -382,7 +381,7 @@ void b2DestroySensor( b2World* world, b2Shape* sensorShape )
 	b2Sensor* sensor = b2SensorArray_Get( &world->sensors, sensorShape->sensorIndex );
 	for ( int i = 0; i < sensor->overlaps2.count; ++i )
 	{
-		b2ShapeRef* ref = sensor->overlaps2.data + i;
+		b2Visitor* ref = sensor->overlaps2.data + i;
 		b2SensorEndTouchEvent event = {
 			.sensorShapeId =
 				{
@@ -402,9 +401,9 @@ void b2DestroySensor( b2World* world, b2Shape* sensorShape )
 	}
 
 	// Destroy sensor
-	b2ShapeRefArray_Destroy( &sensor->hits );
-	b2ShapeRefArray_Destroy( &sensor->overlaps1 );
-	b2ShapeRefArray_Destroy( &sensor->overlaps2 );
+	b2VisitorArray_Destroy( &sensor->hits );
+	b2VisitorArray_Destroy( &sensor->overlaps1 );
+	b2VisitorArray_Destroy( &sensor->overlaps2 );
 
 	int movedIndex = b2SensorArray_RemoveSwap( &world->sensors, sensorShape->sensorIndex );
 	if ( movedIndex != B2_NULL_INDEX )

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -26,6 +26,7 @@ typedef struct b2ShapeRef
 
 typedef struct b2Sensor
 {
+	// todo find a way to pool these
 	b2ShapeRefArray hits;
 	b2ShapeRefArray overlaps1;
 	b2ShapeRefArray overlaps2;

--- a/src/sensor.h
+++ b/src/sensor.h
@@ -14,22 +14,20 @@ typedef struct b2SensorHit
 {
 	int sensorId;
 	int visitorId;
-	b2Transform visitorTransform;
 } b2SensorHit;
 
-typedef struct b2ShapeRef
+typedef struct b2Visitor
 {
-	b2Transform transform;
 	int shapeId;
 	uint16_t generation;
-} b2ShapeRef;
+} b2Visitor;
 
 typedef struct b2Sensor
 {
 	// todo find a way to pool these
-	b2ShapeRefArray hits;
-	b2ShapeRefArray overlaps1;
-	b2ShapeRefArray overlaps2;
+	b2VisitorArray hits;
+	b2VisitorArray overlaps1;
+	b2VisitorArray overlaps2;
 	int shapeId;
 } b2Sensor;
 
@@ -45,4 +43,4 @@ void b2DestroySensor( b2World* world, b2Shape* sensorShape );
 B2_ARRAY_INLINE( b2Sensor, b2Sensor )
 B2_ARRAY_INLINE( b2SensorHit, b2SensorHit )
 B2_ARRAY_INLINE( b2SensorTaskContext, b2SensorTaskContext )
-B2_ARRAY_INLINE( b2ShapeRef, b2ShapeRef )
+B2_ARRAY_INLINE( b2Visitor, b2Visitor )

--- a/src/solver.c
+++ b/src/solver.c
@@ -289,7 +289,7 @@ static bool b2ContinuousQueryCallback( int proxyId, uint64_t userData, void* con
 	}
 
 	// Skip sensors except if the body wants sensor hits
-	bool isSensor = shape->sensorIndex != B2_NULL_INDEX;
+	bool isSensor = shape->sensorIndex != B2_NULL_INDEX || fastShape->sensorIndex != B2_NULL_INDEX;
 	if ( isSensor && ( fastBodySim->flags & b2_enableSensorHits ) == 0 )
 	{
 		return true;
@@ -501,12 +501,6 @@ static void b2SolveContinuous( b2World* world, int bodySimIndex, b2TaskContext* 
 
 		// Store this to avoid double computation in the case there is no impact event
 		fastShape->aabb = box2;
-
-		// No continuous collision for sensors (but still need the updated bounds)
-		if ( fastShape->sensorIndex != B2_NULL_INDEX )
-		{
-			continue;
-		}
 
 		b2AABB sweptBox = b2AABB_Union( box1, box2 );
 

--- a/src/solver.c
+++ b/src/solver.c
@@ -272,6 +272,8 @@ static bool b2ContinuousQueryCallback( int proxyId, uint64_t userData, void* con
 	b2Shape* fastShape = continuousContext->fastShape;
 	b2BodySim* fastBodySim = continuousContext->fastBodySim;
 
+	B2_ASSERT( fastShape->sensorIndex == B2_NULL_INDEX );
+
 	// Skip same shape
 	if ( shapeId == fastShape->id )
 	{
@@ -288,9 +290,10 @@ static bool b2ContinuousQueryCallback( int proxyId, uint64_t userData, void* con
 		return true;
 	}
 
-	// Skip sensors except if the body wants sensor hits
-	bool isSensor = shape->sensorIndex != B2_NULL_INDEX || fastShape->sensorIndex != B2_NULL_INDEX;
-	if ( isSensor && ( fastBodySim->flags & b2_enableSensorHits ) == 0 )
+	bool isSensor = shape->sensorIndex != B2_NULL_INDEX;
+
+	// Skip sensors unless the shapes want sensor events
+	if ( isSensor && ( shape->enableSensorEvents == false || fastShape->enableSensorEvents == false ) )
 	{
 		return true;
 	}
@@ -335,8 +338,7 @@ static bool b2ContinuousQueryCallback( int proxyId, uint64_t userData, void* con
 	}
 
 	// Early out on fast parallel movement over a chain shape.
-	// No early out for sensor sweeps.
-	if ( shape->type == b2_chainSegmentShape && isSensor == false )
+	if ( shape->type == b2_chainSegmentShape )
 	{
 		b2Transform transform = bodySim->transform;
 		b2Vec2 p1 = b2TransformPoint( transform, shape->chainSegment.segment.point1 );
@@ -402,12 +404,13 @@ static bool b2ContinuousQueryCallback( int proxyId, uint64_t userData, void* con
 		if ( output.fraction <= continuousContext->fraction && continuousContext->sensorCount < B2_MAX_CONTINUOUS_SENSOR_HITS )
 		{
 			int index = continuousContext->sensorCount;
-			b2Transform hitTransform = b2GetSweepTransform( &continuousContext->sweep, output.fraction );
+
+			// The hit shape is a sensor
 			b2SensorHit sensorHit = {
 				.sensorId = shape->id,
 				.visitorId = fastShape->id,
-				.visitorTransform = hitTransform,
 			};
+
 			continuousContext->sensorHits[index] = sensorHit;
 			continuousContext->sensorFractions[index] = output.fraction;
 			continuousContext->sensorCount += 1;
@@ -501,6 +504,12 @@ static void b2SolveContinuous( b2World* world, int bodySimIndex, b2TaskContext* 
 
 		// Store this to avoid double computation in the case there is no impact event
 		fastShape->aabb = box2;
+
+		// No continuous collision for sensors (but still need the updated bounds)
+		if ( fastShape->sensorIndex != B2_NULL_INDEX )
+		{
+			continue;
+		}
 
 		b2AABB sweptBox = b2AABB_Union( box1, box2 );
 
@@ -602,6 +611,7 @@ static void b2SolveContinuous( b2World* world, int bodySimIndex, b2TaskContext* 
 	// Push sensor hits on the the task context for serial processing.
 	for ( int i = 0; i < context.sensorCount; ++i )
 	{
+		// Skip any sensor hits that occurred after a solid hit
 		if ( context.sensorFractions[i] < context.fraction )
 		{
 			b2SensorHitArray_Push( &taskContext->sensorHits, context.sensorHits[i] );
@@ -2091,7 +2101,7 @@ void b2Solve( b2World* world, b2StepContext* stepContext )
 		for ( int i = 0; i < bulletBodyCount; ++i )
 		{
 			b2BodySim* bulletBodySim = bodySimArray + bulletBodySimIndices[i];
-			if ((bulletBodySim->flags & b2_enlargeBounds) == 0)
+			if ( ( bulletBodySim->flags & b2_enlargeBounds ) == 0 )
 			{
 				continue;
 			}
@@ -2159,12 +2169,11 @@ void b2Solve( b2World* world, b2StepContext* stepContext )
 				b2Shape* visitor = b2ShapeArray_Get( &world->shapes, hit.visitorId );
 
 				b2Sensor* sensor = b2SensorArray_Get( &world->sensors, sensorShape->sensorIndex );
-				b2ShapeRef shapeRef = {
-					.transform = hit.visitorTransform,
+				b2Visitor shapeRef = {
 					.shapeId = hit.visitorId,
 					.generation = visitor->generation,
 				};
-				b2ShapeRefArray_Push( &sensor->hits, shapeRef );
+				b2VisitorArray_Push( &sensor->hits, shapeRef );
 			}
 		}
 


### PR DESCRIPTION
- Removed b2BodyDef::enableSensorHits
- Added access to joint event thresholds
- Removed b2SensorData
- motion locks no longer affect mass
- all visitors now do continuous checks against static sensors
- bullets visitors do continuous checks against all non-bullet sensors
- gave up on supporting fast moving sensors or collecting sensor collision data
- instead people should use ray and shape casts to get detailed swept collision data or use contact events
- added sample that shows how to make an exploding projectile

