### PR TITLE
Define `b2Chain_GetSurfaceMaterialCount`

### DIFF
--- a/src/shape.c
+++ b/src/shape.c
@@ -573,6 +573,18 @@ int b2Chain_GetSegments( b2ChainId chainId, b2ShapeId* segmentArray, int capacit
 	return count;
 }
 
+int b2Chain_GetSurfaceMaterialCount( b2ChainId chainId )
+{
+	b2World* world = b2GetWorldLocked( chainId.world0 );
+	if ( world == NULL )
+	{
+		return 0;
+	}
+
+	b2ChainShape* chain = b2GetChainShape( world, chainId );
+	return chain->materialCount;
+}
+
 b2AABB b2ComputeShapeAABB( const b2Shape* shape, b2Transform xf )
 {
 	switch ( shape->type )


### PR DESCRIPTION
Currently, `b2Chain_GetSurfaceMaterialCount` is defined in `box2d/box2d.h` but does not exist yet, so define it.

