### PR TITLE
Loose chain segment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,26 @@ jobs:
       working-directory: ${{github.workspace}}/build
       run: ./bin/test
       
+  build-ubuntu-clang-msan:
+    name: ubuntu-clang-msan
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=memory -fsanitize-memory-track-origins=1 -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=memory" -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      env:
+        MSAN_OPTIONS: abort_on_error=1:halt_on_error=1
+      run: ./bin/test
+            
   build-macos:
     name: macos
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 4
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 4
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DCMAKE_CXX_COMPILER=clang++-18 -DCMAKE_C_COMPILER=clang-18 -DCMAKE_C_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer" -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread" -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: 4
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
@@ -71,7 +71,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup MSVC dev command prompt
       uses: TheMrMilchmann/setup-msvc-dev@v3
@@ -96,7 +96,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: cmake -T ClangCL -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_SAMPLES=OFF -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
@@ -117,7 +117,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup MSYS2 UCRT64
       uses: msys2/setup-msys2@v2
@@ -146,7 +146,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: cmake -A arm64 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOX2D_DISABLE_SIMD=TRUE -DBOX2D_SAMPLES=OFF -DBOX2D_SANITIZE=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_VALIDATE=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON
@@ -165,7 +165,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup MSVC dev command prompt
       uses: TheMrMilchmann/setup-msvc-dev@v3
@@ -185,7 +185,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Setup MSVC dev command prompt
       uses: TheMrMilchmann/setup-msvc-dev@v4
@@ -204,7 +204,7 @@ jobs:
     timeout-minutes: 6
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=OFF -DBOX2D_UNIT_TESTS=OFF
@@ -218,7 +218,7 @@ jobs:
     timeout-minutes: 6
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DBOX2D_SAMPLES=ON -DBUILD_SHARED_LIBS=ON -DBOX2D_UNIT_TESTS=OFF
@@ -232,7 +232,7 @@ jobs:
     timeout-minutes: 6
     if: github.event_name == 'push' || github.event.pull_request.draft == false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install X11, Wayland & GL development libraries
       run: sudo apt-get update && sudo apt-get install -y libx11-dev wayland-protocols libwayland-dev libxkbcommon-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libgl-dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup MSVC dev command prompt
-      uses: TheMrMilchmann/setup-msvc-dev@v3
+      uses: TheMrMilchmann/setup-msvc-dev@v4
       with:
         arch: x64
 
@@ -168,7 +168,7 @@ jobs:
     - uses: actions/checkout@v6
 
     - name: Setup MSVC dev command prompt
-      uses: TheMrMilchmann/setup-msvc-dev@v3
+      uses: TheMrMilchmann/setup-msvc-dev@v4
       with:
         arch: x64
 

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -912,10 +912,29 @@ shape id for a chain segment shape, you can get the owning chain id. This will r
 if the shape is not a chain segment.
 
 ```c
-b2ChainId chainId = b2SHape_GetParentChain(myShapeId);
+b2ChainId chainId = b2Shape_GetParentChain(myShapeId);
 ```
 
-You cannot create a chain segment shape directly.
+You can create an orphaned chain segment directly via `b2CreateChainSegmentShape`. This is useful for streaming or destructible terrain, per-segment lifetime control, or any case where you already manage your own continuity data. The caller is responsible for supplying correct ghost vertices that maintain smooth contact normals across adjacent segments. You can also update an orphaned segment (or convert any shape to one) using `b2Shape_SetChainSegment`. However, this function cannot mutate a segment that is owned by a `b2ChainShape`.
+
+```c
+// Chain segments are one-sided. The collision normal points to the right of
+// the segment direction (point1 -> point2), so this segment collides with
+// shapes above it.
+b2ChainSegment chainSegment;
+chainSegment.ghost1 = (b2Vec2){  2.0f, 0.0f };
+chainSegment.segment.point1 = (b2Vec2){  1.0f, 0.0f };
+chainSegment.segment.point2 = (b2Vec2){ -1.0f, 0.0f };
+chainSegment.ghost2 = (b2Vec2){ -2.0f, 0.0f };
+chainSegment.chainId = B2_NULL_INDEX;
+
+b2ShapeDef shapeDef = b2DefaultShapeDef();
+b2ShapeId shapeId = b2CreateChainSegmentShape( myBodyId, &shapeDef, &chainSegment );
+
+// Later, update ghost vertices in place.
+chainSegment.ghost1 = (b2Vec2){ 3.0f, 0.5f };
+b2Shape_SetChainSegment( shapeId, &chainSegment );
+```
 
 ### Sensors
 Sometimes game logic needs to know when two shapes overlap yet there

--- a/include/box2d/base.h
+++ b/include/box2d/base.h
@@ -5,6 +5,9 @@
 
 #include <stdint.h>
 
+/// Used to indicate an unset or invalid index value.
+#define B2_NULL_INDEX ( -1 )
+
 // clang-format off
 // 
 // Shared library macros

--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -460,6 +460,16 @@ B2_API void b2Body_SetBullet( b2BodyId bodyId, bool flag );
 /// Is this body a bullet?
 B2_API bool b2Body_IsBullet( b2BodyId bodyId );
 
+/// Enable or disable contact recycling for this body. Contact recycling is a performance optimization
+/// that reuses contact manifolds when bodies move slightly. Disabling it can avoid ghost collisions
+/// on characters at the cost of higher per-step work. Existing contacts retain their prior setting;
+/// only contacts created after this call see the new value.
+/// @see b2BodyDef::enableContactRecycling
+B2_API void b2Body_EnableContactRecycling( b2BodyId bodyId, bool flag );
+
+/// Is contact recycling enabled on this body?
+B2_API bool b2Body_IsContactRecyclingEnabled( b2BodyId bodyId );
+
 /// Enable/disable contact events on all shapes.
 /// @see b2ShapeDef::enableContactEvents
 /// @warning changing this at runtime may cause mismatched begin/end touch events

--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -426,7 +426,7 @@ B2_API void b2Body_SetAwake( b2BodyId bodyId, bool awake );
 /// Wake bodies touching this body. Works for static bodies.
 B2_API void b2Body_WakeTouching( b2BodyId bodyId );
 
-/// Enable or disable sleeping for this body. If sleeping is disabled the body will wake.
+/// Enable or disable sleeping for this body. If sleeping is disabled the body will wake (and the entire island).
 B2_API void b2Body_EnableSleep( b2BodyId bodyId, bool enableSleep );
 
 /// Returns true if sleeping is enabled for this body

