### PR TITLE
Fix various warnings and improve compatibility for clang-cl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if (MSVC OR APPLE)
 			add_link_options(-fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined)
 		endif()
 	else()
-		if(MSVC AND PROJECT_IS_TOP_LEVEL)
+		if(MSVC AND CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND PROJECT_IS_TOP_LEVEL)
 			# enable hot reloading
 			add_compile_options("$<$<CONFIG:Debug>:/ZI>")
 			add_link_options("$<$<CONFIG:Debug>:/INCREMENTAL>")

--- a/benchmark/main.c
+++ b/benchmark/main.c
@@ -18,7 +18,7 @@
 #include <string.h>
 
 #if defined( _WIN64 )
-#include <windows.h>
+#include <Windows.h>
 #elif defined( __APPLE__ )
 #include <unistd.h>
 #elif defined( __linux__ )

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -745,7 +745,7 @@ typedef struct b2PrismaticJointDef
 } b2PrismaticJointDef;
 
 /// Use this to initialize your joint definition
-/// @ingroupd prismatic_joint
+/// @ingroup prismatic_joint
 B2_API b2PrismaticJointDef b2DefaultPrismaticJointDef( void );
 
 /// Revolute joint definition

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,11 +77,11 @@ add_library(box2d ${BOX2D_SOURCE_FILES} ${BOX2D_API_FILES})
 
 target_include_directories(box2d
   PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}
+	${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 set(CMAKE_DEBUG_POSTFIX "d")
@@ -89,10 +89,10 @@ set(CMAKE_DEBUG_POSTFIX "d")
 # Box2D uses C17 for _Static_assert and anonymous unions
 set_target_properties(box2d PROPERTIES
 	C_STANDARD 17
-    C_STANDARD_REQUIRED YES
-    C_EXTENSIONS YES
-    VERSION ${PROJECT_VERSION}
-    SOVERSION ${PROJECT_VERSION_MAJOR}
+	C_STANDARD_REQUIRED YES
+	C_EXTENSIONS YES
+	VERSION ${PROJECT_VERSION}
+	SOVERSION ${PROJECT_VERSION_MAJOR}
 	DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX}
 )
 
@@ -141,6 +141,24 @@ if (MSVC)
 	# Warnings
 	# 4710 - warn about inline functions that are not inlined
 	target_compile_options(box2d PRIVATE /Wall /wd4820 /wd5045 /wd4061 /wd4711 /wd4710)
+
+	# Add suppressions for clang-cl -Wall, seem safe for codebase.
+	target_compile_options(box2d PRIVATE
+		-Wno-declaration-after-statement
+		-Wno-extra-semi-stmt # Macros with semicolon
+		-Wno-sign-conversion
+		-Wno-implicit-int-conversion
+		-Wno-implicit-int-float-conversion
+		-Wno-cast-qual
+		-Wno-float-equal
+		-Wno-comma
+		-Wno-unsafe-buffer-usage
+		-Wno-switch-enum
+		-Wno-covered-switch-default
+		-Wno-switch-default
+		-Wno-unused-macros # B2_CONTACT_REMOVE_THRESHOLD
+		-Wno-pre-c11-compat # _Static_assert
+	)
 
 	if (BOX2D_AVX2)
 		message(STATUS "Box2D using AVX2")	

--- a/src/island.c
+++ b/src/island.c
@@ -446,6 +446,7 @@ void b2UnlinkJoint( b2World* world, b2Joint* joint )
 	b2ValidateIsland( world, islandId );
 }
 
+// Unused
 #define B2_CONTACT_REMOVE_THRESHOLD 1
 
 // Possible optimizations:

--- a/src/motor_joint.c
+++ b/src/motor_joint.c
@@ -310,7 +310,7 @@ void b2SolveMotorJoint( b2JointSim* base, b2StepContext* context )
 	}
 
 	// angular velocity
