### PR TITLE
migrate some joint drawing to the extras

### DIFF
--- a/samples/sample_joints.cpp
+++ b/samples/sample_joints.cpp
@@ -420,8 +420,8 @@ public:
 	{
 		if ( m_context->restart == false )
 		{
-			m_context->camera.center = { 0.0f, 7.0f };
-			m_context->camera.zoom = 25.0f * 0.4f;
+			m_context->camera.center = { 0.0f, 10.0f };
+			m_context->camera.zoom = 12.0f;
 		}
 
 		b2BodyId groundId;

--- a/src/joint.c
+++ b/src/joint.c
@@ -1695,8 +1695,6 @@ void b2DrawJoint( b2DebugDraw* draw, b2World* world, b2Joint* joint )
 	b2Pos pA = b2TransformWorldPoint( xfA, jointSim->localFrameA.p );
 	b2Pos pB = b2TransformWorldPoint( xfB, jointSim->localFrameB.p );
 
-	b2HexColor color = b2_colorDarkSeaGreen;
-
 	float scale = b2MaxFloat( 0.0001f, draw->jointScale * joint->drawScale );
 
 	switch ( joint->type )
@@ -1706,13 +1704,21 @@ void b2DrawJoint( b2DebugDraw* draw, b2World* world, b2Joint* joint )
 			break;
 
 		case b2_filterJoint:
-			draw->DrawLineFcn( pA, pB, b2_colorGold, draw->context );
+			draw->DrawPointFcn( pA, 8.0f, b2_colorLightSkyBlue, draw->context );
+			draw->DrawPointFcn( pB, 8.0f, b2_colorLightSkyBlue, draw->context );
+			if (draw->drawJointExtras)
+			{
+				draw->DrawLineFcn( pA, pB, b2_colorGold, draw->context );
+			}
 			break;
 
 		case b2_motorJoint:
 			draw->DrawPointFcn( pA, 8.0f, b2_colorYellowGreen, draw->context );
 			draw->DrawPointFcn( pB, 8.0f, b2_colorPlum, draw->context );
-			draw->DrawLineFcn( pA, pB, b2_colorLightGray, draw->context );
+			if (draw->drawJointExtras)
+			{
+				draw->DrawLineFcn( pA, pB, b2_colorLightGray, draw->context );
+			}
 			break;
 
 		case b2_moverJoint:
@@ -1740,9 +1746,6 @@ void b2DrawJoint( b2DebugDraw* draw, b2World* world, b2Joint* joint )
 			break;
 
 		default:
-			draw->DrawLineFcn( xfA.p, pA, color, draw->context );
-			draw->DrawLineFcn( pA, pB, color, draw->context );
-			draw->DrawLineFcn( xfB.p, pB, color, draw->context );
 			break;
 	}
 

--- a/src/revolute_joint.c
+++ b/src/revolute_joint.c
@@ -550,9 +550,13 @@ void b2DrawRevoluteJoint( b2DebugDraw* draw, b2JointSim* base, b2WorldTransform 
 	}
 
 	b2HexColor color = b2_colorGold;
-	draw->DrawLineFcn( transformA.p, frameA.p, color, draw->context );
 	draw->DrawLineFcn( frameA.p, frameB.p, color, draw->context );
-	draw->DrawLineFcn( transformB.p, frameB.p, color, draw->context );
+
+	if ( draw->drawJointExtras )
+	{
+		draw->DrawLineFcn( transformA.p, frameA.p, color, draw->context );
+		draw->DrawLineFcn( transformB.p, frameB.p, color, draw->context );
+	}
 
 	// char buffer[32];
 	// sprintf(buffer, "%.1f", b2Length(joint->impulse));


### PR DESCRIPTION
Some aspects of joint drawing has moved to `drawJointExtras` to reduce visual clutter.
#974