--- a/include/box2d/box2d.h
+++ b/include/box2d/box2d.h
@@ -515,8 +515,15 @@ B2_API b2ShapeId b2CreateCircleShape( b2BodyId bodyId, const b2ShapeDef* def, co
 
 /// Create a line segment shape and attach it to a body. The shape definition and geometry are fully cloned.
 /// Contacts are not created until the next time step.
-/// @return the shape id for accessing the shape
+/// @return the shape id or b2_nullShapeId if the segment is too short.
 B2_API b2ShapeId b2CreateSegmentShape( b2BodyId bodyId, const b2ShapeDef* def, const b2Segment* segment );
+
+/// Create an orphaned chain segment shape and attach it to a body. The shape definition and
+/// geometry are fully cloned. The caller is responsible for the segment's ghost vertices and
+/// lifetime. The segment is not owned by any b2ChainShape (b2Shape_GetParentChain returns
+/// b2_nullChainId). Contacts are not created until the next time step.
+/// @return the shape id, or b2_nullShapeId if the segment is too short.
+B2_API b2ShapeId b2CreateChainSegmentShape( b2BodyId bodyId, const b2ShapeDef* def, const b2ChainSegment* chainSegment );
 
 /// Create a capsule shape and attach it to a body. The shape definition and geometry are fully cloned.
 /// Contacts are not created until the next time step.
@@ -667,6 +674,12 @@ B2_API void b2Shape_SetSegment( b2ShapeId shapeId, const b2Segment* segment );
 /// This does not modify the mass properties.
 /// @see b2Body_ApplyMassFromShapes
 B2_API void b2Shape_SetPolygon( b2ShapeId shapeId, const b2Polygon* polygon );
+
+/// Allows you to change a shape to be an orphaned chain segment or update the current chain
+/// segment, including its ghost vertices. The chainId on the input is ignored. The resulting
+/// shape is always orphaned. Asserts if the shape is already a chain segment
+/// owned by a b2ChainShape (chainId != B2_NULL_INDEX).
+B2_API void b2Shape_SetChainSegment( b2ShapeId shapeId, const b2ChainSegment* chainSegment );
 
 /// Get the parent chain id if the shape type is a chain segment, otherwise
 /// returns b2_nullChainId.

--- a/include/box2d/constants.h
+++ b/include/box2d/constants.h
@@ -34,7 +34,7 @@
 #define B2_MAX_WORLDS 128
 #endif
 
-/// Maximum length of the body name. Must be at least 1. Includes null termination.
+/// Maximum length of the body name. Can be 0 if you don't need names.
 #ifndef B2_NAME_LENGTH
 #define B2_NAME_LENGTH 10
 #endif

--- a/include/box2d/constants.h
+++ b/include/box2d/constants.h
@@ -34,6 +34,11 @@
 #define B2_MAX_WORLDS 128
 #endif
 
+/// Maximum length of the body name. Must be at least 1. Includes null termination.
+#ifndef B2_NAME_LENGTH
+#define B2_NAME_LENGTH 10
+#endif
+
 /// The maximum rotation of a body per time step. This limit is very large and is used
 /// to prevent numerical problems. You shouldn't need to adjust this.
 /// @warning increasing this to 0.5f * b2_pi or greater will break continuous collision.
@@ -46,6 +51,9 @@
 
 /// The default contact recycling distance.
 #define B2_CONTACT_RECYCLE_DISTANCE ( 10.0f * B2_LINEAR_SLOP )
+
+/// The default contact recycling world angle threshold. 0.98 ~= 11.5 degrees
+#define B2_CONTACT_RECYCLE_COS_ANGLE ( 0.98f  )
 
 /// This is used to fatten AABBs in the dynamic tree. This allows proxies
 /// to move by a small amount without triggering a tree adjustment. This is in meters.

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -228,7 +228,7 @@ typedef struct b2BodyDef
 	/// Sleep speed threshold, default is 0.05 meters per second
 	float sleepThreshold;
 
-	/// Optional body name for debugging. Up to B2_NAME_LENGTH characters (including null termination)
+	/// Optional body name for debugging. Up to B2_NAME_LENGTH characters
 	const char* name;
 
 	/// Use this to store application specific body data.

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -1409,6 +1409,9 @@ typedef struct b2DebugDraw
 	/// Option to draw shapes
 	bool drawShapes;
 
+	/// Option to draw chain shape normals
+	bool drawChainNormals;
+
 	/// Option to draw joints
 	bool drawJoints;
 

--- a/include/box2d/types.h
+++ b/include/box2d/types.h
@@ -228,7 +228,7 @@ typedef struct b2BodyDef
 	/// Sleep speed threshold, default is 0.05 meters per second
 	float sleepThreshold;
 
-	/// Optional body name for debugging. Up to 31 characters (excluding null termination)
+	/// Optional body name for debugging. Up to B2_NAME_LENGTH characters (including null termination)
 	const char* name;
 
 	/// Use this to store application specific body data.
@@ -266,6 +266,10 @@ typedef struct b2BodyDef
 	/// This allows this body to bypass rotational speed limits. Should only be used
 	/// for circular objects, like wheels.
 	bool allowFastRotation;
+
+	/// Enable contact recycling. True by default. Leaving this enabled improves performance
+	/// but may lead to ghost collision that should be avoided on characters.
+	bool enableContactRecycling;
 
 	/// Used internally to detect a valid definition. DO NOT SET.
 	int internalValue;

--- a/samples/main.cpp
+++ b/samples/main.cpp
@@ -150,6 +150,7 @@ static void CreateUI( GLFWwindow* window, const char* glslVersion )
 	if ( file != nullptr )
 	{
 		ImFontConfig fontConfig;
+		// This brightens the font, improving readability when it is small.
 		fontConfig.RasterizerMultiply = s_context.uiScale * s_framebufferScale;
 
 		float regularSize = floorf( 13.0f * s_context.uiScale );
@@ -157,6 +158,7 @@ static void CreateUI( GLFWwindow* window, const char* glslVersion )
 		float largeSize = floorf( 64.0f * s_context.uiScale );
 
 		ImGuiIO& io = ImGui::GetIO();
+		//s_context.regularFont = io.Fonts->AddFontFromFileTTF( fontPath, regularSize );
 		s_context.regularFont = io.Fonts->AddFontFromFileTTF( fontPath, regularSize, &fontConfig );
 		s_context.mediumFont = io.Fonts->AddFontFromFileTTF( fontPath, mediumSize, &fontConfig );
 		s_context.largeFont = io.Fonts->AddFontFromFileTTF( fontPath, largeSize, &fontConfig );

--- a/samples/sample.cpp
+++ b/samples/sample.cpp
@@ -1172,6 +1172,7 @@ void UpdateSampleUI( SampleContext* context )
 				ImGui::Separator();
 
 				ImGui::Checkbox( "Shapes", &context->debugDraw.drawShapes );
+				ImGui::Checkbox( "Chain Normals", &context->debugDraw.drawChainNormals );
 				ImGui::Checkbox( "Joints", &context->debugDraw.drawJoints );
 				ImGui::Checkbox( "Joint Extras", &context->debugDraw.drawJointExtras );
 				ImGui::Checkbox( "Bounds", &context->debugDraw.drawBounds );

--- a/samples/sample_shapes.cpp
+++ b/samples/sample_shapes.cpp
@@ -225,6 +225,190 @@ public:
 
 static int sampleChainShape = RegisterSample( "Shapes", "Chain Shape", ChainShape::Create );
 
+class ChainSegmentShape : public Sample
+{
+public:
+	enum ShapeType
+	{
+		e_circleShape = 0,
+		e_capsuleShape,
+		e_boxShape
+	};
+
+	explicit ChainSegmentShape( SampleContext* context )
+		: Sample( context )
+	{
+		if ( m_context->restart == false )
+		{
+			m_context->camera.center = { 0.0f, 0.0f };
+			m_context->camera.zoom = 25.0f * 1.0f;
+		}
+
+		m_bodyId = b2_nullBodyId;
+		m_shapeType = e_circleShape;
+		m_mutateIndex = 0;
+
+		{
+			b2BodyDef bodyDef = b2DefaultBodyDef();
+			b2BodyId groundId = b2CreateBody( m_worldId, &bodyDef );
+
+			// Walk right-to-left so the right-perpendicular normal of (point2 - point1) points up.
+			for ( int i = 0; i < m_pointCount; ++i )
+			{
+				float x = 25.0f - 50.0f * i / ( m_pointCount - 1 );
+				float y = 1.5f * sinf( 0.18f * x );
+				m_points[i] = { x, y };
+			}
+
+			b2ShapeDef shapeDef = b2DefaultShapeDef();
+			for ( int i = 0; i < m_segmentCount; ++i )
+			{
+				b2ChainSegment chainSegment;
+				chainSegment.ghost1 = m_points[i];
+				chainSegment.segment.point1 = m_points[i + 1];
+				chainSegment.segment.point2 = m_points[i + 2];
+				chainSegment.ghost2 = m_points[i + 3];
+				chainSegment.chainId = -1;
+				m_segmentShapes[i] = b2CreateChainSegmentShape( groundId, &shapeDef, &chainSegment );
+			}
+		}
+
+		Launch();
+	}
+
+	void Launch()
+	{
+		if ( B2_IS_NON_NULL( m_bodyId ) )
+		{
+			b2DestroyBody( m_bodyId );
+		}
+
+		b2BodyDef bodyDef = b2DefaultBodyDef();
+		bodyDef.type = b2_dynamicBody;
+		bodyDef.position = { -18.0f, 5.0f };
+		m_bodyId = b2CreateBody( m_worldId, &bodyDef );
+
+		b2ShapeDef shapeDef = b2DefaultShapeDef();
+		if ( m_shapeType == e_circleShape )
+		{
+			b2Circle circle = { { 0.0f, 0.0f }, 0.5f };
+			b2CreateCircleShape( m_bodyId, &shapeDef, &circle );
+		}
+		else if ( m_shapeType == e_capsuleShape )
+		{
+			b2Capsule capsule = { { -0.5f, 0.0f }, { 0.5f, 0.0f }, 0.25f };
+			b2CreateCapsuleShape( m_bodyId, &shapeDef, &capsule );
+		}
+		else
+		{
+			b2Polygon box = b2MakeSquare( 0.5f );
+			b2CreatePolygonShape( m_bodyId, &shapeDef, &box );
+		}
+	}
+
+	void Mutate()
+	{
+		// Get an index in [1,pointCount - 2]
+		// index 0 and pointCount-1 are ghost vertices and are not mutated
+		int index = m_mutateIndex + 1;
+		assert( 1 <= index && index <= m_pointCount - 2 );
+
+		m_mutateIndex += 1;
+		if ( m_mutateIndex == m_segmentCount )
+		{
+			m_mutateIndex = 0;
+		}
+
+		m_points[index].y += 0.25f;
+
+		b2ChainSegment cs;
+		cs.ghost1 = m_points[index - 1];
+		cs.segment.point1 = m_points[index];
+		cs.segment.point2 = m_points[index + 1];
+		cs.ghost2 = m_points[index + 2];
+		cs.chainId = -1;
+
+		assert( 0 <= index - 1 && index - 1 < m_segmentCount );
+		b2Shape_SetChainSegment( m_segmentShapes[index - 1], &cs );
+
+		if ( index - 1 > 0 )
+		{
+			assert( 0 <= index - 2 );
+			b2ChainSegment cs2;
+			cs2.ghost1 = m_points[index - 2];
+			cs2.segment.point1 = m_points[index - 1];
+			cs2.segment.point2 = m_points[index];
+			cs2.ghost2 = m_points[index + 1];
+			cs2.chainId = -1;
+			assert( 0 <= index - 2 && index - 2 < m_segmentCount );
+			b2Shape_SetChainSegment( m_segmentShapes[index - 2], &cs2 );
+		}
+
+		if ( index + 1 < m_pointCount - 2 )
+		{
+			assert( index + 3 < m_pointCount );
+			b2ChainSegment cs3;
+			cs3.ghost1 = m_points[index];
+			cs3.segment.point1 = m_points[index + 1];
+			cs3.segment.point2 = m_points[index + 2];
+			cs3.ghost2 = m_points[index + 3];
+			cs3.chainId = -1;
+			assert( 0 <= index && index < m_segmentCount );
+			b2Shape_SetChainSegment( m_segmentShapes[index], &cs3 );
+		}
+	}
+
+	void UpdateGui() override
+	{
+		float fontSize = ImGui::GetFontSize();
+		float height = 130.0f;
+		ImGui::SetNextWindowPos( ImVec2( 0.5f * fontSize, m_camera->height - height - 2.0f * fontSize ), ImGuiCond_Once );
+		ImGui::SetNextWindowSize( ImVec2( 240.0f, height ) );
+
+		ImGui::Begin( "Chain Segment Shape", nullptr, ImGuiWindowFlags_NoResize );
+
+		const char* shapeTypes[] = { "Circle", "Capsule", "Box" };
+		int shapeType = int( m_shapeType );
+		if ( ImGui::Combo( "Shape", &shapeType, shapeTypes, IM_ARRAYSIZE( shapeTypes ) ) )
+		{
+			m_shapeType = ShapeType( shapeType );
+			Launch();
+		}
+
+		if ( ImGui::Button( "Launch" ) )
+		{
+			Launch();
+		}
+
+		if ( ImGui::Button( "Mutate" ) )
+		{
+			Mutate();
+		}
+
+		ImGui::End();
+	}
+
+	void Step() override
+	{
+		Sample::Step();
+	}
+
+	static Sample* Create( SampleContext* context )
+	{
+		return new ChainSegmentShape( context );
+	}
+
+	static constexpr int m_segmentCount = 32;
+	static constexpr int m_pointCount = m_segmentCount + 3;
+	b2BodyId m_bodyId;
+	ShapeType m_shapeType;
+	b2ShapeId m_segmentShapes[m_segmentCount];
+	b2Vec2 m_points[m_pointCount];
+	int m_mutateIndex;
+};
+
+static int sampleChainSegmentShape = RegisterSample( "Shapes", "Chain Segment", ChainSegmentShape::Create );
+
 // This sample shows how careful creation of compound shapes leads to better simulation and avoids
 // objects getting stuck.
 // This also shows how to get the combined AABB for the body.

--- a/samples/sample_shapes.cpp
+++ b/samples/sample_shapes.cpp
@@ -291,7 +291,7 @@ public:
 		b2ShapeDef shapeDef = b2DefaultShapeDef();
 		if ( m_shapeType == e_circleShape )
 		{
-			b2Circle circle = { { 0.0f, 0.0f }, 0.5f };
+			b2Circle circle = { { 0.0f, 0.0f }, 0.25f };
 			b2CreateCircleShape( m_bodyId, &shapeDef, &circle );
 		}
 		else if ( m_shapeType == e_capsuleShape )

--- a/samples/sample_world.cpp
+++ b/samples/sample_world.cpp
@@ -143,6 +143,8 @@ public:
 
 	void UpdateGui() override
 	{
+		Sample::UpdateGui();
+
 		float fontSize = ImGui::GetFontSize();
 		float height = 13.0f * fontSize;
 		ImGui::SetNextWindowPos( ImVec2( 0.5f * fontSize, m_camera->height - height - 2.0f * fontSize ), ImGuiCond_Once );

--- a/src/body.c
+++ b/src/body.c
@@ -19,6 +19,8 @@
 
 #include <string.h>
 
+_Static_assert( B2_NAME_LENGTH >= 1, "minimum name length" );
+
 static void b2LimitVelocity( b2BodyState* state, float maxLinearSpeed )
 {
 	float v2 = b2LengthSquared( state->linearVelocity );
@@ -234,6 +236,8 @@ b2BodyId b2CreateBody( b2WorldId worldId, const b2BodyDef* def )
 	bodySim->flags |= def->isBullet ? b2_isBullet : 0;
 	bodySim->flags |= def->allowFastRotation ? b2_allowFastRotation : 0;
 	bodySim->flags |= def->type == b2_dynamicBody ? b2_dynamicFlag : 0;
+	bodySim->flags |= def->enableSleep ? b2_enableSleep : 0;
+	bodySim->flags |= def->enableContactRecycling ? b2_bodyEnableContactRecycling : 0;
 
 	if ( setId == b2_awakeSet )
 	{
@@ -299,7 +303,6 @@ b2BodyId b2CreateBody( b2WorldId worldId, const b2BodyDef* def )
 	body->sleepTime = 0.0f;
 	body->type = def->type;
 	body->flags = bodySim->flags;
-	body->enableSleep = def->enableSleep;
 
 	// dynamic and kinematic bodies that are enabled need a island
 	if ( setId >= b2_awakeSet )
@@ -1560,7 +1563,7 @@ bool b2Body_IsSleepEnabled( b2BodyId bodyId )
 {
 	b2World* world = b2GetWorld( bodyId.world0 );
 	b2Body* body = b2GetBodyFullId( world, bodyId );
-	return body->enableSleep;
+	return (body->flags & b2_enableSleep) == b2_enableSleep;
 }
 
 void b2Body_SetSleepThreshold( b2BodyId bodyId, float sleepThreshold )
@@ -1586,7 +1589,14 @@ void b2Body_EnableSleep( b2BodyId bodyId, bool enableSleep )
 	}
 
 	b2Body* body = b2GetBodyFullId( world, bodyId );
-	body->enableSleep = enableSleep;
+
+	bool flag = ( body->flags & b2_enableSleep ) == b2_enableSleep;
+	if ( enableSleep == flag )
+	{
+		return;
+	}
+
+	body->flags = enableSleep ? body->flags | b2_enableSleep : body->flags & ~b2_enableSleep;
 
 	if ( enableSleep == false )
 	{

--- a/src/body.c
+++ b/src/body.c
@@ -282,7 +282,8 @@ b2BodyId b2CreateBody( b2WorldId worldId, const b2BodyDef* def )
 #if defined( _MSC_VER )
 		strncpy_s( body->name, B2_NAME_LENGTH + 1, def->name, B2_NAME_LENGTH );
 #else
-		strncpy( body->name, def->name, B2_NAME_LENGTH + 1 );
+		strncpy( body->name, def->name, B2_NAME_LENGTH );
+		body->name[B2_NAME_LENGTH] = 0;
 #endif
 	}
 	else
@@ -1307,7 +1308,8 @@ void b2Body_SetName( b2BodyId bodyId, const char* name )
 #if defined( _MSC_VER )
 		strncpy_s( body->name, B2_NAME_LENGTH + 1, name, B2_NAME_LENGTH );
 #else
-		strncpy( body->name, name, B2_NAME_LENGTH + 1 );
+		strncpy( body->name, name, B2_NAME_LENGTH );
+		body->name[B2_NAME_LENGTH] = 0;
 #endif
 	}
 	else
@@ -1848,6 +1850,35 @@ bool b2Body_IsBullet( b2BodyId bodyId )
 	b2Body* body = b2GetBodyFullId( world, bodyId );
 	b2BodySim* bodySim = b2GetBodySim( world, body );
 	return ( bodySim->flags & b2_isBullet ) != 0;
+}
+
+void b2Body_EnableContactRecycling( b2BodyId bodyId, bool flag )
+{
+	b2World* world = b2GetWorldLocked( bodyId.world0 );
+	if ( world == NULL )
+	{
+		return;
+	}
+
+	uint32_t newFlag = flag ? b2_bodyEnableContactRecycling : 0;
+
+	b2Body* body = b2GetBodyFullId( world, bodyId );
+	if ( ( body->flags & b2_bodyEnableContactRecycling ) == newFlag )
+	{
+		return;
+	}
+
+	body->flags &= ~b2_bodyEnableContactRecycling;
+	body->flags |= newFlag;
+
+	b2SyncBodyFlags( world, body );
+}
+
+bool b2Body_IsContactRecyclingEnabled( b2BodyId bodyId )
+{
+	b2World* world = b2GetWorld( bodyId.world0 );
+	b2Body* body = b2GetBodyFullId( world, bodyId );
+	return ( body->flags & b2_bodyEnableContactRecycling ) != 0;
 }
 
 void b2Body_EnableContactEvents( b2BodyId bodyId, bool flag )

--- a/src/body.c
+++ b/src/body.c
@@ -19,7 +19,7 @@
 
 #include <string.h>
 
-_Static_assert( B2_NAME_LENGTH >= 1, "minimum name length" );
+_Static_assert( B2_NAME_LENGTH >= 0, "minimum name length" );
 
 static void b2LimitVelocity( b2BodyState* state, float maxLinearSpeed )
 {
@@ -88,7 +88,7 @@ b2BodyState* b2GetBodyState( b2World* world, b2Body* body )
 	return NULL;
 }
 
-static void b2SyncBodyFlags( b2World* world, b2Body* body )
+void b2SyncBodyFlags( b2World* world, b2Body* body )
 {
 	// Never sync transient flags
 	uint32_t flags = body->flags & ~b2_bodyTransientFlags;
@@ -279,22 +279,15 @@ b2BodyId b2CreateBody( b2WorldId worldId, const b2BodyDef* def )
 
 	if ( def->name )
 	{
-		int i = 0;
-		while ( i < B2_NAME_LENGTH - 1 && def->name[i] != 0 )
-		{
-			body->name[i] = def->name[i];
-			i += 1;
-		}
-
-		while ( i < B2_NAME_LENGTH )
-		{
-			body->name[i] = 0;
-			i += 1;
-		}
+#if defined( _MSC_VER )
+		strncpy_s( body->name, B2_NAME_LENGTH + 1, def->name, B2_NAME_LENGTH );
+#else
+		strncpy( body->name, def->name, B2_NAME_LENGTH + 1 );
+#endif
 	}
 	else
 	{
-		memset( body->name, 0, B2_NAME_LENGTH * sizeof( char ) );
+		memset( body->name, 0, sizeof( body->name ) );
 	}
 
 	body->userData = def->userData;
@@ -1311,22 +1304,15 @@ void b2Body_SetName( b2BodyId bodyId, const char* name )
 
 	if ( name )
 	{
-		int i = 0;
-		while ( i < B2_NAME_LENGTH - 1 && name[i] != 0 )
-		{
-			body->name[i] = name[i];
-			i += 1;
-		}
-
-		while ( i < B2_NAME_LENGTH )
-		{
-			body->name[i] = 0;
-			i += 1;
-		}
+#if defined( _MSC_VER )
+		strncpy_s( body->name, B2_NAME_LENGTH + 1, name, B2_NAME_LENGTH );
+#else
+		strncpy( body->name, name, B2_NAME_LENGTH + 1 );
+#endif
 	}
 	else
 	{
-		memset( body->name, 0, B2_NAME_LENGTH * sizeof( char ) );
+		memset( body->name, 0, sizeof( body->name ) );
 	}
 }
 
@@ -1609,6 +1595,7 @@ void b2Body_EnableSleep( b2BodyId bodyId, bool enableSleep )
 	}
 
 	body->flags = enableSleep ? body->flags | b2_enableSleep : body->flags & ~b2_enableSleep;
+	b2SyncBodyFlags( world, body );
 
 	if ( enableSleep == false )
 	{
@@ -1841,17 +1828,18 @@ void b2Body_SetBullet( b2BodyId bodyId, bool flag )
 		return;
 	}
 
-	b2Body* body = b2GetBodyFullId( world, bodyId );
-	b2BodySim* bodySim = b2GetBodySim( world, body );
+	uint32_t newFlag = flag ? b2_isBullet : 0;
 
-	if ( flag )
+	b2Body* body = b2GetBodyFullId( world, bodyId );
+	if ((body->flags & b2_isBullet) == newFlag)
 	{
-		bodySim->flags |= b2_isBullet;
+		return;
 	}
-	else
-	{
-		bodySim->flags &= ~b2_isBullet;
-	}
+
+	body->flags &= ~b2_isBullet;
+	body->flags |= newFlag;
+
+	b2SyncBodyFlags( world, body );
 }
 
 bool b2Body_IsBullet( b2BodyId bodyId )

