### PR TITLE
(Samples app) Preserve world position of mouse cursor after scroll zoom

### DIFF
--- a/samples/main.cpp
+++ b/samples/main.cpp
@@ -378,6 +378,11 @@ static void ScrollCallback( GLFWwindow* window, double dx, double dy )
 		return;
 	}
 
+	double xd, yd;
+	glfwGetCursorPos( window, &xd, &yd );
+	b2Vec2 ps = { float( xd ), float( yd ) };
+	b2Vec2 pwBefore = ConvertScreenToWorld( &s_context.camera, ps );
+
 	if ( dy > 0 )
 	{
 		s_context.camera.zoom /= 1.1f;
@@ -386,6 +391,10 @@ static void ScrollCallback( GLFWwindow* window, double dx, double dy )
 	{
 		s_context.camera.zoom *= 1.1f;
 	}
+
+	b2Vec2 pwAfter = ConvertScreenToWorld( &s_context.camera, ps );
+	b2Vec2 delta = pwAfter - pwBefore;
+	s_context.camera.center -= delta;
 }
 
 static void UpdateUI()


### PR DESCRIPTION
After scroll zoom, reposition camera so that world location under mouse cursor remains unchanged (a la Google maps and many other graphical editors) to allow zoom and pan in one action.