### PR TITLE
Inital zig build support and integrating it with the CI 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,52 +162,24 @@ jobs:
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config Release
 
-  build-ubuntu-zig-static:
-    name: ubuntu-zig-static
-    runs-on: ubuntu-latest
+  zig-matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        zig: [0.15.1]
+        os: [ubuntu-latest, windows-latest]
+        shared: [false]
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.1
-      - name: Build
-        run: zig build -Dunit_tests=true
+    - uses: actions/checkout@v4
 
-      - name: Test
-        run: ./zig-out/bin/test
-    
-  build-ubuntu-zig-dynamic:
-    name: ubuntu-zig-dynamic
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.1
-      - name: Build
-        run: zig build -Dshared=true
+    - name: Setup zig
+      uses: mlugg/setup-zig@v2
+      with:
+        version: ${{ matrix.zig }}
 
-  build-windows-zig-static:
-    name: windows-zig-static
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.1
-      - name: Build
-        run: zig build -Dunit_tests=true
+    - name: Build lib and unit tests
+      run: zig build -Dshared=${{ matrix.shared }} -Dunit_tests=true
 
-      - name: Test
-        run: .\zig-out\bin\test.exe
-
-  build-windows-zig-dynamic:
-    name: windows-zig-dynamic
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.15.1
-      - name: Build
-        run: zig build -Dshared=true
+    - name: Test
+      run: ${{github.workspace}}/zig-out/bin/test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,4 +161,53 @@ jobs:
       
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config Release
-      
+
+  build-ubuntu-zig-static:
+    name: ubuntu-zig-static
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.1
+      - name: Build
+        run: zig build -Dunit_tests=true
+
+      - name: Test
+        run: ./zig-out/bin/test
+    
+  build-ubuntu-zig-dynamic:
+    name: ubuntu-zig-dynamic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.1
+      - name: Build
+        run: zig build -Dshared=true
+
+  build-windows-zig-static:
+    name: windows-zig-static
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.1
+      - name: Build
+        run: zig build -Dunit_tests=true
+
+      - name: Test
+        run: .\zig-out\bin\test.exe
+
+  build-windows-zig-dynamic:
+    name: windows-zig-dynamic
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.15.1
+      - name: Build
+        run: zig build -Dshared=true

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ settings.ini
 CMakeUserPresets.json
 .cache/
 .idea/
+zig-out
+.zig-cache

--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ Box2D is a 2D physics engine for games.
 - cmake --build . --config Release
 - cmake --install . (might need sudo)
 