--- a/src/body.c
+++ b/src/body.c
@@ -88,6 +88,21 @@ b2BodyState* b2GetBodyState( b2World* world, b2Body* body )
 	return NULL;
 }
 
+static void b2SyncBodyFlags( b2World* world, b2Body* body )
+{
+	// Never sync transient flags
+	uint32_t flags = body->flags & ~b2_bodyTransientFlags;
+
+	b2BodySim* bodySim = b2GetBodySim( world, body );
+	bodySim->flags = flags;
+
+	b2BodyState* bodyState = b2GetBodyState( world, body );
+	if ( bodyState != NULL )
+	{
+		bodyState->flags = flags;
+	}
+}
+
 static void b2CreateIslandForBody( b2World* world, int setIndex, b2Body* body )
 {
 	B2_ASSERT( body->islandId == B2_NULL_INDEX );
@@ -1129,6 +1144,8 @@ void b2Body_SetType( b2BodyId bodyId, b2BodyType type )
 			body->flags &= ~b2_dynamicFlag;
 		}
 
+		b2SyncBodyFlags( world, body );
+
 		// Body type affects the mass properties
 		b2UpdateBodyMassData( world, body );
 		return;
@@ -1278,15 +1295,10 @@ void b2Body_SetType( b2BodyId bodyId, b2BodyType type )
 		b2LinkJoint( world, joint );
 	}
 
+	b2SyncBodyFlags( world, body );
+
 	// Body type affects the mass
 	b2UpdateBodyMassData( world, body );
