### PR TITLE
Fix c clang cl wall

### DIFF
--- a/benchmark/main.c
+++ b/benchmark/main.c
@@ -18,7 +18,7 @@
 #include <string.h>
 
 #if defined( _WIN64 )
-#include <windows.h>
+#include <Windows.h>
 #elif defined( __APPLE__ )
 #include <unistd.h>
 #elif defined( __linux__ )

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -745,7 +745,7 @@ typedef struct b2PrismaticJointDef
 } b2PrismaticJointDef;
 
 /// Use this to initialize your joint definition
-/// @ingroupd prismatic_joint
+/// @ingroup prismatic_joint
 B2_API b2PrismaticJointDef b2DefaultPrismaticJointDef( void );
 
 /// Revolute joint definition

--- a/src/motor_joint.c
+++ b/src/motor_joint.c
@@ -310,7 +310,7 @@ void b2SolveMotorJoint( b2JointSim* base, b2StepContext* context )
 	}
 
 	// angular velocity
-	if ( joint->maxVelocityTorque > 0.0 )
+	if ( joint->maxVelocityTorque > 0.0f )
 	{
 		float cdot = wB - wA - joint->angularVelocity;
 		float impulse = -joint->angularMass * cdot;

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -1747,10 +1747,10 @@ void b2World_DumpMemoryStats( b2WorldId worldId )
 	fprintf( file, "kinematic tree: %d\n", b2DynamicTree_GetByteCount( world->broadPhase.trees + b2_kinematicBody ) );
 	fprintf( file, "dynamic tree: %d\n", b2DynamicTree_GetByteCount( world->broadPhase.trees + b2_dynamicBody ) );
 	b2HashSet* moveSet = &world->broadPhase.moveSet;
-	fprintf( file, "moveSet: %d (%d, %d)\n", b2GetHashSetBytes( moveSet ), moveSet->count, moveSet->capacity );
+	fprintf( file, "moveSet: %d (%u, %u)\n", b2GetHashSetBytes( moveSet ), moveSet->count, moveSet->capacity );
 	fprintf( file, "moveArray: %d\n", b2IntArray_ByteCount( &world->broadPhase.moveArray ) );
 	b2HashSet* pairSet = &world->broadPhase.pairSet;
-	fprintf( file, "pairSet: %d (%d, %d)\n", b2GetHashSetBytes( pairSet ), pairSet->count, pairSet->capacity );
+	fprintf( file, "pairSet: %d (%u, %u)\n", b2GetHashSetBytes( pairSet ), pairSet->count, pairSet->capacity );
 	fprintf( file, "\n" );
 
 	// solver sets

--- a/src/timer.c
+++ b/src/timer.c
@@ -13,7 +13,7 @@
 #define WIN32_LEAN_AND_MEAN 1
 #endif
 
-#include <windows.h>
+#include <Windows.h>
 
 static double s_invFrequency = 0.0;
 


### PR DESCRIPTION
Extracted from #991 . No functional changes. Fixes /Wall diagnostics under clang-cl (float suffix, %u for uint32_t, Windows.h capitalisation, Doxygen @ ingroup).