+## Building with zig
+
+In your project using build.zig:
+
+ - zig fetch --save git+https://github.com/erincatto/box2d
+```zig
+// In your build.zig:
+// link with box2d c headers
+{
+    const box2d = b.dependency("box2d", .{
+        .shared = false,
+    });
+    const box2d_artifact = box2d.artifact("box2d");
+    exe.linkLibrary(box2d_artifact);
+}
+
+// In your zig code:
+const box2d_c = @cImport(@cInclude("box2d/box2d.h"));
+```
+
 ## Compatibility
 The Box2D library and samples build and run on Windows, Linux, and Mac.
 

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,137 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const min_supported_ver = "0.14.0";
+
+comptime {
+    const order = std.SemanticVersion.order;
+    const parse = std.SemanticVersion.parse;
+    if (order(builtin.zig_version, parse(min_supported_ver) catch unreachable) == .lt)
+        @compileError("Box2d requires zig version " ++ min_supported_ver);
+}
+
+fn compileBox2d(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, options: Options) !*std.Build.Step.Compile {
+    var box2d_flags_arr = std.ArrayList([]const u8).init(b.allocator);
+    defer box2d_flags_arr.deinit();
+
+    try box2d_flags_arr.appendSlice(&[_][]const u8{
+        "-std=gnu99",
+        "-D_GNU_SOURCE",
+    });
+
+    if (options.shared) {
+        try box2d_flags_arr.appendSlice(&[_][]const u8{
+            "-fPIC",
+            "-DBUILD_LIBTYPE_SHARED",
+        });
+    }
+
+    const box2d = if (options.shared)
+        b.addSharedLibrary(.{
+            .name = "box2d",
+            .target = target,
+            .optimize = optimize,
+        })
+    else
+        b.addStaticLibrary(.{
+            .name = "box2d",
+            .target = target,
+            .optimize = optimize,
+        });
+    box2d.linkLibC();
+
+    const c_source_files = &[_][]const u8{
+        "src/aabb.c",
+        "src/aabb.h",
+        "src/arena_allocator.c",
+        "src/arena_allocator.h",
+        "src/array.c",
+        "src/array.h",
+        "src/atomic.h",
+        "src/bitset.c",
+        "src/bitset.h",
+        "src/body.c",
+        "src/body.h",
+        "src/broad_phase.c",
+        "src/broad_phase.h",
+        "src/constants.h",
+        "src/constraint_graph.c",
+        "src/constraint_graph.h",
+        "src/contact.c",
+        "src/contact.h",
+        "src/contact_solver.c",
+        "src/contact_solver.h",
+        "src/core.c",
+        "src/core.h",
+        "src/ctz.h",
+        "src/distance.c",
+        "src/distance_joint.c",
+        "src/dynamic_tree.c",
+        "src/geometry.c",
+        "src/hull.c",
+        "src/id_pool.c",
+        "src/id_pool.h",
+        "src/island.c",
+        "src/island.h",
+        "src/joint.c",
+        "src/joint.h",
+        "src/manifold.c",
+        "src/math_functions.c",
+        "src/motor_joint.c",
+        "src/mouse_joint.c",
+        "src/mover.c",
+        "src/prismatic_joint.c",
+        "src/revolute_joint.c",
+        "src/sensor.c",
+        "src/sensor.h",
+        "src/shape.c",
+        "src/shape.h",
+        "src/solver.c",
+        "src/solver.h",
+        "src/solver_set.c",
+        "src/solver_set.h",
+        "src/table.c",
+        "src/table.h",
+        "src/timer.c",
+        "src/types.c",
+        "src/weld_joint.c",
+        "src/wheel_joint.c",
+        "src/world.c",
+        "src/world.h",
+    };
+
+    box2d.addIncludePath(b.path("include"));
+
+    box2d.root_module.addCSourceFiles(.{
+        .files = c_source_files,
+        .flags = box2d_flags_arr.items,
+    });
+
+    return box2d;
+}
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const lib = try compileBox2d(b, target, optimize, Options.getOptions(b));
+    lib.installHeader(b.path("include/box2d/base.h"), "base.h");
+    lib.installHeader(b.path("include/box2d/box2d.h"), "box2d/box2d.h");
+    lib.installHeader(b.path("include/box2d/collision.h"), "collision.h");
+    lib.installHeader(b.path("include/box2d/id.h"), "id.h");
+    lib.installHeader(b.path("include/box2d/math_functions.h"), "math_functions.h");
+    lib.installHeader(b.path("include/box2d/types.h"), "types.h");
+
+    b.installArtifact(lib);
+}
+
+pub const Options = struct {
+    shared: bool = false,
+
+    const defaults = Options{};
+
+    pub fn getOptions(b: *std.Build) Options {
+        return .{
+            .shared = b.option(bool, "shared", "Compile as shared library") orelse defaults.shared,
+        };
+    }
+};