-
-	b2BodyState* state = b2GetBodyState( world, body );
-	if ( state != NULL )
-	{
-		// Ensure flags are in sync (b2_skipSolverWrite)
-		state->flags = body->flags;
-	}
 
 	b2ValidateSolverSets( world );
 	b2ValidateIsland( world, body->islandId );
@@ -1563,7 +1575,7 @@ bool b2Body_IsSleepEnabled( b2BodyId bodyId )
 {
 	b2World* world = b2GetWorld( bodyId.world0 );
 	b2Body* body = b2GetBodyFullId( world, bodyId );
-	return (body->flags & b2_enableSleep) == b2_enableSleep;
+	return ( body->flags & b2_enableSleep ) == b2_enableSleep;
 }
 
 void b2Body_SetSleepThreshold( b2BodyId bodyId, float sleepThreshold )
@@ -1785,16 +1797,12 @@ void b2Body_SetMotionLocks( b2BodyId bodyId, b2MotionLocks locks )
 		body->flags &= ~b2_allLocks;
 		body->flags |= newFlags;
 
-		b2BodySim* bodySim = b2GetBodySim( world, body );
-		bodySim->flags &= ~b2_allLocks;
-		bodySim->flags |= newFlags;
+		b2SyncBodyFlags( world, body );
 
 		b2BodyState* state = b2GetBodyState( world, body );
 
 		if ( state != NULL )
 		{
-			state->flags = bodySim->flags;
-
 			if ( locks.linearX )
 			{
 				state->linearVelocity.x = 0.0f;

--- a/src/body.h
+++ b/src/body.h
@@ -58,6 +58,7 @@ enum b2BodyFlags
 	b2_allLocks = b2_lockAngularZ | b2_lockLinearX | b2_lockLinearY,
 
 	// If this flag is set then the body has fixed rotation
+	// todo use this to set the inverse inertia to zero
 	b2_fixedRotation = b2_lockAngularZ,
 
 	// These flags are transient per time step. These may be different across b2Body, b2BodySim, and b2BodyState.

--- a/src/body.h
+++ b/src/body.h
@@ -57,7 +57,7 @@ enum b2BodyFlags
 	// All lock flags
 	b2_allLocks = b2_lockAngularZ | b2_lockLinearX | b2_lockLinearY,
 
-	// If all this flags is set then the body has fixed rotation
+	// If this flag is set then the body has fixed rotation
 	b2_fixedRotation = b2_lockAngularZ,
 
 	// These flags are transient per time step. These may be different across b2Body, b2BodySim, and b2BodyState.
@@ -119,7 +119,7 @@ typedef struct b2Body
 	// Used to check for invalid b2BodyId
 	uint16_t generation;
 
-	char name[B2_NAME_LENGTH];
+	char name[B2_NAME_LENGTH + 1];
 } b2Body;
 
 // Body State
@@ -223,12 +223,13 @@ bool b2ShouldBodiesCollide( b2World* world, b2Body* bodyA, b2Body* bodyB );
 
 b2BodySim* b2GetBodySim( b2World* world, b2Body* body );
 b2BodyState* b2GetBodyState( b2World* world, b2Body* body );
-void b2RemoveBodySim( b2Array( b2BodySim )* bodySims, b2Array( b2Body )* bodies, int localIndex );
+void b2RemoveBodySim( b2Array( b2BodySim ) * bodySims, b2Array( b2Body ) * bodies, int localIndex );
 
 // careful calling this because it can invalidate body, state, joint, and contact pointers
 bool b2WakeBody( b2World* world, b2Body* body );
 
 void b2UpdateBodyMassData( b2World* world, b2Body* body );
+void b2SyncBodyFlags( b2World* world, b2Body* body );
 
 static inline b2Sweep b2MakeSweep( const b2BodySim* bodySim )
 {

--- a/src/body.h
+++ b/src/body.h
@@ -5,11 +5,9 @@
 
 #include "container.h"
 
+#include "box2d/constants.h"
 #include "box2d/math_functions.h"
 #include "box2d/types.h"
-
-// Length of body debug name
-#define B2_NAME_LENGTH 32
 
 typedef struct b2World b2World;
 
@@ -52,15 +50,20 @@ enum b2BodyFlags
 	// computation but b2Body_ApplyMassFromShapes was not called before the world step.
 	b2_dirtyMass = 0x00000400,
 
+	b2_enableSleep = 0x00000800,
+
+	b2_bodyEnableContactRecycling = 0x00001000,
+
 	// All lock flags
 	b2_allLocks = b2_lockAngularZ | b2_lockLinearX | b2_lockLinearY,
+
+	// If all this flags is set then the body has fixed rotation
+	b2_fixedRotation = b2_lockAngularZ,
 };
 
 // Body organizational details that are not used in the solver.
 typedef struct b2Body
 {
-	char name[B2_NAME_LENGTH];
-
 	void* userData;
 
 	// index of solver set stored in b2World
@@ -113,8 +116,7 @@ typedef struct b2Body
 	// Used to check for invalid b2BodyId
 	uint16_t generation;
 
-	// todo move into flags
-	bool enableSleep;
+	char name[B2_NAME_LENGTH];
 } b2Body;
 
 // Body State

--- a/src/body.h
+++ b/src/body.h
@@ -59,6 +59,9 @@ enum b2BodyFlags
 
 	// If all this flags is set then the body has fixed rotation
 	b2_fixedRotation = b2_lockAngularZ,
+
+	// These flags are transient per time step. These may be different across b2Body, b2BodySim, and b2BodyState.
+	b2_bodyTransientFlags = b2_isFast | b2_isSpeedCapped | b2_hadTimeOfImpact,
 };
 
 // Body organizational details that are not used in the solver.

--- a/src/broad_phase.c
+++ b/src/broad_phase.c
@@ -413,6 +413,8 @@ void b2UpdateBroadPhasePairs( b2World* world )
 {
 	b2BroadPhase* bp = &world->broadPhase;
 
+	b2ValidateMovedProxies( bp );
+
 	int moveCount = bp->moveArray.count;
 
 	if ( moveCount == 0 )
@@ -562,6 +564,30 @@ void b2ValidateNoEnlarged( const b2BroadPhase* bp )
 		const b2DynamicTree* tree = bp->trees + j;
 		b2DynamicTree_ValidateNoEnlarged( tree );
 	}
+#else
+	B2_UNUSED( bp );
+#endif
+}
+
+void b2ValidateMovedProxies( const b2BroadPhase* bp )
+{
+#if B2_ENABLE_VALIDATION == 1
+	// Invariant: bit set in movedProxies[type] iff proxyKey is present in moveArray.
+	int moveCount = bp->moveArray.count;
+	for ( int i = 0; i < moveCount; ++i )
+	{
+		int proxyKey = bp->moveArray.data[i];
+		b2BodyType proxyType = B2_PROXY_TYPE( proxyKey );
+		int proxyId = B2_PROXY_ID( proxyKey );
+		B2_ASSERT( b2GetBit( &bp->movedProxies[proxyType], proxyId ) );
+	}
+
+	int totalSetBits = 0;
+	for ( int i = 0; i < b2_bodyTypeCount; ++i )
+	{
+		totalSetBits += b2CountSetBits( (b2BitSet*)&bp->movedProxies[i] );
+	}
+	B2_ASSERT( totalSetBits == moveCount );
 #else
 	B2_UNUSED( bp );
 #endif

--- a/src/broad_phase.c
+++ b/src/broad_phase.c
@@ -34,7 +34,9 @@ void b2CreateBroadPhase( b2BroadPhase* bp, const b2Capacity* capacity )
 	//	fprintf(s_file, "============\n\n");
 	// }
 
-	bp->moveSet = b2CreateSet( b2MaxInt( 16, 2 * capacity->dynamicShapeCount ) );
+	bp->movedProxies[b2_staticBody] = b2CreateBitSet( b2MaxInt( 16, capacity->staticShapeCount ) );
+	bp->movedProxies[b2_kinematicBody] = b2CreateBitSet( 16 );
+	bp->movedProxies[b2_dynamicBody] = b2CreateBitSet( b2MaxInt( 16, capacity->dynamicShapeCount ) );
 	b2Array_CreateN( bp->moveArray, b2MaxInt( 16, capacity->dynamicShapeCount ) );
 	bp->moveResults = NULL;
 	bp->movePairs = NULL;
@@ -59,7 +61,10 @@ void b2DestroyBroadPhase( b2BroadPhase* bp )
 		b2DynamicTree_Destroy( bp->trees + i );
 	}
 
-	b2DestroySet( &bp->moveSet );
+	for ( int i = 0; i < b2_bodyTypeCount; ++i )
+	{
+		b2DestroyBitSet( &bp->movedProxies[i] );
+	}
 	b2Array_Destroy( bp->moveArray );
 	b2DestroySet( &bp->pairSet );
 