-	if ( joint->maxVelocityTorque > 0.0 )
+	if ( joint->maxVelocityTorque > 0.0f )
 	{
 		float cdot = wB - wA - joint->angularVelocity;
 		float impulse = -joint->angularMass * cdot;

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -1747,10 +1747,10 @@ void b2World_DumpMemoryStats( b2WorldId worldId )
 	fprintf( file, "kinematic tree: %d\n", b2DynamicTree_GetByteCount( world->broadPhase.trees + b2_kinematicBody ) );
 	fprintf( file, "dynamic tree: %d\n", b2DynamicTree_GetByteCount( world->broadPhase.trees + b2_dynamicBody ) );
 	b2HashSet* moveSet = &world->broadPhase.moveSet;
-	fprintf( file, "moveSet: %d (%d, %d)\n", b2GetHashSetBytes( moveSet ), moveSet->count, moveSet->capacity );
+	fprintf( file, "moveSet: %d (%u, %u)\n", b2GetHashSetBytes( moveSet ), moveSet->count, moveSet->capacity );
 	fprintf( file, "moveArray: %d\n", b2IntArray_ByteCount( &world->broadPhase.moveArray ) );
 	b2HashSet* pairSet = &world->broadPhase.pairSet;
-	fprintf( file, "pairSet: %d (%d, %d)\n", b2GetHashSetBytes( pairSet ), pairSet->count, pairSet->capacity );
+	fprintf( file, "pairSet: %d (%u, %u)\n", b2GetHashSetBytes( pairSet ), pairSet->count, pairSet->capacity );
 	fprintf( file, "\n" );
 
 	// solver sets

--- a/src/timer.c
+++ b/src/timer.c
@@ -13,7 +13,7 @@
 #define WIN32_LEAN_AND_MEAN 1
 #endif
 
-#include <windows.h>
+#include <Windows.h>
 
 static double s_invFrequency = 0.0;
 


### PR DESCRIPTION
Hello,

I understand you generally discourage PRs , but this submission is a collection of small correctness and compatibility fixes for the clang-cl toolchain. I felt a pull request would be the most direct way to present them, but I am happy to close this and submit individual issues if you prefer.

I've been compiling Box2D using clang-cl on Windows with a strict set of warnings enabled (/Wall). The following changes address the warnings that appeared:

1. **Direct code fixes:**

- **Documentation Typo:** Corrected a Doxygen command typo (@ingroupd to @ingroup) in include/box2d/types.h. (-Wdocumentation-unknown-command)
- **Float Literal:** Added the f suffix to a double literal in src/motor_joint.c to prevent an unnecessary promotion when comparing with a float. (-Wdouble-promotion) I noticed PR #966 aimed to resolve these, but this one seems to have been missed.
- **printf Format Specifiers:** Corrected format specifiers in src/physics_world.c from %d to %u to match uint32_t arguments. (-Wformat)
- **Include Path Portability:** Corrected the casing of the Windows header include in src/timer.c and benchmark/main.c from <windows.h> to <Windows.h>. (-Wnonportable-system-include-path)
- **CMake Build Fix:** Modified the top-level CMakeLists.txt to only add the /ZI (Edit and Continue) flag for the MSVC compiler, not clang-cl, which doesn't support it. This removes the -Wunused-command-line-argument warning when building the samples.

**2. Stylistic Warning Suppressions for clang-cl**
After the direct fixes, /Wall still flags a number of patterns that are intentional, safe C-style idioms. To allow other clang-cl users to build Box2D cleanly, I've added a block to src/CMakeLists.txt to suppress these specific warnings for the box2d target:

- -Wno-declaration-after-statement
- -Wno-extra-semi-stmt (for some macros ending in semicolons)
- -Wno-sign-conversion
- -Wno-implicit-int-conversion
- -Wno-implicit-int-float-conversion
- -Wno-cast-qual (for const-incorrect SIMD load APIs)
- -Wno-float-equal (for intentional state-identity checks)
- -Wno-comma
- -Wno-unsafe-buffer-usage (for C-style pointer arithmetic)
- -Wno-switch-enum, -Wno-covered-switch-default, -Wno-switch-default (for the mixed-style enum handling)
- -Wno-unused-macros (for B2_CONTACT_REMOVE_THRESHOLD)
- -Wno-pre-c11-compat (for _Static_assert)

Finally, **thank you** for this great library and all the work you've done. I have also enjoyed having a look over some of your approach to key bottlenecks.