--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 
-const min_supported_ver = "0.14.0";
+const min_supported_ver = "0.15.0";
 
 comptime {
     const order = std.SemanticVersion.order;
@@ -10,16 +10,61 @@ comptime {
         @compileError("Box2d requires zig version " ++ min_supported_ver);
 }
 
-fn compileBox2d(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, options: Options) !*std.Build.Step.Compile {
+pub const Options = struct {
+    shared: bool,
+    unit_tests: bool,
+
+    const defaults = Options{
+        .shared = false,
+        .unit_tests = false,
+    };
+
+    pub fn getOptions(b: *std.Build) Options {
+        return .{
+            .shared = b.option(bool, "shared", "Compile as shared library") orelse defaults.shared,
+            .unit_tests = b.option(bool, "unit_tests", "Compile units tests") orelse defaults.unit_tests,
+        };
+    }
+};
+
+pub fn build(b: *std.Build) !void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const options = Options.getOptions(b);
+    const lib = try compileBox2d(b, target, optimize, options.shared);
+
+    b.installArtifact(lib);
+
+    var shared_lib: ?*std.Build.Step.Compile = null;
+    if (options.unit_tests) {
+        shared_lib = buildShared(b, target, optimize, lib);
+    }
+
+    if (options.unit_tests) {
+        // link with enkiTS c headers
+        const enki_ts = get_enki_ts_artifact: {
+            const enki_ts_dep = b.dependency("enkiTS", .{
+                .shared = false,
+            });
+
+            break :get_enki_ts_artifact enki_ts_dep.artifact("enki_ts");
+        };
+
+        buildTests(b, target, optimize, lib, enki_ts, shared_lib.?);
+    }
+}
+
+fn compileBox2d(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, shared: bool) !*std.Build.Step.Compile {
     var box2d_flags_arr = std.ArrayList([]const u8).empty;
     defer box2d_flags_arr.deinit(b.allocator);
 
     try box2d_flags_arr.appendSlice(b.allocator, &[_][]const u8{
         "-std=gnu99",
         "-D_GNU_SOURCE",
+        "-ffp-contract=off",
     });
 
-    if (options.shared) {
+    if (shared) {
         try box2d_flags_arr.appendSlice(b.allocator, &[_][]const u8{
             "-fPIC",
             "-DBUILD_LIBTYPE_SHARED",
@@ -29,16 +74,15 @@ fn compileBox2d(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.b
     const module = b.addModule("box2d", .{
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
 
-    const linkage: std.builtin.LinkMode = if (options.shared) .dynamic else .static;
+    const linkage: std.builtin.LinkMode = if (shared) .dynamic else .static;
     const box2d = b.addLibrary(.{
         .root_module = module,
         .name = "box2d",
         .linkage = linkage,
     });
-
-    box2d.linkLibC();
 
     const c_source_files = &[_][]const u8{
         "src/aabb.c",
@@ -99,38 +143,99 @@ fn compileBox2d(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.b
         "src/wheel_joint.c",
     };
 
-    box2d.addIncludePath(b.path("include"));
+    box2d.root_module.addIncludePath(b.path("include"));
+    box2d.installHeadersDirectory(b.path("include/box2d"), "box2d", .{});
 
     box2d.root_module.addCSourceFiles(.{
         .files = c_source_files,
         .flags = box2d_flags_arr.items,
+        .language = .c,
     });
 
     return box2d;
 }
 
-pub fn build(b: *std.Build) !void {
-    const target = b.standardTargetOptions(.{});
-    const optimize = b.standardOptimizeOption(.{});
-    const lib = try compileBox2d(b, target, optimize, Options.getOptions(b));
-    lib.installHeader(b.path("include/box2d/base.h"), "base.h");
-    lib.installHeader(b.path("include/box2d/box2d.h"), "box2d/box2d.h");
-    lib.installHeader(b.path("include/box2d/collision.h"), "collision.h");
-    lib.installHeader(b.path("include/box2d/id.h"), "id.h");
-    lib.installHeader(b.path("include/box2d/math_functions.h"), "math_functions.h");
-    lib.installHeader(b.path("include/box2d/types.h"), "types.h");
+pub fn buildTests(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    box2d_lib: *std.Build.Step.Compile,
+    enki_ts_lib: *std.Build.Step.Compile,
+    box2d_shared_lib: *std.Build.Step.Compile,
+) void {
+    const module = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+    });
 
-    b.installArtifact(lib);
+    module.addCSourceFiles(.{
+        .files = &[_][]const u8{
+            "test/main.c",
+            "test/test_bitset.c",
+            "test/test_collision.c",
+            "test/test_determinism.c",
+            "test/test_distance.c",
+            "test/test_id.c",
+            "test/test_math.c",
+            "test/test_shape.c",
+            "test/test_table.c",
+            "test/test_world.c",
+        },
+        .flags = &[_][]const u8{
+            "-std=c17",
+            "-ffp-contract=off",
+        },
+        .language = .c,
+    });
+
+    const exe = b.addExecutable(.{
+        .name = "test",
+        .root_module = module,
+    });
+
+    exe.root_module.addIncludePath(b.path("src"));
+    exe.root_module.addIncludePath(b.path("shared"));
+
+    exe.root_module.linkLibrary(box2d_lib);
+    exe.root_module.linkLibrary(box2d_shared_lib);
+    exe.root_module.linkLibrary(enki_ts_lib);
+
+    b.installArtifact(exe);
 }
 
-pub const Options = struct {
-    shared: bool = false,
+pub fn buildShared(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    optimize: std.builtin.OptimizeMode,
+    box2d_lib: *std.Build.Step.Compile,
+) *std.Build.Step.Compile {
+    const module = b.createModule(.{
+        .target = target,
+        .optimize = optimize,
+    });
 
-    const defaults = Options{};
+    module.addCSourceFiles(.{
+        .files = &[_][]const u8{
+            "shared/benchmarks.c",
+            "shared/benchmarks.h",
+            "shared/determinism.c",
+            "shared/determinism.h",
+            "shared/human.c",
+            "shared/human.h",
+            "shared/random.c",
+            "shared/random.h",
+        },
+        .flags = &[_][]const u8{
+            "-ffp-contract=off",
+        },
+        .language = .c,
+    });
 
-    pub fn getOptions(b: *std.Build) Options {
-        return .{
-            .shared = b.option(bool, "shared", "Compile as shared library") orelse defaults.shared,
-        };
-    }
-};
+    module.linkLibrary(box2d_lib);
+
+    return b.addLibrary(.{
+        .root_module = module,
+        .name = "shared",
+        .linkage = .static,
+    });
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = .box2d,
+    .version = "3.0.0",
+    .minimum_zig_version = "0.14.0",
+
+    .fingerprint = 0xbbd8fcbd18ea5e0b, // Changing this has security and trust implications.
+
+    .dependencies = .{},
+
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "include/box2d",
+        "shared",
+        "src",
+    },
+}

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,8 +7,8 @@
 
     .dependencies = .{
         .enkiTS = .{
-            .url = "git+https://github.com/Avokadoen/enkiTS?ref=zig-build#9147a704e095849a08db1c2879f0059c71e3036b",
-            .hash = "enkiTS-1.11.0-SlhBp-h6AgAvYOsbAaFfuCtsRQsX2a5cAAAyY8kdMCdu",
+            .url = "git+https://github.com/dougbinks/enkiTS#d0e74e1b0ed5886d600c09809d572fcdee418f27",
+            .hash = "enkiTS-1.11.0-SlhBpzV8AgBFq7N6lqhX78C2XO5mr8GJUgNuW9fazCiv",
         },
     },
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,11 +1,16 @@
 .{
     .name = .box2d,
     .version = "3.0.0",
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.1",
 
     .fingerprint = 0xbbd8fcbd18ea5e0b, // Changing this has security and trust implications.
 
-    .dependencies = .{},
+    .dependencies = .{
+        .enkiTS = .{
+            .url = "git+https://github.com/Avokadoen/enkiTS?ref=zig-build#9147a704e095849a08db1c2879f0059c71e3036b",
+            .hash = "enkiTS-1.11.0-SlhBp-h6AgAvYOsbAaFfuCtsRQsX2a5cAAAyY8kdMCdu",
+        },
+    },
 
     .paths = .{
         "build.zig",


### PR DESCRIPTION
This PR adds a build.zig + build.zig.zon. It also add jobs in the CI to build with zig for windows and linux

This means there is now support for building box2d as a lib and enabling any zig build users (including other C/C++ projects) to trivially call `zig fetch --save git+https://github.com/erincatto/box2d` and start using it!

TODOs:

- [x] Building as lib for zig fetch
- [x] Building unit tests 
- [x] option BOX2D_DISABLE_SIMD
- [x] option BOX2D_AVX2
- [ ] option BOX2D_DOCS
- [ ] option BOX2D_PROFILE


Out of PR scope? 
option BOX2D_SAMPLES
option BOX2D_BENCHMARKS