@@ -74,10 +79,14 @@ void b2DestroyBroadPhase( b2BroadPhase* bp )
 
 static inline void b2UnBufferMove( b2BroadPhase* bp, int proxyKey )
 {
-	bool found = b2RemoveKey( &bp->moveSet, proxyKey + 1 );
+	b2BodyType proxyType = B2_PROXY_TYPE( proxyKey );
+	int proxyId = B2_PROXY_ID( proxyKey );
+	b2BitSet* set = &bp->movedProxies[proxyType];
 
-	if ( found )
+	if ( b2GetBit( set, proxyId ) )
 	{
+		b2ClearBit( set, proxyId );
+
 		// Purge from move buffer. Linear search.
 		// todo if I can iterate the move set then I don't need the moveArray
 		int count = bp->moveArray.count;
@@ -107,7 +116,6 @@ int b2BroadPhase_CreateProxy( b2BroadPhase* bp, b2BodyType proxyType, b2AABB aab
 
 void b2BroadPhase_DestroyProxy( b2BroadPhase* bp, int proxyKey )
 {
-	B2_ASSERT( bp->moveArray.count == (int)bp->moveSet.count );
 	b2UnBufferMove( bp, proxyKey );
 
 	b2BodyType proxyType = B2_PROXY_TYPE( proxyKey );
@@ -182,22 +190,16 @@ static bool b2PairQueryCallback( int proxyId, uint64_t userData, void* context )
 
 	// De-duplication
 	// It is important to prevent duplicate contacts from being created. Ideally I can prevent duplicates
-	// early and in the worker. Most of the time the moveSet contains dynamic and kinematic proxies, but
-	// sometimes it has static proxies.
-
-	// I had an optimization here to skip checking the move set if this is a query into
-	// the static tree. The assumption is that the static proxies are never in the move set
-	// so there is no risk of duplication. However, this is not true with
-	// b2ShapeDef::invokeContactCreation or when a static shape is modified.
-	// There can easily be scenarios where the static proxy is in the moveSet but the dynamic proxy is not.
-	// I could have some flag to indicate that there are any static bodies in the moveSet.
+	// early and in the worker. Most of the time the movedProxies bit sets contain dynamic and kinematic
+	// proxies, but sometimes static proxies are in there too (b2ShapeDef::invokeContactCreation or a
+	// modified static shape), so we always have to check.
 
 	// Is this proxy also moving?
 	if ( queryProxyType == b2_dynamicBody )
 	{
 		if ( treeType == b2_dynamicBody && proxyKey < queryProxyKey )
 		{
-			bool moved = b2ContainsKey( &broadPhase->moveSet, proxyKey + 1 );
+			bool moved = b2GetBit( &broadPhase->movedProxies[treeType], proxyId );
 			if ( moved )
 			{
 				// Both proxies are moving. Avoid duplicate pairs.
@@ -208,7 +210,7 @@ static bool b2PairQueryCallback( int proxyId, uint64_t userData, void* context )
 	else
 	{
 		B2_ASSERT( treeType == b2_dynamicBody );
-		bool moved = b2ContainsKey( &broadPhase->moveSet, proxyKey + 1 );
+		bool moved = b2GetBit( &broadPhase->movedProxies[treeType], proxyId );
 		if ( moved )
 		{
 			// Both proxies are moving. Avoid duplicate pairs.
@@ -412,7 +414,6 @@ void b2UpdateBroadPhasePairs( b2World* world )
 	b2BroadPhase* bp = &world->broadPhase;
 
 	int moveCount = bp->moveArray.count;
-	B2_ASSERT( moveCount == (int)bp->moveSet.count );
 
 	if ( moveCount == 0 )
 	{
@@ -505,9 +506,14 @@ void b2UpdateBroadPhasePairs( b2World* world )
 	//	fprintf(s_file, "count = %d\n\n", pairCount);
 	// }
 
-	// Reset move buffer
+	// Reset move buffer: clear only the bits that were set this step.
+	// Invariant: bit set in movedProxies[type] iff proxyKey is present in moveArray.
+	for ( int i = 0; i < bp->moveArray.count; ++i )
+	{
+		int proxyKey = bp->moveArray.data[i];
+		b2ClearBit( &bp->movedProxies[B2_PROXY_TYPE( proxyKey )], B2_PROXY_ID( proxyKey ) );
+	}
 	b2Array_Clear( bp->moveArray );
-	b2ClearSet( &bp->moveSet );
 
 	b2StackFree( alloc, bp->movePairs );
 	bp->movePairs = NULL;

--- a/src/broad_phase.h
+++ b/src/broad_phase.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "bitset.h"
 #include "container.h"
 #include "table.h"
 
@@ -27,12 +28,9 @@ typedef struct b2BroadPhase
 {
 	b2DynamicTree trees[b2_bodyTypeCount];
 
-	// The move set and array are used to track shapes that have moved significantly
-	// and need a pair query for new contacts. The array has a deterministic order.
-	// todo perhaps just a move set?
-	// todo implement a 32bit hash set for faster lookup
-	// todo moveSet can grow quite large on the first time step and remain large
-	b2HashSet moveSet;
+	// Per body-type bit sets indexed by proxyId, marking proxies moved this step.
+	// Paired with moveArray which preserves deterministic insertion order for pair queries.
+	b2BitSet movedProxies[b2_bodyTypeCount];
 	b2Array( int ) moveArray;
 
 	// These are the results from the pair query and are used to create new contacts
@@ -70,10 +68,12 @@ void b2ValidateNoEnlarged( const b2BroadPhase* bp );
 // Warning: this must be called in deterministic order
 static inline void b2BufferMove( b2BroadPhase* bp, int queryProxy )
 {
-	// Adding 1 because 0 is the sentinel
-	bool alreadyAdded = b2AddKey( &bp->moveSet, queryProxy + 1 );
-	if ( alreadyAdded == false )
+	b2BodyType proxyType = B2_PROXY_TYPE( queryProxy );
+	int proxyId = B2_PROXY_ID( queryProxy );
+	b2BitSet* set = &bp->movedProxies[proxyType];
+	if ( b2GetBit( set, proxyId ) == false )
 	{
+		b2SetBitGrow( set, proxyId );
 		b2Array_Push( bp->moveArray, queryProxy );
 	}
 }

--- a/src/broad_phase.h
+++ b/src/broad_phase.h
@@ -63,6 +63,7 @@ bool b2BroadPhase_TestOverlap( const b2BroadPhase* bp, int proxyKeyA, int proxyK
 
 void b2ValidateBroadphase( const b2BroadPhase* bp );
 void b2ValidateNoEnlarged( const b2BroadPhase* bp );
+void b2ValidateMovedProxies( const b2BroadPhase* bp );
 
 // This is what triggers new contact pairs to be created
 // Warning: this must be called in deterministic order

--- a/src/contact.c
+++ b/src/contact.c
@@ -283,8 +283,13 @@ void b2CreateContact( b2World* world, b2Shape* shapeA, b2Shape* shapeB )
 	contact->islandIndex = B2_NULL_INDEX;
 	contact->shapeIdA = shapeIdA;
 	contact->shapeIdB = shapeIdB;
-	//contact->isMarked = false;
 	contact->flags = 0;
+
+	// Both bodies must enable recycling
+	if ( ( bodyA->flags & b2_bodyEnableContactRecycling ) != 0 && ( bodyB->flags & b2_bodyEnableContactRecycling ) != 0 )
+	{
+		contact->flags |= b2_contactRecycleFlag;
+	}
 
 	B2_ASSERT( shapeA->sensorIndex == B2_NULL_INDEX && shapeB->sensorIndex == B2_NULL_INDEX );
 
@@ -359,7 +364,7 @@ void b2CreateContact( b2World* world, b2Shape* shapeA, b2Shape* shapeB )
 														  shapeB->material.restitution, shapeB->material.userMaterialId );
 
 	contactSim->tangentSpeed = 0.0f;
-	contactSim->simFlags = 0;
+	contactSim->simFlags = contact->flags;
 
 	if ( shapeA->enablePreSolveEvents || shapeB->enablePreSolveEvents )
 	{

--- a/src/contact.h
+++ b/src/contact.h
@@ -22,6 +22,29 @@ enum b2ContactFlags
 
 	// This contact wants contact events
 	b2_contactEnableContactEvents = 0x00000004,
+
+	b2_contactRecycleFlag = 0x00000008,
+
+	// Set when the shapes are touching
+	b2_simTouchingFlag = 0x00010000,
+
+	// This contact no longer has overlapping AABBs
+	b2_simDisjoint = 0x00020000,
+
+	// This contact started touching
+	b2_simStartedTouching = 0x00040000,
+
+	// This contact stopped touching
+	b2_simStoppedTouching = 0x00080000,
+
+	// This contact has a hit event
+	b2_simEnableHitEvent = 0x00100000,
+
+	// This contact wants pre-solve events
+	b2_simEnablePreSolveEvents = 0x00200000,
+
+	// This contact has a cached relative transform
+	b2_simRelativeTransformValid = 0x00400000,
 };
 
 // A contact edge is used to connect bodies and contacts together
@@ -74,31 +97,6 @@ typedef struct b2Contact
 	uint32_t generation;
 } b2Contact;
 
-// Shifted to be distinct from b2ContactFlags
-enum b2ContactSimFlags
-{
-	// Set when the shapes are touching
-	b2_simTouchingFlag = 0x00010000,
-
-	// This contact no longer has overlapping AABBs
-	b2_simDisjoint = 0x00020000,
-
-	// This contact started touching
-	b2_simStartedTouching = 0x00040000,
-
-	// This contact stopped touching
-	b2_simStoppedTouching = 0x00080000,
-
-	// This contact has a hit event
-	b2_simEnableHitEvent = 0x00100000,
-
-	// This contact wants pre-solve events
-	b2_simEnablePreSolveEvents = 0x00200000,
-
-	// This contact has a cached relative transform
-	b2_simRelativeTransformValid = 0x00400000,
-};
-
 /// The class manages contact between two shapes. A contact exists for each overlapping
 /// AABB in the broad-phase (except if filtered). Therefore a contact object may exist
 /// that has no contact points.
@@ -135,7 +133,7 @@ typedef struct b2ContactSim
 	float rollingResistance;
 	float tangentSpeed;
 
-	// b2ContactSimFlags
+	// b2ContactFlags
 	uint32_t simFlags;
 
 	b2SimplexCache cache;

--- a/src/core.h
+++ b/src/core.h
@@ -7,8 +7,6 @@
 
 // clang-format off
 
-#define B2_NULL_INDEX ( -1 )
-
 // for performance comparisons
 #define B2_RESTRICT restrict
 

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -2893,6 +2893,15 @@ void b2ValidateSolverSets( b2World* world )
 					B2_ASSERT( body->setIndex == setIndex );
 					B2_ASSERT( body->localIndex == i );
 
+					uint32_t syncedFlags = body->flags & ~b2_bodyTransientFlags;
+					B2_ASSERT( ( bodySim->flags & syncedFlags ) == syncedFlags );
+
+					b2BodyState* bodyState = b2GetBodyState( world, body );
+					if ( bodyState != NULL )
+					{
+						B2_ASSERT( ( bodyState->flags & syncedFlags ) == syncedFlags );
+					}
+
 					if ( body->type == b2_dynamicBody )
 					{
 						B2_ASSERT( body->flags & b2_dynamicFlag );

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -954,7 +954,7 @@ void b2World_Step( b2WorldId worldId, float timeStep, int subStepCount )
 	b2TracyCFrame;
 }
 
-static void b2DrawShape( b2DebugDraw* draw, b2Shape* shape, b2Transform xf, b2HexColor color )
+static void b2DrawShape( b2DebugDraw* draw, b2Shape* shape, b2Transform xf, b2HexColor color, bool drawChainNormals )
 {
 	switch ( shape->type )
 	{
@@ -998,7 +998,15 @@ static void b2DrawShape( b2DebugDraw* draw, b2Shape* shape, b2Transform xf, b2He
 			b2Vec2 p2 = b2TransformPoint( xf, segment->point2 );
 			draw->DrawLineFcn( p1, p2, color, draw->context );
 			draw->DrawPointFcn( p2, 4.0f, color, draw->context );
-			draw->DrawLineFcn( p1, b2Lerp( p1, p2, 0.1f ), b2_colorPaleGreen, draw->context );
+
+			if (drawChainNormals)
+			{
+				b2Vec2 c = b2Lerp( p1, p2, 0.5f );
+				b2Vec2 e = b2Normalize( b2Sub( p2, p1 ) );
+				b2Vec2 n = b2RightPerp( e );
+				float L = 0.2f * b2GetLengthUnitsPerMeter();
+				draw->DrawLineFcn( c, b2MulAdd( c, L, n ), b2_colorPaleGreen, draw->context );
+			}
 		}
 		break;
 
@@ -1085,7 +1093,7 @@ static bool DrawQueryCallback( int proxyId, uint64_t userData, void* context )
 			color = b2_colorGray;
 		}
 
-		b2DrawShape( draw, shape, bodySim->transform, color );
+		b2DrawShape( draw, shape, bodySim->transform, color, draw->drawChainNormals );
 	}
 
 	if ( draw->drawBounds )
@@ -1955,8 +1963,12 @@ void b2World_DumpMemoryStats( b2WorldId worldId )
 	fprintf( file, "static tree: %d\n", b2DynamicTree_GetByteCount( world->broadPhase.trees + b2_staticBody ) );
 	fprintf( file, "kinematic tree: %d\n", b2DynamicTree_GetByteCount( world->broadPhase.trees + b2_kinematicBody ) );
 	fprintf( file, "dynamic tree: %d\n", b2DynamicTree_GetByteCount( world->broadPhase.trees + b2_dynamicBody ) );
-	b2HashSet* moveSet = &world->broadPhase.moveSet;
-	fprintf( file, "moveSet: %d (%u, %u)\n", b2GetHashSetBytes( moveSet ), moveSet->count, moveSet->capacity );
+	int movedBytes = 0;
+	for ( int i = 0; i < b2_bodyTypeCount; ++i )
+	{
+		movedBytes += b2GetBitSetBytes( &world->broadPhase.movedProxies[i] );
+	}
+	fprintf( file, "movedProxies: %d\n", movedBytes );
 	fprintf( file, "moveArray: %d\n", b2Array_ByteCount( world->broadPhase.moveArray ) );
 	b2HashSet* pairSet = &world->broadPhase.pairSet;
 	fprintf( file, "pairSet: %d (%u, %u)\n", b2GetHashSetBytes( pairSet ), pairSet->count, pairSet->capacity );

--- a/src/physics_world.c
+++ b/src/physics_world.c
@@ -420,6 +420,11 @@ void b2DestroyWorld( b2WorldId worldId )
 	world->generation = generation + 1;
 }
 
+static inline float b2RelativeCos( b2Rot a, b2Rot b )
+{
+	return a.c * b.c + a.s * b.s;
+}
+
 static void b2CollideTask( int startIndex, int endIndex, int workerIndex, void* context )
 {
 	b2TracyCZoneNC( collide_task, "Collide", b2_colorDodgerBlue, true );
@@ -478,10 +483,16 @@ static void b2CollideTask( int startIndex, int endIndex, int workerIndex, void* 
 			// Contact recycling optimization. Please cite this code if you use this optimization.
 			// This is inspired by persistent contact manifolds used in some physics engines, such as PhysX.
 			// However, this allows larger relative motion and has fewer tuning parameters (just one).
-			if ( recycleDistance > 0.0f && contactSim->simFlags & b2_simRelativeTransformValid )
+			if ( recycleDistance > 0.0f && ( contactSim->simFlags & b2_simRelativeTransformValid ) &&
+				 ( contactSim->simFlags & b2_contactRecycleFlag ) )
 			{
 				b2Transform xf = b2InvMulTransforms( transformA, transformB );
 				b2Transform xfc = b2InvMulTransforms( contactSim->cachedTransformA, contactSim->cachedTransformB );
+
+				float cosA = b2RelativeCos( transformA.q, contactSim->cachedTransformA.q );
+				float cosB = b2RelativeCos( transformB.q, contactSim->cachedTransformB.q );
+				float minCos = b2MinFloat( cosA, cosB );
+
 				float maxExtentA = bodyA->type == b2_staticBody ? 0.0f : bodySimA->maxExtent;
 				float maxExtentB = bodyB->type == b2_staticBody ? 0.0f : bodySimB->maxExtent;
 				float maxExtent = b2MaxFloat( maxExtentA, maxExtentB );
@@ -492,7 +503,8 @@ static void b2CollideTask( int startIndex, int endIndex, int workerIndex, void* 
 				// Note that qr.s == sin(theta) ~= theta for small angles.
 				// Need a tighter tolerance for non-touching shapes so that contacts are not missed.
 				float tolerance = wasTouching ? recycleDistance : recycleDistanceNonTouching;
-				if ( distance + maxExtent * b2AbsFloat( qr.s ) < tolerance )
+
+				if ( minCos > B2_CONTACT_RECYCLE_COS_ANGLE && distance + maxExtent * b2AbsFloat( qr.s ) < tolerance )
 				{
 					b2Rot dqA = b2MulRot( transformA.q, b2InvertRot( contactSim->cachedTransformA.q ) );
 					b2Rot dqB = b2MulRot( transformB.q, b2InvertRot( contactSim->cachedTransformB.q ) );

--- a/src/shape.c
+++ b/src/shape.c
@@ -394,9 +394,10 @@ void b2DestroyShape( b2ShapeId shapeId, bool updateBodyMass )
 
 	b2Shape* shape = b2GetShape( world, shapeId );
 
-	if (shape->type == b2_chainSegmentShape && shape->chainSegment.chainId != B2_NULL_INDEX)
+	// Cannot destroy a chain segment that has a parent chain shape
+	if ( shape->type == b2_chainSegmentShape && shape->chainSegment.chainId != B2_NULL_INDEX )
 	{
-		b2Log( "Cannot destroy a chain segment that is part of a chain shape" );
+		B2_ASSERT( false );
 		return;
 	}
 

--- a/src/shape.c
+++ b/src/shape.c
@@ -277,6 +277,22 @@ b2ShapeId b2CreateSegmentShape( b2BodyId bodyId, const b2ShapeDef* def, const b2
 	return b2CreateShape( bodyId, def, segment, b2_segmentShape );
 }
 
+b2ShapeId b2CreateChainSegmentShape( b2BodyId bodyId, const b2ShapeDef* def, const b2ChainSegment* chainSegment )
+{
+	float lengthSqr = b2DistanceSquared( chainSegment->segment.point1, chainSegment->segment.point2 );
+	if ( lengthSqr <= B2_LINEAR_SLOP * B2_LINEAR_SLOP )
+	{
+		B2_ASSERT( false );
+		return b2_nullShapeId;
+	}
+
+	// No parent chain shape
+	b2ChainSegment local = *chainSegment;
+	local.chainId = B2_NULL_INDEX;
+
+	return b2CreateShape( bodyId, def, &local, b2_chainSegmentShape );
+}
+
 // Destroy a shape on a body. This doesn't need to be called when destroying a body.
 static void b2DestroyShapeInternal( b2World* world, b2Shape* shape, b2Body* body, bool wakeBodies )
 {
@@ -1526,6 +1542,39 @@ void b2Shape_SetPolygon( b2ShapeId shapeId, const b2Polygon* polygon )
 	shape->aabbMargin = b2ComputeShapeMargin( shape );
 
 	// need to wake bodies so they can react to the shape change
+	bool wakeBodies = true;
+	bool destroyProxy = true;
+	b2ResetProxy( world, shape, wakeBodies, destroyProxy );
+}
+
+void b2Shape_SetChainSegment( b2ShapeId shapeId, const b2ChainSegment* chainSegment )
+{
+	b2World* world = b2GetWorldLocked( shapeId.world0 );
+	if ( world == NULL )
+	{
+		return;
+	}
+
+	b2Shape* shape = b2GetShape( world, shapeId );
+
+	// Cannot modify a chain segment that has a parent chain shape
+	if ( shape->type == b2_chainSegmentShape && shape->chainSegment.chainId != B2_NULL_INDEX )
+	{
+		B2_ASSERT( false );
+		return;
+	}
+
+	float lengthSqr = b2DistanceSquared( chainSegment->segment.point1, chainSegment->segment.point2 );
+	if ( lengthSqr <= B2_LINEAR_SLOP * B2_LINEAR_SLOP )
+	{
+		return;
+	}
+
+	shape->chainSegment = *chainSegment;
+	shape->chainSegment.chainId = B2_NULL_INDEX;
+	shape->type = b2_chainSegmentShape;
+	shape->aabbMargin = b2ComputeShapeMargin( shape );
+
 	bool wakeBodies = true;
 	bool destroyProxy = true;
 	b2ResetProxy( world, shape, wakeBodies, destroyProxy );

--- a/src/shape.c
+++ b/src/shape.c
@@ -232,9 +232,10 @@ static b2ShapeId b2CreateShape( b2BodyId bodyId, const b2ShapeDef* def, const vo
 	{
 		b2UpdateBodyMassData( world, body );
 	}
-	else
+	else if ( ( body->flags & b2_dirtyMass ) == 0 )
 	{
 		body->flags |= b2_dirtyMass;
+		b2SyncBodyFlags( world, body );
 	}
 
 	b2ValidateSolverSets( world );
@@ -392,6 +393,12 @@ void b2DestroyShape( b2ShapeId shapeId, bool updateBodyMass )
 	}
 
 	b2Shape* shape = b2GetShape( world, shapeId );
+
+	if (shape->type == b2_chainSegmentShape && shape->chainSegment.chainId != B2_NULL_INDEX)
+	{
+		b2Log( "Cannot destroy a chain segment that is part of a chain shape" );
+		return;
+	}
 
 	// need to wake bodies because this might be a static body
 	bool wakeBodies = true;

--- a/src/solver.c
+++ b/src/solver.c
@@ -1950,7 +1950,7 @@ void b2Solve( b2World* world, b2StepContext* stepContext )
 				B2_ASSERT( B2_PROXY_TYPE( proxyKey ) == b2_dynamicBody );
 
 				// all fast bullet shapes should already be in the move buffer
-				B2_ASSERT( b2ContainsKey( &broadPhase->moveSet, proxyKey + 1 ) );
+				B2_ASSERT( b2GetBit( &broadPhase->movedProxies[b2_dynamicBody], proxyId ) );
 
 				b2DynamicTree_EnlargeProxy( dynamicTree, proxyId, shape->fatAABB );
 

--- a/src/solver.c
+++ b/src/solver.c
@@ -619,11 +619,11 @@ static void b2FinalizeBodiesTask( int startIndex, int endIndex, int workerIndex,
 		// If you hit this then it means you deferred mass computation but never called b2Body_ApplyMassFromShapes
 		B2_ASSERT( ( body->flags & b2_dirtyMass ) == 0 );
 
-		body->flags &= ~( b2_isFast | b2_isSpeedCapped | b2_hadTimeOfImpact );
+		body->flags &= ~b2_bodyTransientFlags;
 		body->flags |= ( sim->flags & ( b2_isSpeedCapped | b2_hadTimeOfImpact ) );
 		body->flags |= ( state->flags & ( b2_isSpeedCapped | b2_hadTimeOfImpact ) );
-		sim->flags &= ~( b2_isFast | b2_isSpeedCapped | b2_hadTimeOfImpact );
-		state->flags &= ~( b2_isFast | b2_isSpeedCapped | b2_hadTimeOfImpact );
+		sim->flags &= ~b2_bodyTransientFlags;
+		state->flags &= ~b2_bodyTransientFlags;
 
 		if ( enableSleep == false || ( body->flags & b2_enableSleep ) == 0 || sleepVelocity > body->sleepThreshold )
 		{

--- a/src/solver.c
+++ b/src/solver.c
@@ -625,7 +625,7 @@ static void b2FinalizeBodiesTask( int startIndex, int endIndex, int workerIndex,
 		sim->flags &= ~( b2_isFast | b2_isSpeedCapped | b2_hadTimeOfImpact );
 		state->flags &= ~( b2_isFast | b2_isSpeedCapped | b2_hadTimeOfImpact );
 
-		if ( enableSleep == false || body->enableSleep == false || sleepVelocity > body->sleepThreshold )
+		if ( enableSleep == false || ( body->flags & b2_enableSleep ) == 0 || sleepVelocity > body->sleepThreshold )
 		{
 			// Body is not sleepy
 			body->sleepTime = 0.0f;

--- a/src/types.c
+++ b/src/types.c
@@ -35,6 +35,7 @@ b2BodyDef b2DefaultBodyDef( void )
 	def.sleepThreshold = 0.05f * b2GetLengthUnitsPerMeter();
 	def.gravityScale = 1.0f;
 	def.enableSleep = true;
+	def.enableContactRecycling = true;
 	def.isAwake = true;
 	def.isEnabled = true;
 	def.internalValue = B2_SECRET_COOKIE;

--- a/test/test_determinism.c
+++ b/test/test_determinism.c
@@ -15,8 +15,8 @@
 #define TracyCFrameMark
 #endif
 
-#define EXPECTED_SLEEP_STEP 262
-#define EXPECTED_HASH 0x3841BB81
+#define EXPECTED_SLEEP_STEP 328
+#define EXPECTED_HASH 0x26E08AEE
 
 static int SingleMultithreadingTest( int workerCount )
 {

--- a/test/test_world.c
+++ b/test/test_world.c
@@ -9,6 +9,9 @@
 #include "box2d/constants.h"
 #include "box2d/math_functions.h"
 
+#include "core.h"
+
+#include <float.h>
 #include <stdio.h>
 
 // This is a simple example of building and running a simulation
@@ -435,6 +438,101 @@ static int TestSetWorkerCount( void )
 	return 0;
 }
 
+static int ChainSegmentShapeTest( void )
+{
+	b2WorldDef worldDef = b2DefaultWorldDef();
+	worldDef.gravity = (b2Vec2){ 0.0f, -10.0f };
+	b2WorldId worldId = b2CreateWorld( &worldDef );
+
+	b2BodyDef bodyDef = b2DefaultBodyDef();
+	b2BodyId groundId = b2CreateBody( worldId, &bodyDef );
+
+	b2ChainSegment cs = { 0 };
+	cs.ghost1 = (b2Vec2){ 2.0f, 0.0f };
+	cs.segment.point1 = (b2Vec2){ 1.0f, 0.0f };
+	cs.segment.point2 = (b2Vec2){ -1.0f, 0.0f };
+	cs.ghost2 = (b2Vec2){ -2.0f, 0.0f };
+	cs.chainId = 99;
+
+	b2ShapeDef shapeDef = b2DefaultShapeDef();
+	b2ShapeId orphanShape = b2CreateChainSegmentShape( groundId, &shapeDef, &cs );
+	ENSURE( B2_IS_NON_NULL( orphanShape ) );
+
+	ENSURE( b2Shape_GetType( orphanShape ) == b2_chainSegmentShape );
+
+	b2ChainId parentChain = b2Shape_GetParentChain( orphanShape );
+	ENSURE( B2_IS_NULL( parentChain ) );
+
+	b2ChainSegment got = b2Shape_GetChainSegment( orphanShape );
+	ENSURE_SMALL( got.ghost1.x - cs.ghost1.x, 1e-5f );
+	ENSURE_SMALL( got.ghost1.y - cs.ghost1.y, 1e-5f );
+	ENSURE_SMALL( got.segment.point1.x - cs.segment.point1.x, 1e-5f );
+	ENSURE_SMALL( got.segment.point1.y - cs.segment.point1.y, 1e-5f );
+	ENSURE_SMALL( got.segment.point2.x - cs.segment.point2.x, 1e-5f );
+	ENSURE_SMALL( got.segment.point2.y - cs.segment.point2.y, 1e-5f );
+	ENSURE_SMALL( got.ghost2.x - cs.ghost2.x, 1e-5f );
+	ENSURE_SMALL( got.ghost2.y - cs.ghost2.y, 1e-5f );
+	ENSURE( got.chainId == B2_NULL_INDEX );
+
+	b2BodyDef dynamicDef = b2DefaultBodyDef();
+	dynamicDef.type = b2_dynamicBody;
+	dynamicDef.position = (b2Vec2){ 0.0f, 2.0f };
+	b2BodyId circleBodyId = b2CreateBody( worldId, &dynamicDef );
+	b2Circle circle = { { 0.0f, 0.0f }, 0.5f };
+	b2ShapeDef circleShapeDef = b2DefaultShapeDef();
+	b2CreateCircleShape( circleBodyId, &circleShapeDef, &circle );
+
+	for ( int i = 0; i < 120; ++i )
+	{
+		b2World_Step( worldId, 1.0f / 60.0f, 4 );
+	}
+
+	b2Vec2 circlePos = b2Body_GetPosition( circleBodyId );
+	ENSURE( circlePos.y > 0.0f );
+
+	b2ChainSegment cs2 = { 0 };
+	cs2.ghost1 = (b2Vec2){ 3.0f, 0.0f };
+	cs2.segment.point1 = (b2Vec2){ 2.0f, 0.0f };
+	cs2.segment.point2 = (b2Vec2){ -2.0f, 0.0f };
+	cs2.ghost2 = (b2Vec2){ -3.0f, 0.0f };
+	cs2.chainId = B2_NULL_INDEX;
+
+	b2Shape_SetChainSegment( orphanShape, &cs2 );
+
+	b2ChainSegment got2 = b2Shape_GetChainSegment( orphanShape );
+	ENSURE_SMALL( got2.segment.point1.x - cs2.segment.point1.x, 1e-5f );
+	ENSURE_SMALL( got2.segment.point1.y - cs2.segment.point1.y, 1e-5f );
+	ENSURE_SMALL( got2.segment.point2.x - cs2.segment.point2.x, 1e-5f );
+	ENSURE_SMALL( got2.segment.point2.y - cs2.segment.point2.y, 1e-5f );
+	ENSURE_SMALL( got2.ghost1.x - cs2.ghost1.x, 1e-5f );
+	ENSURE_SMALL( got2.ghost2.x - cs2.ghost2.x, 1e-5f );
+	ENSURE( got2.chainId == B2_NULL_INDEX );
+
+	b2ChainId parentChain2 = b2Shape_GetParentChain( orphanShape );
+	ENSURE( B2_IS_NULL( parentChain2 ) );
+
+	b2BodyId convBody = b2CreateBody( worldId, &bodyDef );
+	b2Circle convCircle = { { 0.0f, 0.0f }, 0.25f };
+	b2ShapeId convShape = b2CreateCircleShape( convBody, &shapeDef, &convCircle );
+	ENSURE( b2Shape_GetType( convShape ) == b2_circleShape );
+
+	b2Shape_SetChainSegment( convShape, &cs2 );
+
+	ENSURE( b2Shape_GetType( convShape ) == b2_chainSegmentShape );
+	b2ChainSegment got3 = b2Shape_GetChainSegment( convShape );
+	ENSURE_SMALL( got3.ghost1.x - cs2.ghost1.x, 1e-5f );
+	ENSURE_SMALL( got3.ghost2.x - cs2.ghost2.x, 1e-5f );
+	ENSURE( got3.chainId == B2_NULL_INDEX );
+
+	b2ChainId parentChain3 = b2Shape_GetParentChain( convShape );
+	ENSURE( B2_IS_NULL( parentChain3 ) );
+
+	b2DestroyShape( orphanShape, true );
+	b2DestroyWorld( worldId );
+
+	return 0;
+}
+
 int WorldTest( void )
 {
 	RUN_SUBTEST( HelloWorld );
@@ -445,6 +543,7 @@ int WorldTest( void )
 	RUN_SUBTEST( TestWorldCoverage );
 	RUN_SUBTEST( TestSensor );
 	RUN_SUBTEST( TestSetWorkerCount );
+	RUN_SUBTEST( ChainSegmentShapeTest );
 
 	return 0;
 }

--- a/test/test_world.c
+++ b/test/test_world.c
@@ -578,6 +578,36 @@ static int EnableSleepFlagSyncTest( void )
 	return 0;
 }
 
+static int EnableContactRecyclingTest( void )
+{
+	b2WorldDef worldDef = b2DefaultWorldDef();
+	b2WorldId worldId = b2CreateWorld( &worldDef );
+
+	b2BodyDef bodyDef = b2DefaultBodyDef();
+	bodyDef.type = b2_dynamicBody;
+
+	// Default is enabled
+	b2BodyId bodyA = b2CreateBody( worldId, &bodyDef );
+	ENSURE( b2Body_IsContactRecyclingEnabled( bodyA ) == true );
+
+	b2Body_EnableContactRecycling( bodyA, false );
+	ENSURE( b2Body_IsContactRecyclingEnabled( bodyA ) == false );
+
+	b2Body_EnableContactRecycling( bodyA, true );
+	ENSURE( b2Body_IsContactRecyclingEnabled( bodyA ) == true );
+
+	// Per-def opt-out at creation
+	bodyDef.enableContactRecycling = false;
+	b2BodyId bodyB = b2CreateBody( worldId, &bodyDef );
+	ENSURE( b2Body_IsContactRecyclingEnabled( bodyB ) == false );
+
+	// Stepping after toggling must not trip the flag-sync validator
+	b2World_Step( worldId, 1.0f / 60.0f, 4 );
+
+	b2DestroyWorld( worldId );
+	return 0;
+}
+
 static int SetBulletDriftTest( void )
 {
 	b2WorldDef worldDef = b2DefaultWorldDef();
@@ -678,6 +708,7 @@ int WorldTest( void )
 	RUN_SUBTEST( DestroyOwnedChainSegmentTest );
 	RUN_SUBTEST( DeferredMassFlagSyncTest );
 	RUN_SUBTEST( EnableSleepFlagSyncTest );
+	RUN_SUBTEST( EnableContactRecyclingTest );
 
 	return 0;
 }

--- a/test/test_world.c
+++ b/test/test_world.c
@@ -653,46 +653,6 @@ static int SetBulletDriftTest( void )
 	return 0;
 }
 
-static int DestroyOwnedChainSegmentTest( void )
-{
-	b2WorldDef worldDef = b2DefaultWorldDef();
-	b2WorldId worldId = b2CreateWorld( &worldDef );
-
-	b2BodyDef bodyDef = b2DefaultBodyDef();
-	b2BodyId groundId = b2CreateBody( worldId, &bodyDef );
-
-	b2Vec2 points[5] = {
-		{ -4.0f, 0.0f }, { -2.0f, 0.0f }, { 0.0f, 0.0f }, { 2.0f, 0.0f }, { 4.0f, 0.0f },
-	};
-	b2SurfaceMaterial material = { 0 };
-	b2ChainDef chainDef = b2DefaultChainDef();
-	chainDef.points = points;
-	chainDef.count = 5;
-	chainDef.materials = &material;
-	chainDef.materialCount = 1;
-	chainDef.isLoop = false;
-	b2ChainId chainId = b2CreateChain( groundId, &chainDef );
-
-	int segmentCount = b2Chain_GetSegmentCount( chainId );
-	ENSURE( segmentCount > 0 );
-
-	b2ShapeId segments[8] = { 0 };
-	int got = b2Chain_GetSegments( chainId, segments, segmentCount );
-	ENSURE( got == segmentCount );
-
-	for ( int i = 0; i < segmentCount; ++i )
-	{
-		b2ChainId parent = b2Shape_GetParentChain( segments[i] );
-		ENSURE( B2_IS_NON_NULL( parent ) );
-	}
-
-	b2DestroyShape( segments[0], true );
-
-	b2DestroyChain( chainId );
-	b2DestroyWorld( worldId );
-	return 0;
-}
-
 int WorldTest( void )
 {
 	RUN_SUBTEST( HelloWorld );
@@ -705,7 +665,6 @@ int WorldTest( void )
 	RUN_SUBTEST( TestSetWorkerCount );
 	RUN_SUBTEST( ChainSegmentShapeTest );
 	RUN_SUBTEST( SetBulletDriftTest );
-	RUN_SUBTEST( DestroyOwnedChainSegmentTest );
 	RUN_SUBTEST( DeferredMassFlagSyncTest );
 	RUN_SUBTEST( EnableSleepFlagSyncTest );
 	RUN_SUBTEST( EnableContactRecyclingTest );

--- a/test/test_world.c
+++ b/test/test_world.c
@@ -9,9 +9,6 @@
 #include "box2d/constants.h"
 #include "box2d/math_functions.h"
 
-#include "core.h"
-
-#include <float.h>
 #include <stdio.h>
 
 // This is a simple example of building and running a simulation
@@ -505,7 +502,9 @@ static int ChainSegmentShapeTest( void )
 	ENSURE_SMALL( got2.segment.point2.x - cs2.segment.point2.x, 1e-5f );
 	ENSURE_SMALL( got2.segment.point2.y - cs2.segment.point2.y, 1e-5f );
 	ENSURE_SMALL( got2.ghost1.x - cs2.ghost1.x, 1e-5f );
+	ENSURE_SMALL( got2.ghost1.y - cs2.ghost1.y, 1e-5f );
 	ENSURE_SMALL( got2.ghost2.x - cs2.ghost2.x, 1e-5f );
+	ENSURE_SMALL( got2.ghost2.y - cs2.ghost2.y, 1e-5f );
 	ENSURE( got2.chainId == B2_NULL_INDEX );
 
 	b2ChainId parentChain2 = b2Shape_GetParentChain( orphanShape );
@@ -521,7 +520,9 @@ static int ChainSegmentShapeTest( void )
 	ENSURE( b2Shape_GetType( convShape ) == b2_chainSegmentShape );
 	b2ChainSegment got3 = b2Shape_GetChainSegment( convShape );
 	ENSURE_SMALL( got3.ghost1.x - cs2.ghost1.x, 1e-5f );
+	ENSURE_SMALL( got3.ghost1.y - cs2.ghost1.y, 1e-5f );
 	ENSURE_SMALL( got3.ghost2.x - cs2.ghost2.x, 1e-5f );
+	ENSURE_SMALL( got3.ghost2.y - cs2.ghost2.y, 1e-5f );
 	ENSURE( got3.chainId == B2_NULL_INDEX );
 
 	b2ChainId parentChain3 = b2Shape_GetParentChain( convShape );
@@ -530,6 +531,135 @@ static int ChainSegmentShapeTest( void )
 	b2DestroyShape( orphanShape, true );
 	b2DestroyWorld( worldId );
 
+	return 0;
+}
+
+static int DeferredMassFlagSyncTest( void )
+{
+	b2WorldDef worldDef = b2DefaultWorldDef();
+	b2WorldId worldId = b2CreateWorld( &worldDef );
+
+	b2BodyDef bodyDef = b2DefaultBodyDef();
+	bodyDef.type = b2_dynamicBody;
+	b2BodyId bodyId = b2CreateBody( worldId, &bodyDef );
+
+	b2ShapeDef shapeDef = b2DefaultShapeDef();
+	shapeDef.updateBodyMass = false;
+
+	b2Circle circle = { { 0.0f, 0.0f }, 0.5f };
+	b2CreateCircleShape( bodyId, &shapeDef, &circle );
+
+	b2Body_ApplyMassFromShapes( bodyId );
+
+	b2World_Step( worldId, 1.0f / 60.0f, 4 );
+
+	b2DestroyWorld( worldId );
+	return 0;
+}
+
+static int EnableSleepFlagSyncTest( void )
+{
+	b2WorldDef worldDef = b2DefaultWorldDef();
+	b2WorldId worldId = b2CreateWorld( &worldDef );
+
+	b2BodyDef bodyDef = b2DefaultBodyDef();
+	bodyDef.type = b2_dynamicBody;
+	bodyDef.enableSleep = false;
+	b2BodyId bodyId = b2CreateBody( worldId, &bodyDef );
+
+	ENSURE( b2Body_IsSleepEnabled( bodyId ) == false );
+
+	b2Body_EnableSleep( bodyId, true );
+	ENSURE( b2Body_IsSleepEnabled( bodyId ) == true );
+
+	b2World_Step( worldId, 1.0f / 60.0f, 4 );
+
+	b2DestroyWorld( worldId );
+	return 0;
+}
+
+static int SetBulletDriftTest( void )
+{
+	b2WorldDef worldDef = b2DefaultWorldDef();
+	b2WorldId worldId = b2CreateWorld( &worldDef );
+
+	{
+		b2BodyDef bodyDef = b2DefaultBodyDef();
+		bodyDef.type = b2_dynamicBody;
+		bodyDef.isBullet = false;
+		b2BodyId bodyId = b2CreateBody( worldId, &bodyDef );
+
+		ENSURE( b2Body_IsBullet( bodyId ) == false );
+
+		b2Body_SetBullet( bodyId, true );
+		ENSURE( b2Body_IsBullet( bodyId ) == true );
+
+		b2MotionLocks locks = { 0 };
+		locks.linearX = true;
+		b2Body_SetMotionLocks( bodyId, locks );
+
+		ENSURE( b2Body_IsBullet( bodyId ) == true );
+	}
+
+	{
+		b2BodyDef bodyDef = b2DefaultBodyDef();
+		bodyDef.type = b2_dynamicBody;
+		bodyDef.isBullet = true;
+		b2BodyId bodyId = b2CreateBody( worldId, &bodyDef );
+
+		ENSURE( b2Body_IsBullet( bodyId ) == true );
+
+		b2Body_SetBullet( bodyId, false );
+		ENSURE( b2Body_IsBullet( bodyId ) == false );
+
+		b2MotionLocks locks = { 0 };
+		locks.linearX = true;
+		b2Body_SetMotionLocks( bodyId, locks );
+
+		ENSURE( b2Body_IsBullet( bodyId ) == false );
+	}
+
+	b2DestroyWorld( worldId );
+	return 0;
+}
+
+static int DestroyOwnedChainSegmentTest( void )
+{
+	b2WorldDef worldDef = b2DefaultWorldDef();
+	b2WorldId worldId = b2CreateWorld( &worldDef );
+
+	b2BodyDef bodyDef = b2DefaultBodyDef();
+	b2BodyId groundId = b2CreateBody( worldId, &bodyDef );
+
+	b2Vec2 points[5] = {
+		{ -4.0f, 0.0f }, { -2.0f, 0.0f }, { 0.0f, 0.0f }, { 2.0f, 0.0f }, { 4.0f, 0.0f },
+	};
+	b2SurfaceMaterial material = { 0 };
+	b2ChainDef chainDef = b2DefaultChainDef();
+	chainDef.points = points;
+	chainDef.count = 5;
+	chainDef.materials = &material;
+	chainDef.materialCount = 1;
+	chainDef.isLoop = false;
+	b2ChainId chainId = b2CreateChain( groundId, &chainDef );
+
+	int segmentCount = b2Chain_GetSegmentCount( chainId );
+	ENSURE( segmentCount > 0 );
+
+	b2ShapeId segments[8] = { 0 };
+	int got = b2Chain_GetSegments( chainId, segments, segmentCount );
+	ENSURE( got == segmentCount );
+
+	for ( int i = 0; i < segmentCount; ++i )
+	{
+		b2ChainId parent = b2Shape_GetParentChain( segments[i] );
+		ENSURE( B2_IS_NON_NULL( parent ) );
+	}
+
+	b2DestroyShape( segments[0], true );
+
+	b2DestroyChain( chainId );
+	b2DestroyWorld( worldId );
 	return 0;
 }
 
@@ -544,6 +674,10 @@ int WorldTest( void )
 	RUN_SUBTEST( TestSensor );
 	RUN_SUBTEST( TestSetWorkerCount );
 	RUN_SUBTEST( ChainSegmentShapeTest );
+	RUN_SUBTEST( SetBulletDriftTest );
+	RUN_SUBTEST( DestroyOwnedChainSegmentTest );
+	RUN_SUBTEST( DeferredMassFlagSyncTest );
+	RUN_SUBTEST( EnableSleepFlagSyncTest );
 
 	return 0;
 }


### PR DESCRIPTION
- Added `b2CreateChainSegmentShape` and `b2Shape_SetChainSegment` #1016
- angular threshold for contact recycling `B2_CONTACT_RECYCLE_COS_ANGLE`
- per body option to disable contact recycling `b2BodyDef::enableContactRecycling` #1046
- adjustable body name length `B2_NAME_LENGTH` #994
- fix bug where body flags can get out of sync
- optimization: converted move set to a bit set, avoid a large per step memset in large world scenarios
