### PR TITLE
Improve encapsulation and robustness of some global variables

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "core.h"
+#include "constants.h"
 
 #if defined( B2_COMPILER_MSVC )
 #define _CRTDBG_MAP_ALLOC
@@ -51,7 +52,7 @@ static int b2DefaultAssertFcn( const char* condition, const char* fileName, int 
 	return 1;
 }
 
-b2AssertFcn* b2AssertHandler = b2DefaultAssertFcn;
+static b2AssertFcn* b2AssertHandler = b2DefaultAssertFcn;
 
 void b2SetAssertFcn( b2AssertFcn* assertFcn )
 {
@@ -78,7 +79,7 @@ b2Version b2GetVersion( void )
 static b2AllocFcn* b2_allocFcn = NULL;
 static b2FreeFcn* b2_freeFcn = NULL;
 
-b2AtomicInt b2_byteCount;
+static b2AtomicInt b2_byteCount;
 
 void b2SetAllocator( b2AllocFcn* allocFcn, b2FreeFcn* freeFcn )
 {

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -32,7 +32,7 @@
 
 _Static_assert( B2_MAX_WORLDS > 0, "must be 1 or more" );
 _Static_assert( B2_MAX_WORLDS < UINT16_MAX, "B2_MAX_WORLDS limit exceeded" );
-b2World b2_worlds[B2_MAX_WORLDS];
+static b2World b2_worlds[B2_MAX_WORLDS];
 
 B2_ARRAY_SOURCE( b2BodyMoveEvent, b2BodyMoveEvent )
 B2_ARRAY_SOURCE( b2ContactBeginTouchEvent, b2ContactBeginTouchEvent )


### PR DESCRIPTION
Hello,

Sorry, another PR, but very small. Following my previous PR for clang-cl compatibility, this pull request addresses the -Wmissing-variable-declarations warnings found during the audit.

**1. Internal globals without static:**
The following global variables appear to be internal to their respective modules. I have marked them as static to prevent potential linker conflicts and clarify intent.
**src/core.c:**
b2AssertHandler
b2_byteCount
**src/physics_world.c:**
b2_worlds

**2. Extern declaration not found:**
The file src/core.c defines b2_lengthUnitsPerMeter (used as a public global variable), but does not include constants.h that contains the extern declaration. I have added #include "constants.h" to src/core.c, creating a consistency check between the declaration and the definition.

These changes resolve the main warnings from my audit, thanks again!
